### PR TITLE
updating trigger terraform to allow for the description field, also u…

### DIFF
--- a/docs/resources/processautomation_trigger.md
+++ b/docs/resources/processautomation_trigger.md
@@ -37,6 +37,7 @@ resource "genesyscloud_processautomation_trigger" "example-trigger" {
     value     = "CHAT"
   }
   event_ttl_seconds = 60
+  description       = "description of trigger"
 }
 ```
 
@@ -52,6 +53,7 @@ resource "genesyscloud_processautomation_trigger" "example-trigger" {
 
 ### Optional
 
+- `description` (String) A description of the trigger
 - `event_ttl_seconds` (Number) How old an event can be to fire the trigger. Must be an number greater than or equal to 10
 - `match_criteria` (Block Set) Match criteria that controls when the trigger will fire. (see [below for nested schema](#nestedblock--match_criteria))
 

--- a/examples/resources/genesyscloud_processautomation_trigger/resource.tf
+++ b/examples/resources/genesyscloud_processautomation_trigger/resource.tf
@@ -12,4 +12,5 @@ resource "genesyscloud_processautomation_trigger" "example-trigger" {
     value     = "CHAT"
   }
   event_ttl_seconds = 60
+  description       = "description of trigger"
 }

--- a/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
+++ b/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
@@ -1,5 +1,5 @@
 workflow:
- name: terraform-provider-test-6b7b7594-dd68-4b73-91ce-3cfc3a1b6f5d
+ name: terraform-provider-test-32fefb46-cfab-4ce3-b13c-00f928196ba7
  division: Home
  startUpRef: "/workflow/states/state[Initial State_10]"
  defaultLanguage: en-us

--- a/genesyscloud/data_source_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/data_source_genesyscloud_processautomation_trigger_test.go
@@ -22,6 +22,7 @@ func TestAccDataSourceProcessAutomationTrigger(t *testing.T) {
 		match_criteria_operator  = "Equal"
 		match_criteria_value     = "CHAT"
 		eventTtlSeconds1         = "60"
+		description1             = "description 1"
 
 		flowResource1 = "test_flow1"
 		filePath1     = "../examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml"
@@ -101,6 +102,7 @@ func TestAccDataSourceProcessAutomationTrigger(t *testing.T) {
                     }
                     `, match_criteria_json_path, match_criteria_operator, match_criteria_value),
 					eventTtlSeconds1,
+					description1,
 				) + generateProcessAutomationTriggerDataSource(
 					triggerResource2,
 					triggerName1,

--- a/genesyscloud/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/resource_genesyscloud_processautomation_trigger.go
@@ -27,15 +27,18 @@ type ProcessAutomationTrigger struct {
 	Enabled         *bool            `json:"enabled,omitempty"`
 	EventTTLSeconds *int             `json:"eventTTLSeconds,omitempty"`
 	Version         *int             `json:"version,omitempty"`
+	Description     *string          `json:"description,omitempty"`
 }
 
 type UpdateTriggerInput struct {
+	TopicName       *string          `json:"topicName,omitempty"`
 	Name            *string          `json:"name,omitempty"`
 	Target          *Target          `json:"target,omitempty"`
 	MatchCriteria   *[]MatchCriteria `json:"matchCriteria,omitempty"`
 	Enabled         *bool            `json:"enabled,omitempty"`
 	EventTTLSeconds *int             `json:"eventTTLSeconds,omitempty"`
 	Version         *int             `json:"version,omitempty"`
+	Description     *string          `json:"description,omitempty"`
 }
 
 type MatchCriteria struct {
@@ -163,6 +166,12 @@ func resourceProcessAutomationTrigger() *schema.Resource {
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(10),
 			},
+			"description": {
+				Description:  "A description of the trigger",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringLenBetween(0, 512),
+			},
 		},
 	}
 }
@@ -181,6 +190,7 @@ func createProcessAutomationTrigger(ctx context.Context, d *schema.ResourceData,
 	topic_name := d.Get("topic_name").(string)
 	enabled := d.Get("enabled").(bool)
 	eventTTLSeconds := d.Get("event_ttl_seconds").(int)
+	description := d.Get("description").(string)
 
 	sdkConfig := meta.(*providerMeta).ClientConfig
 	integAPI := platformclientv2.NewIntegrationsApiWithConfig(sdkConfig)
@@ -193,6 +203,7 @@ func createProcessAutomationTrigger(ctx context.Context, d *schema.ResourceData,
 		Target:        buildTarget(d),
 		MatchCriteria: buildMatchCriteria(d),
 		Enabled:       &enabled,
+		Description:   &description,
 	}
 
 	if eventTTLSeconds > 0 {
@@ -261,6 +272,12 @@ func readProcessAutomationTrigger(ctx context.Context, d *schema.ResourceData, m
 			d.Set("event_ttl_seconds", nil)
 		}
 
+		if trigger.Description != nil {
+			d.Set("description", *trigger.Description)
+		} else {
+			d.Set("description", nil)
+		}
+
 		log.Printf("Read process automation trigger %s %s", d.Id(), *trigger.Name)
 		return cc.CheckState()
 	})
