### PR TITLE
Fixing knowledgebase export process

### DIFF
--- a/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
@@ -22,7 +22,7 @@ func getAllKnowledgeKnowledgebases(_ context.Context, clientConfig *platformclie
 
 	publishedEntities, err := getAllKnowledgebaseEntities(*knowledgeAPI, true)
 	if err != nil {
-		return nil, diag.Errorf("%v", err)
+		return nil, err
 	}
 
 	for _, knowledgeBase := range *publishedEntities {
@@ -31,7 +31,7 @@ func getAllKnowledgeKnowledgebases(_ context.Context, clientConfig *platformclie
 
 	unpublishedEntities, err := getAllKnowledgebaseEntities(*knowledgeAPI, false)
 	if err != nil {
-		return nil, diag.Errorf("%v", err)
+		return nil, err
 	}
 
 	for _, knowledgeBase := range *unpublishedEntities {
@@ -41,7 +41,7 @@ func getAllKnowledgeKnowledgebases(_ context.Context, clientConfig *platformclie
 	return resources, nil
 }
 
-func getAllKnowledgebaseEntities(knowledgeApi platformclientv2.KnowledgeApi, published bool) (*[]platformclientv2.Knowledgebase, error) {
+func getAllKnowledgebaseEntities(knowledgeApi platformclientv2.KnowledgeApi, published bool) (*[]platformclientv2.Knowledgebase, diag.Diagnostics) {
 	var (
 		after    string
 		entities []platformclientv2.Knowledgebase
@@ -51,7 +51,7 @@ func getAllKnowledgebaseEntities(knowledgeApi platformclientv2.KnowledgeApi, pub
 	for i := 0; ; i++ {
 		knowledgeBases, _, getErr := knowledgeApi.GetKnowledgeKnowledgebases("", after, "", fmt.Sprintf("%v", pageSize), "", "", published, "", "")
 		if getErr != nil {
-			return nil, fmt.Errorf("Failed to get page of knowledge bases: %v", getErr)
+			return nil, diag.Errorf("Failed to get page of knowledge bases: %v", getErr)
 		}
 
 		if knowledgeBases.Entities == nil || len(*knowledgeBases.Entities) == 0 {
@@ -66,7 +66,7 @@ func getAllKnowledgebaseEntities(knowledgeApi platformclientv2.KnowledgeApi, pub
 
 		u, err := url.Parse(*knowledgeBases.NextUri)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to parse after cursor from knowledge base nextUri: %v", err)
+			return nil, diag.Errorf("Failed to parse after cursor from knowledge base nextUri: %v", err)
 		}
 		m, _ := url.ParseQuery(u.RawQuery)
 		if afterSlice, ok := m["after"]; ok && len(afterSlice) > 0 {

--- a/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"time"
-
+	"net/url"
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
@@ -20,23 +20,64 @@ func getAllKnowledgeKnowledgebases(_ context.Context, clientConfig *platformclie
 	resources := make(ResourceIDMetaMap)
 	knowledgeAPI := platformclientv2.NewKnowledgeApiWithConfig(clientConfig)
 
-	for pageNum := 1; ; pageNum++ {
-		const pageSize = 100
-		knowledgeBases, _, getErr := knowledgeAPI.GetKnowledgeKnowledgebases("", "", "", fmt.Sprintf("%v", pageSize), "", "", false, "", "")
+	publishedEntities, err := getAllKnowledgebaseEntities(*knowledgeAPI, true)
+	if err != nil {
+		return nil, diag.Errorf("%v", err)
+	}
+
+	for _, knowledgeBase := range *publishedEntities {
+		resources[*knowledgeBase.Id] = &ResourceMeta{Name: *knowledgeBase.Name}
+	}
+
+	unpublishedEntities, err := getAllKnowledgebaseEntities(*knowledgeAPI, false)
+	if err != nil {
+		return nil, diag.Errorf("%v", err)
+	}
+
+	for _, knowledgeBase := range *unpublishedEntities {
+		resources[*knowledgeBase.Id] = &ResourceMeta{Name: *knowledgeBase.Name}
+	}
+
+	return resources, nil
+}
+
+func getAllKnowledgebaseEntities(knowledgeApi platformclientv2.KnowledgeApi, published bool) (*[]platformclientv2.Knowledgebase, error) {
+	var (
+		after    string
+		entities []platformclientv2.Knowledgebase
+	)
+
+	const pageSize = 100
+	for i := 0; ; i++ {
+		knowledgeBases, _, getErr := knowledgeApi.GetKnowledgeKnowledgebases("", after, "", fmt.Sprintf("%v", pageSize), "", "", published, "", "")
 		if getErr != nil {
-			return nil, diag.Errorf("Failed to get page of knowledge bases: %v", getErr)
+			return nil, fmt.Errorf("Failed to get page of knowledge bases: %v", getErr)
 		}
 
 		if knowledgeBases.Entities == nil || len(*knowledgeBases.Entities) == 0 {
 			break
 		}
 
-		for _, knowledgeBase := range *knowledgeBases.Entities {
-			resources[*knowledgeBase.Id] = &ResourceMeta{Name: *knowledgeBase.Name}
+		entities = append(entities, *knowledgeBases.Entities...)
+
+		if knowledgeBases.NextUri == nil || *knowledgeBases.NextUri == "" {
+			break
+		}
+
+		u, err := url.Parse(*knowledgeBases.NextUri)
+		if err != nil {
+			return nil, fmt.Errorf("Failed to parse after cursor from knowledge base nextUri: %v", err)
+		}
+		m, _ := url.ParseQuery(u.RawQuery)
+		if afterSlice, ok := m["after"]; ok && len(afterSlice) > 0 {
+			after = afterSlice[0]
+		}
+		if after == "" {
+			break
 		}
 	}
 
-	return resources, nil
+	return &entities, nil
 }
 
 func knowledgeKnowledgebaseExporter() *ResourceExporter {

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -1009,7 +1009,8 @@ func generateTfExportResource(
 			"genesyscloud_telephony_providers_edges_trunk",
 			"genesyscloud_user_roles",
 			"genesyscloud_webdeployments_configuration",
-			"genesyscloud_webdeployments_deployment"
+			"genesyscloud_webdeployments_deployment",
+			"genesyscloud_knowledge_knowledgebase"
 		]
 		exclude_attributes = [%s]
 	}


### PR DESCRIPTION
Because the exporter function was trying to use the pageNumber system when it should have been using cursor logic, it was getting stuck in an infinite loop. Trusting the terraform code generator too much probably caused this one.

It also wasn't exporting both published and unpublished entities. 