### PR TITLE
Fix invalid value error when creating new data table and rows with defaults

### DIFF
--- a/genesyscloud/resource_genesyscloud_architect_datatable_row.go
+++ b/genesyscloud/resource_genesyscloud_architect_datatable_row.go
@@ -224,13 +224,15 @@ func buildSdkRowPropertyMap(propertiesJson string, keyStr string) (map[string]in
 func customizeDatatableRowDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	// Defaults must be set on missing properties
 
-	if !diff.NewValueKnown("datatable_id") {
-		// datatable_id not yet in final state. Nothing to do.
+	if !diff.NewValueKnown("properties_json") {
+		// properties_json value not yet in final state. Nothing to do.
 		return nil
 	}
 
-	if !diff.NewValueKnown("properties_json") {
-		// properties_json value not yet in final state. Nothing to do.
+	if !diff.NewValueKnown("datatable_id") {
+		// datatable_id not yet in final state, but properties_json is marked as known.
+		// There may be computed defaults to set on properties_json that we do not know yet.
+		diff.SetNewComputed("properties_json")
 		return nil
 	}
 

--- a/genesyscloud/resource_genesyscloud_architect_datatable_row_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_datatable_row_test.go
@@ -64,12 +64,14 @@ func TestAccResourceArchitectDatatableRow(t *testing.T) {
 					rowResource1,
 					"genesyscloud_architect_datatable."+tableResource1+".id",
 					keyVal1,
-					nullValue, // No JSON values specified, so all props in state should be default
+					generateJsonEncodedProperties(
+						generateJsonProperty(propInt, intVal1), // Most props in state should be default
+					),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_architect_datatable_row."+rowResource1, "key_value", keyVal1),
 					resource.TestCheckResourceAttrPair("genesyscloud_architect_datatable_row."+rowResource1, "datatable_id", "genesyscloud_architect_datatable."+tableResource1, "id"),
-					validateValueInJsonAttr("genesyscloud_architect_datatable_row."+rowResource1, "properties_json", propInt, defInt1),
+					validateValueInJsonAttr("genesyscloud_architect_datatable_row."+rowResource1, "properties_json", propInt, intVal1),
 					validateValueInJsonAttr("genesyscloud_architect_datatable_row."+rowResource1, "properties_json", propBool, defBool1),
 					validateValueInJsonAttr("genesyscloud_architect_datatable_row."+rowResource1, "properties_json", propNum, defNum),
 					validateValueInJsonAttr("genesyscloud_architect_datatable_row."+rowResource1, "properties_json", propStr, defStr),


### PR DESCRIPTION
When expanding the plan for genesyscloud_architect_datatable_row.john-smith-2749 to include new values learned so far during apply, provider "registry.terraform.io/mypurecloud/genesyscloud" produced an invalid new value for .properties_json: was cty.StringVal("{"identifier":2749}"), but now cty.StringVal("{"deleted":false,"identifier":2749}").