### PR TITLE
Fix: Exporter Docs by removing explicit required_provider and indicate to use the Use Provider dropdown

### DIFF
--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -9,15 +9,9 @@ description: |-
 
 For existing orgs, it may be desirable to have Terraform begin managing your configuration. If there are only a handful of users, queues, etc. to manage, Terraform has an option to [import individual resources](https://www.terraform.io/docs/cli/import/index.html) into a Terraform module.
 
-However, if there are a lot of existing resources it can be painful to manually import all of them into a Terraform state file. To make this easier, a special resource has been defined to export that configuration into a local Terraform [JSON configuration file](https://www.terraform.io/docs/language/syntax/json.html) or [TF configuration file](https://www.terraform.io/language/syntax/configuration). Ensure you have the Terraform CLI installed and create a `.tf` file that requires the genesyscloud provider as shown below. Add a `genesyscloud_tf_export` resource to that same file:
+However, if there are a lot of existing resources it can be painful to manually import all of them into a Terraform state file. To make this easier, a special resource has been defined to export that configuration into a local Terraform [JSON configuration file](https://www.terraform.io/docs/language/syntax/json.html) or [TF configuration file](https://www.terraform.io/language/syntax/configuration). Ensure you have the Terraform CLI installed and create a `.tf` file that requires the genesyscloud provider (click the Use Provider drop down to learn how to use the latest version of the required provider). Add a `provider` block and a `genesyscloud_tf_export` resource to that same file:
 ```hcl
-terraform {
-  required_providers {
-    genesyscloud = {
-      source  = "mypurecloud/genesyscloud"
-      version = "~> 1.0.0"
-    }
-  }
+provider "genesyscloud" {
 }
 
 resource "genesyscloud_tf_export" "export" {

--- a/templates/guides/export.md.tmpl
+++ b/templates/guides/export.md.tmpl
@@ -9,15 +9,9 @@ description: |-
 
 For existing orgs, it may be desirable to have Terraform begin managing your configuration. If there are only a handful of users, queues, etc. to manage, Terraform has an option to [import individual resources](https://www.terraform.io/docs/cli/import/index.html) into a Terraform module.
 
-However, if there are a lot of existing resources it can be painful to manually import all of them into a Terraform state file. To make this easier, a special resource has been defined to export that configuration into a local Terraform [JSON configuration file](https://www.terraform.io/docs/language/syntax/json.html) or [TF configuration file](https://www.terraform.io/language/syntax/configuration). Ensure you have the Terraform CLI installed and create a `.tf` file that requires the genesyscloud provider as shown below. Add a `genesyscloud_tf_export` resource to that same file:
+However, if there are a lot of existing resources it can be painful to manually import all of them into a Terraform state file. To make this easier, a special resource has been defined to export that configuration into a local Terraform [JSON configuration file](https://www.terraform.io/docs/language/syntax/json.html) or [TF configuration file](https://www.terraform.io/language/syntax/configuration). Ensure you have the Terraform CLI installed and create a `.tf` file that requires the genesyscloud provider (click the Use Provider drop down to learn how to use the latest version of the required provider). Add a `provider` block and a `genesyscloud_tf_export` resource to that same file:
 ```hcl
-terraform {
-  required_providers {
-    genesyscloud = {
-      source  = "mypurecloud/genesyscloud"
-      version = "~> 1.0.0"
-    }
-  }
+provider "genesyscloud" {
 }
 
 resource "genesyscloud_tf_export" "export" {


### PR DESCRIPTION
I needed to use the exporter tool for the first time today. I was following the example in creating my `export.tf` file and tried to use the `export_as_hcl` attribute. However, I got the following error:

```
│ Error: Unsupported argument
│
│   on export_as_hcl.tf line 12, in resource "genesyscloud_tf_export" "export":
│   12:   export_as_hcl      = true
│
│ An argument named "export_as_hcl" is not expected here.
```
I realized after some looking around that I was using an outdated version of the provider from the example. Upgrading the provider to the latest version resolved this problem.

I'm updating the docs to remove the `required_provider` block from the example because there is no straight-forward way to generate the latest version inside these docs, and instead elected to refer to the *Use Provider* dropdown available on the Terraform Library docs website. Also, added the required `provider` block to the example.