### PR TITLE
DEVENGAGE-1580: Removed the force new flag off of schedule.

### DIFF
--- a/docs/resources/architect_schedules.md
+++ b/docs/resources/architect_schedules.md
@@ -35,7 +35,7 @@ resource "genesyscloud_architect_schedules" "sample_schedule" {
 ### Required
 
 - `end` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000.
-- `name` (String) Name of the schedule. Note: If the name is changed, this will cause the schedule object to be dropped and recreated with a new ID.  This can cause an Architect Flow to become invalid.
+- `name` (String) Name of the schedule.
 - `start` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000.
 
 ### Optional

--- a/genesyscloud/resource_genesyscloud_architect_schedules.go
+++ b/genesyscloud/resource_genesyscloud_architect_schedules.go
@@ -62,10 +62,9 @@ func resourceArchitectSchedules() *schema.Resource {
 		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Description: "Name of the schedule. Note: If the name is changed, this will cause the schedule object to be dropped and recreated with a new ID.  This can cause an Architect Flow to become invalid.",
+				Description: "Name of the schedule.",
 				Type:        schema.TypeString,
 				Required:    true,
-				ForceNew:    true,
 			},
 			"division_id": {
 				Description: "The division to which this schedule group will belong. If not set, the home division will be used. If set, you must have all divisions and future divisions selected in your OAuth client role",


### PR DESCRIPTION
I can't figure out why ForceNew was added here.  The put allows you to change the new without any problems.  The problem with schedules is that schedules can be referenced in an Architect flow.  If you change the name and force a new object to be created/delete, it breaks the dependency on architect flow.  I tried to rerun the test, but my OAuth client seems to be missing a permission that I cant figure out;