### PR TITLE
Add OTHER phone type

### DIFF
--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -34,11 +34,11 @@ var (
 				ValidateFunc: validation.StringInSlice([]string{"PHONE", "SMS"}, false),
 			},
 			"type": {
-				Description:  "Type of number (WORK | WORK2 | WORK3 | WORK4 | HOME | MOBILE).",
+				Description:  "Type of number (WORK | WORK2 | WORK3 | WORK4 | HOME | MOBILE | OTHER).",
 				Type:         schema.TypeString,
 				Optional:     true,
 				Default:      "WORK",
-				ValidateFunc: validation.StringInSlice([]string{"WORK", "WORK2", "WORK3", "WORK4", "HOME", "MOBILE"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"WORK", "WORK2", "WORK3", "WORK4", "HOME", "MOBILE", "OTHER"}, false),
 			},
 			"extension": {
 				Description: "Phone number extension",


### PR DESCRIPTION
"Other" is a valid phone type, which can also be set via the UI and for integrations such as Teams.

Note: This works fine when creating a new user, however for some reason when updating a user, adding a phone set to other do not take effect (no error is returned, however). This seems like an API bug to me, I'm not sure whether that should block this or not.