@@ -270,6 +287,7 @@ func updateProcessAutomationTrigger(ctx context.Context, d *schema.ResourceData,
 	name := d.Get("name").(string)
 	enabled := d.Get("enabled").(bool)
 	eventTTLSeconds := d.Get("event_ttl_seconds").(int)
+	description := d.Get("description").(string)
 
 	topic_name := d.Get("topic_name").(string)
 
@@ -285,17 +303,14 @@ func updateProcessAutomationTrigger(ctx context.Context, d *schema.ResourceData,
 			return resp, diag.Errorf("Failed to read process automation trigger %s: %s", d.Id(), getErr)
 		}
 
-		//make sure that topic name is not updated
-		if topic_name != *trigger.TopicName {
-			return resp, diag.Errorf("Cannot update topic_name of an existing trigger")
-		}
-
 		triggerInput := &UpdateTriggerInput{
+			TopicName:     &topic_name,
 			Name:          &name,
 			Enabled:       &enabled,
 			Target:        buildTarget(d),
 			MatchCriteria: buildMatchCriteria(d),
 			Version:       trigger.Version,
+			Description:   &description,
 		}
 
 		if eventTTLSeconds > 0 {

--- a/genesyscloud/resource_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/resource_genesyscloud_processautomation_trigger_test.go
@@ -24,6 +24,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 		match_criteria_operator1  = "Equal"
 		match_criteria_value1     = "CHAT"
 		eventTtlSeconds1          = "60"
+		description1              = "description1"
 
 		triggerName2              = "Terraform trigger2-" + uuid.NewString()
 		enabled2                  = "false"
@@ -31,6 +32,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 		match_criteria_operator2  = "In"
 		match_criteria_value2     = "CLIENT"
 		eventTtlSeconds2          = "120"
+		description2              = "description2"
 
 		flowResource1 = "test_flow1"
 		filePath1     = "../examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml"
@@ -110,12 +112,14 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
                     }
                     `, match_criteria_json_path1, match_criteria_operator1, match_criteria_value1),
 					eventTtlSeconds1,
+					description1,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "name", triggerName1),
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "topic_name", topicName1),
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "enabled", enabled1),
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "event_ttl_seconds", eventTtlSeconds1),
+					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description1),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
 					validateMatchCriteriaWithValue("genesyscloud_processautomation_trigger."+triggerResource1, match_criteria_json_path1, match_criteria_operator1, match_criteria_value1, 0),
@@ -144,12 +148,14 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
                     }
                     `, match_criteria_json_path2, match_criteria_operator2, match_criteria_value2),
 					eventTtlSeconds2,
+					description2,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "name", triggerName2),
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "topic_name", topicName1),
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "enabled", enabled2),
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "event_ttl_seconds", eventTtlSeconds2),
+					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description2),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
 					validateMatchCriteriaWithValues("genesyscloud_processautomation_trigger."+triggerResource1, match_criteria_json_path2, match_criteria_operator2, []string{match_criteria_value2}, 0),
@@ -166,7 +172,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 	})
 }
 
-func generateProcessAutomationTriggerResource(resourceID, name, topic_name, enabled, target, match_criteria, event_ttl_seconds string) string {
+func generateProcessAutomationTriggerResource(resourceID, name, topic_name, enabled, target, match_criteria, event_ttl_seconds, description string) string {
 	return fmt.Sprintf(`resource "genesyscloud_processautomation_trigger" "%s" {
         name = "%s"
         topic_name = "%s"
@@ -174,8 +180,9 @@ func generateProcessAutomationTriggerResource(resourceID, name, topic_name, enab
         %s
         %s
         event_ttl_seconds = %s
+		description = "%s"
 	}
-	`, resourceID, name, topic_name, enabled, target, match_criteria, event_ttl_seconds)
+	`, resourceID, name, topic_name, enabled, target, match_criteria, event_ttl_seconds, description)
 }
 
 func testVerifyProcessAutomationTriggerDestroyed(state *terraform.State) error {


### PR DESCRIPTION
updating how topic name changes on updates are handled, and adding in description field to process automation triggers.

We used to fail the updates to triggers when the topic name field was changed, now the terraform will explicitly say that a replacement is required, and then asks the user to confirm the changes. So the user will need to be aware that the ID of the trigger will change in this case:

![Screen Shot 2022-07-18 at 3 17 31 PM](https://user-images.githubusercontent.com/103056940/179600067-ae97ec27-fa70-43b3-a4a1-d579f61e6623.png)

