### PR TITLE
[DEVENGAGE-1432] Bug fix in callable time sets exporter + oauth_client docs update 

### DIFF
--- a/docs/resources/oauth_client.md
+++ b/docs/resources/oauth_client.md
@@ -48,6 +48,7 @@ resource "genesyscloud_oauth_client" "example-client" {
 
 - `access_token_validity_seconds` (Number) The number of seconds, between 5mins and 48hrs, until tokens created with this client expire. Only clients using Genesys Cloud SCIM (Identity Management) can have a maximum duration of 38880000secs/450 days. Defaults to `86400`.
 - `description` (String) The description of the OAuth client.
+- `integration_credential_name` (String) Optionally, a Name of a Integration Credential (with credential type pureCloudOAuthClient) to be created using this new OAuth Client.
 - `registered_redirect_uris` (Set of String) List of allowed callbacks for this client. For example: https://myapp.example.com/auth/callback.
 - `roles` (Block Set) Set of roles and their corresponding divisions associated with this client. Roles must be set for clients using the CLIENT-CREDENTIALS grant. The roles must also already be assigned to the OAuth Client used by Terraform. (see [below for nested schema](#nestedblock--roles))
 - `scopes` (Set of String) The scopes requested by this client. Scopes must be set for clients not using the CLIENT-CREDENTIALS grant.
@@ -56,6 +57,7 @@ resource "genesyscloud_oauth_client" "example-client" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+- `integration_credential_id` (String) The Id of the created Integration Credential using this new OAuth Client.
 
 <a id="nestedblock--roles"></a>
 ### Nested Schema for `roles`

--- a/genesyscloud/resource_exporter.go
+++ b/genesyscloud/resource_exporter.go
@@ -213,7 +213,7 @@ func getResourceExporters(filter []string) map[string]*ResourceExporter {
 		"genesyscloud_oauth_client":                                oauthClientExporter(),
 		"genesyscloud_outbound_attempt_limit":                      outboundAttemptLimitExporter(),
 		"genesyscloud_outbound_callanalysisresponseset":            outboundCallAnalysisResponseSetExporter(),
-		"genesyscloud_outbound_callable_timeset":                   outboundCallableTimesetExporter(),
+		"genesyscloud_outbound_callabletimeset":                    outboundCallableTimesetExporter(),
 		"genesyscloud_outbound_contact_list":                       outboundContactListExporter(),
 		"genesyscloud_outbound_contactlistfilter":                  outboundContactListFilterExporter(),
 		"genesyscloud_outbound_ruleset":                            outboundRulesetExporter(),

--- a/genesyscloud/resource_genesyscloud_outbound_callabletimeset.go
+++ b/genesyscloud/resource_genesyscloud_outbound_callabletimeset.go
@@ -93,7 +93,7 @@ func getAllOutboundCallableTimesets(_ context.Context, clientConfig *platformcli
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		callableTimesetConfigs, _, getErr := outboundAPI.GetOutboundCallabletimesets(pageSize, pageNum, false, "", "", "", "")
+		callableTimesetConfigs, _, getErr := outboundAPI.GetOutboundCallabletimesets(pageSize, pageNum, true, "", "", "", "")
 		if getErr != nil {
 			return nil, diag.Errorf("Failed to get page of callable timeset configs: %v", getErr)
 		}


### PR DESCRIPTION
I created this ticket to fix a bug with the callable time sets exporter and realised along the way that go generate should have been ran for [DEVENGAGE-1410](https://inindca.atlassian.net/browse/DEVENGAGE-1410)