### PR TITLE
[DEVENGAGE-1104] Adding error handling for <nil> to map[string]interface{} type mismatch

### DIFF
--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -565,6 +565,9 @@ func buildSdkCapabilities(d *schema.ResourceData) *platformclientv2.Phonecapabil
 	if capabilities := d.Get("capabilities").([]interface{}); capabilities != nil {
 		sdkPhoneCapabilities := platformclientv2.Phonecapabilities{}
 		if len(capabilities) > 0 {
+			if _, ok := capabilities[0].(map[string]interface{}); !ok {
+				return nil
+			}
 			capabilitiesMap := capabilities[0].(map[string]interface{})
 
 			// Only set non-empty values.

--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -848,9 +848,12 @@ func buildSdkAddresses(d *schema.ResourceData) (*[]platformclientv2.Contact, dia
 		var otherEmails *schema.Set
 		var phoneNumbers *schema.Set
 		if len(addresses) > 0 {
-			addressMap := addresses[0].(map[string]interface{})
-			otherEmails = addressMap["other_emails"].(*schema.Set)
-			phoneNumbers = addressMap["phone_numbers"].(*schema.Set)
+			if addressMap, ok := addresses[0].(map[string]interface{}); ok {
+				otherEmails = addressMap["other_emails"].(*schema.Set)
+				phoneNumbers = addressMap["phone_numbers"].(*schema.Set)
+			} else {
+				return nil, nil
+			}
 		}
 
 		if otherEmails != nil {
@@ -891,6 +894,9 @@ func buildSdkEmployerInfo(d *schema.ResourceData) *platformclientv2.Employerinfo
 	if configInfo := d.Get("employer_info").([]interface{}); configInfo != nil {
 		var sdkInfo platformclientv2.Employerinfo
 		if len(configInfo) > 0 {
+			if _, ok := configInfo[0].(map[string]interface{}); !ok {
+				return nil
+			}
 			infoMap := configInfo[0].(map[string]interface{})
 			// Only set non-empty values.
 			if offName := infoMap["official_name"].(string); len(offName) > 0 {


### PR DESCRIPTION
This crash occurs when a resource field of type map, which has no required attributes, is defined and left empty. E.g. `genesyscloud_user.addresses` 