### PR TITLE
Devengage 1451 fix queue groups and skill groups

### DIFF
--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -89,11 +89,13 @@ resource "genesyscloud_routing_queue" "example_queue" {
 - `email_in_queue_flow_id` (String) The in-queue flow ID to use for email conversations waiting in queue.
 - `enable_manual_assignment` (Boolean) Indicates whether manual assignment is enabled for this queue. Defaults to `false`.
 - `enable_transcription` (Boolean) Indicates whether voice transcription is enabled for this queue. Defaults to `false`.
+- `groups` (Set of String) List of group ids assigned to the queue
 - `media_settings_call` (Block List, Max: 1) Call media settings. (see [below for nested schema](#nestedblock--media_settings_call))
 - `media_settings_callback` (Block List, Max: 1) Callback media settings. (see [below for nested schema](#nestedblock--media_settings_callback))
 - `media_settings_chat` (Block List, Max: 1) Chat media settings. (see [below for nested schema](#nestedblock--media_settings_chat))
 - `media_settings_email` (Block List, Max: 1) Email media settings. (see [below for nested schema](#nestedblock--media_settings_email))
 - `media_settings_message` (Block List, Max: 1) Message media settings. (see [below for nested schema](#nestedblock--media_settings_message))
+- `member_groups` (Block List) Member group ids that are assigned to the queue (see [below for nested schema](#nestedblock--member_groups))
 - `members` (Set of Object) Users in the queue. If not set, this resource will not manage members. (see [below for nested schema](#nestedatt--members))
 - `message_in_queue_flow_id` (String) The in-queue flow ID to use for message conversations waiting in queue.
 - `outbound_email_address` (Block List, Max: 1) The outbound email address settings for this queue. (see [below for nested schema](#nestedblock--outbound_email_address))
@@ -101,6 +103,8 @@ resource "genesyscloud_routing_queue" "example_queue" {
 - `queue_flow_id` (String) The in-queue flow ID to use for call conversations waiting in queue.
 - `routing_rules` (Block List, Max: 6) The routing rules for the queue, used for routing to known or preferred agents. (see [below for nested schema](#nestedblock--routing_rules))
 - `skill_evaluation_method` (String) The skill evaluation method to use when routing conversations (NONE | BEST | ALL). Defaults to `ALL`.
+- `skill_groups` (Set of String) List of skill group ids assigned to the queue
+- `teams` (Set of String) List of ids assigned to the queue
 - `whisper_prompt_id` (String) The prompt ID used for whisper on the queue, if configured.
 - `wrapup_codes` (Set of String) IDs of wrapup codes assigned to this queue. If not set, this resource will not manage wrapup codes.
 
@@ -168,6 +172,15 @@ Required:
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+
+
+<a id="nestedblock--member_groups"></a>
+### Nested Schema for `member_groups`
+
+Required:
+
+- `id` (String) Group id of the group, team, or skill group being created
+- `type` (String) Type of member group. Must be TEAM, GROUP or SKILLGROUP
 
 
 <a id="nestedatt--members"></a>

--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -95,7 +95,6 @@ resource "genesyscloud_routing_queue" "example_queue" {
 - `media_settings_chat` (Block List, Max: 1) Chat media settings. (see [below for nested schema](#nestedblock--media_settings_chat))
 - `media_settings_email` (Block List, Max: 1) Email media settings. (see [below for nested schema](#nestedblock--media_settings_email))
 - `media_settings_message` (Block List, Max: 1) Message media settings. (see [below for nested schema](#nestedblock--media_settings_message))
-- `member_groups` (Block List) Member group ids that are assigned to the queue (see [below for nested schema](#nestedblock--member_groups))
 - `members` (Set of Object) Users in the queue. If not set, this resource will not manage members. (see [below for nested schema](#nestedatt--members))
 - `message_in_queue_flow_id` (String) The in-queue flow ID to use for message conversations waiting in queue.
 - `outbound_email_address` (Block List, Max: 1) The outbound email address settings for this queue. (see [below for nested schema](#nestedblock--outbound_email_address))
@@ -172,15 +171,6 @@ Required:
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-
-
-<a id="nestedblock--member_groups"></a>
-### Nested Schema for `member_groups`
-
-Required:
-
-- `id` (String) Group id of the group, team, or skill group being created
-- `type` (String) Type of member group. Must be TEAM, GROUP or SKILLGROUP
 
 
 <a id="nestedatt--members"></a>

--- a/examples/resources/genesyscloud_flow/inboundcall_flow_example.yaml
+++ b/examples/resources/genesyscloud_flow/inboundcall_flow_example.yaml
@@ -1,5 +1,5 @@
 inboundCall:
-  name: Terraform Flow Test-7ee65182-530a-49ab-91ca-086f222965a1
+  name: Terraform Flow Test-4a3ee2ec-8573-42d4-8239-0b2fc186b4c7
   defaultLanguage: en-us
   startUpRef: ./menus/menu[mainMenu]
   initialGreeting:

--- a/examples/resources/genesyscloud_flow/inboundcall_flow_example2.yaml
+++ b/examples/resources/genesyscloud_flow/inboundcall_flow_example2.yaml
@@ -1,16 +1,24 @@
-inboundCall:
-  name: Terraform Flow Test-2ea8e2ed-7944-49a3-af20-09355b35bcdf
-  defaultLanguage: en-us
-  startUpRef: ./menus/menu[mainMenu]
-  initialGreeting:
-    tts: Archy says hi!!!!!
-  menus:
-    - menu:
-        name: Main Menu
-        audio:
-          tts: You are at the Main Menu, press 9 to disconnect.
-        refId: mainMenu
-        choices:
-          - menuDisconnect:
-              name: Disconnect
-              dtmf: digit_9
+inboundEmail:
+    name: Terraform Flow Test-6ed35a7a-6168-4ed8-b2b4-0d962c56afa6
+    division: Home0349a372-0480-4879-b98e-8aace58b1bb7
+    startUpRef: "/inboundEmail/states/state[Initial State_10]"
+    defaultLanguage: en-us
+    supportedLanguages:
+        en-us:
+            defaultLanguageSkill:
+                noValue: true
+    settingsInboundEmailHandling:
+        emailHandling:
+            disconnect:
+                none: true
+    settingsErrorHandling:
+        errorHandling:
+            disconnect:
+                none: true
+    states:
+        - state:
+            name: Initial State
+            refId: Initial State_10
+            actions:
+                - disconnect:
+                    name: Disconnect

--- a/examples/resources/genesyscloud_flow/inboundcall_flow_example3.yaml
+++ b/examples/resources/genesyscloud_flow/inboundcall_flow_example3.yaml
@@ -1,24 +1,16 @@
-inboundEmail:
-    name: Terraform Flow Test-7ee65182-530a-49ab-91ca-086f222965a1
-    division: Home0349a372-0480-4879-b98e-8aace58b1bb7
-    startUpRef: "/inboundEmail/states/state[Initial State_10]"
-    defaultLanguage: en-us
-    supportedLanguages:
-        en-us:
-            defaultLanguageSkill:
-                noValue: true
-    settingsInboundEmailHandling:
-        emailHandling:
-            disconnect:
-                none: true
-    settingsErrorHandling:
-        errorHandling:
-            disconnect:
-                none: true
-    states:
-        - state:
-            name: Initial State
-            refId: Initial State_10
-            actions:
-                - disconnect:
-                    name: Disconnect
+inboundCall:
+  name: Terraform Flow Test-244f228b-eb90-48d0-8953-990de9f2058c
+  defaultLanguage: en-us
+  startUpRef: ./menus/menu[mainMenu]
+  initialGreeting:
+    tts: Archy says hi!!!!!
+  menus:
+    - menu:
+        name: Main Menu
+        audio:
+          tts: You are at the Main Menu, press 9 to disconnect.
+        refId: mainMenu
+        choices:
+          - menuDisconnect:
+              name: Disconnect
+              dtmf: digit_9

--- a/genesyscloud/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/resource_genesyscloud_routing_queue.go
@@ -68,22 +68,6 @@ var (
 			},
 		},
 	}
-
-	memberGroupResource = &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"id": {
-				Description: "Group id of the group, team, or skill group being created",
-				Type:        schema.TypeString,
-				Required:    true,
-			},
-			"type": {
-				Description:  "Type of member group. Must be TEAM, GROUP or SKILLGROUP",
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"TEAM", "GROUP", "SKILLGROUP"}, false),
-			},
-		},
-	}
 )
 
 func getAllRoutingQueues(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/resource_genesyscloud_routing_queue.go
@@ -376,12 +376,6 @@ func resourceRoutingQueue() *schema.Resource {
 				Computed:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
-			"member_groups": {
-				Description: "Member group ids that are assigned to the queue",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        memberGroupResource,
-			},
 			"skill_groups": {
 				Description: "List of skill group ids assigned to the queue",
 				Type:        schema.TypeSet,


### PR DESCRIPTION
I originally was the developer who wrote the skill_groups resource.  However, I did not realize that we needed to add it to the routing_queues object.  While in there I discovered there are three types of "groups" that are supported: groups, teams and skill_groups.  I added support for all three (even though teams does not have a resource yet, so I will add that).