### PR TITLE
Upping the timeout for acceptance tests. 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         go mod download
         
     - name: TF acceptance tests
-      timeout-minutes: 30
+      timeout-minutes: 45
       env:
         TF_ACC: "1"
         TF_LOG: "INFO"


### PR DESCRIPTION
Tests take longer now with sleeps to avoid eventual consistency issues