### PR TITLE
Fix the docs for routing_queue

### DIFF
--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -56,7 +56,7 @@ resource "genesyscloud_routing_queue" "test_queue" {
     expansion_timeout_seconds = 15.1
     skills_to_remove          = [genesyscloud_routing_skill.test-skill.id]
   }
-  default_script_ids {
+  default_script_ids = {
     EMAIL = "153fcff5-597e-4f17-94e5-17eac456a0b2"
     CHAT  = "98dff282-c50c-4c36-bc70-80b058564e1b"
   }

--- a/examples/resources/genesyscloud_routing_queue/resource.tf
+++ b/examples/resources/genesyscloud_routing_queue/resource.tf
@@ -30,7 +30,7 @@ resource "genesyscloud_routing_queue" "test_queue" {
     expansion_timeout_seconds = 15.1
     skills_to_remove          = [genesyscloud_routing_skill.test-skill.id]
   }
-  default_script_ids {
+  default_script_ids = {
     EMAIL = "153fcff5-597e-4f17-94e5-17eac456a0b2"
     CHAT  = "98dff282-c50c-4c36-bc70-80b058564e1b"
   }


### PR DESCRIPTION
The default_script_ids object in the genesyscloud_routing_queue resource is a map, so the example in the documentation should be corrected.