### PR TITLE
Guarding access of rrule

### DIFF
--- a/genesyscloud/resource_genesyscloud_architect_schedules.go
+++ b/genesyscloud/resource_genesyscloud_architect_schedules.go
@@ -169,7 +169,10 @@ func readArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta in
 		}
 		d.Set("start", Start)
 		d.Set("end", End)
-		d.Set("rrule", *schedule.Rrule)
+		d.Set("rrule", nil)
+		if schedule.Rrule != nil {
+			d.Set("rrule", *schedule.Rrule)
+		}
 
 		log.Printf("Read schedule %s %s", d.Id(), *schedule.Name)
 		return nil


### PR DESCRIPTION
It caused a nil pointer dereference crash for a customer.
It's marked as required in swagger so it should never be nil ¯\_(ツ)_/¯