### PR TITLE
Update maximum_capacity range to include zero

### DIFF
--- a/docs/resources/routing_utilization.md
+++ b/docs/resources/routing_utilization.md
@@ -67,7 +67,7 @@ resource "genesyscloud_routing_utilization" "org-utililzation" {
 
 Required:
 
-- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 1 and 25.
+- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 0 and 25.
 
 Optional:
 
@@ -80,7 +80,7 @@ Optional:
 
 Required:
 
-- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 1 and 25.
+- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 0 and 25.
 
 Optional:
 
@@ -93,7 +93,7 @@ Optional:
 
 Required:
 
-- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 1 and 25.
+- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 0 and 25.
 
 Optional:
 
@@ -106,7 +106,7 @@ Optional:
 
 Required:
 
-- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 1 and 25.
+- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 0 and 25.
 
 Optional:
 
@@ -119,7 +119,7 @@ Optional:
 
 Required:
 
-- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 1 and 25.
+- `maximum_capacity` (Number) Maximum capacity of conversations of this media type. Value must be between 0 and 25.
 
 Optional:
 

--- a/genesyscloud/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/resource_genesyscloud_routing_utilization.go
@@ -30,10 +30,10 @@ var (
 	utilizationSettingsResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"maximum_capacity": {
-				Description:  "Maximum capacity of conversations of this media type. Value must be between 1 and 25.",
+				Description:  "Maximum capacity of conversations of this media type. Value must be between 0 and 25.",
 				Type:         schema.TypeInt,
 				Required:     true,
-				ValidateFunc: validation.IntBetween(1, 25),
+				ValidateFunc: validation.IntBetween(0, 25),
 			},
 			"interruptible_media_types": {
 				Description: fmt.Sprintf("Set of other media types that can interrupt this media type (%s).", strings.Join(getSdkUtilizationTypes(), " | ")),

--- a/genesyscloud/resource_genesyscloud_user_test.go
+++ b/genesyscloud/resource_genesyscloud_user_test.go
@@ -695,6 +695,7 @@ func TestAccResourceUserRoutingUtil(t *testing.T) {
 		userResource1 = "test-user-util"
 		userName      = "Terraform Util"
 		email1        = "terraform-" + uuid.NewString() + "@example.com"
+		maxCapacity0  = "0"
 		maxCapacity1  = "10"
 		maxCapacity2  = "12"
 		utilTypeCall  = "call"
@@ -767,6 +768,39 @@ func TestAccResourceUserRoutingUtil(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.email.0.include_non_acd", trueValue),
 					validateStringInArray("genesyscloud_user."+userResource1, "routing_utilization.0.email.0.interruptible_media_types", utilTypeCall),
 					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.message.0.maximum_capacity", maxCapacity2),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.message.0.include_non_acd", trueValue),
+					validateStringInArray("genesyscloud_user."+userResource1, "routing_utilization.0.message.0.interruptible_media_types", utilTypeCall),
+				),
+			},
+			{
+				// Ensure max capacity can be set to 0
+				Config: generateUserWithCustomAttrs(
+					userResource1,
+					email1,
+					userName,
+					generateUserRoutingUtil(
+						generateRoutingUtilMediaType("call", maxCapacity0, trueValue, strconv.Quote(utilTypeEmail)),
+						generateRoutingUtilMediaType("callback", maxCapacity0, trueValue, strconv.Quote(utilTypeCall)),
+						generateRoutingUtilMediaType("chat", maxCapacity0, trueValue, strconv.Quote(utilTypeCall)),
+						generateRoutingUtilMediaType("email", maxCapacity0, trueValue, strconv.Quote(utilTypeCall)),
+						generateRoutingUtilMediaType("message", maxCapacity0, trueValue, strconv.Quote(utilTypeCall)),
+					),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					validateUserUtilizationLevel("genesyscloud_user."+userResource1, "Agent"),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.call.0.maximum_capacity", maxCapacity0),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.call.0.include_non_acd", trueValue),
+					validateStringInArray("genesyscloud_user."+userResource1, "routing_utilization.0.call.0.interruptible_media_types", utilTypeEmail),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.callback.0.maximum_capacity", maxCapacity0),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.callback.0.include_non_acd", trueValue),
+					validateStringInArray("genesyscloud_user."+userResource1, "routing_utilization.0.callback.0.interruptible_media_types", utilTypeCall),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.chat.0.maximum_capacity", maxCapacity0),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.chat.0.include_non_acd", trueValue),
+					validateStringInArray("genesyscloud_user."+userResource1, "routing_utilization.0.chat.0.interruptible_media_types", utilTypeCall),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.email.0.maximum_capacity", maxCapacity0),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.email.0.include_non_acd", trueValue),
+					validateStringInArray("genesyscloud_user."+userResource1, "routing_utilization.0.email.0.interruptible_media_types", utilTypeCall),
+					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.message.0.maximum_capacity", maxCapacity0),
 					resource.TestCheckResourceAttr("genesyscloud_user."+userResource1, "routing_utilization.0.message.0.include_non_acd", trueValue),
 					validateStringInArray("genesyscloud_user."+userResource1, "routing_utilization.0.message.0.interruptible_media_types", utilTypeCall),
 				),


### PR DESCRIPTION
This is a partial fix to https://inindca.atlassian.net/browse/DEVENGAGE-1868

This change allows a `maximum_capacity` value to be set to 0-25, not just 1-25.

The API allows this, and we can see that it is confirmed in the API errors:

```
PUT /api/v2/routing/users/3b19297d-64f5-4136-b2be-baeda46e23ea/utilization HTTP/1.1
Content-Type: application/json
Authorization: Bearer XXXXX
Host: api.mypurecloud.com
Content-Length: 925

{
	"utilization": {
		"call": {
			"maximumCapacity": 26,
			"interruptableMediaTypes": [
				"chat",
				"email",
				"message"
			],
			"includeNonAcd": false
		},
		"chat": {
			"maximumCapacity": 1,
			"interruptableMediaTypes": [
				"email",
				"message"
			],
			"includeNonAcd": false
		},
		"email": {
			"maximumCapacity": 2,
			"interruptableMediaTypes": [
				"call",
				"callback",
				"chat"
			],
			"includeNonAcd": false
		},
		"message": {
			"maximumCapacity": 1,
			"interruptableMediaTypes": [
				"chat",
				"email"
			],
			"includeNonAcd": false
		},
		"callback": {
			"maximumCapacity": 0,
			"interruptableMediaTypes": [
				"chat",
				"email",
				"message"
			],
			"includeNonAcd": false
		},
		"workitem": {
			"maximumCapacity": 4,
			"interruptableMediaTypes": [
				"call",
				"callback",
				"chat",
				"email",
				"message"
			],
			"includeNonAcd": true
		}
	},
	"level": "Agent"
}
---
{
	"message": "Maximum capacity must be between 0 and 25.",
	"code": "invalid.media.capacity",
	"status": 400,
	"messageWithParams": "Maximum capacity must be between 0 and 25.",
	"messageParams": {},
	"contextId": "260efd02-4360-4c94-991c-6d691a93148d",
	"details": [],
	"errors": []
}
```

---

This is only a partial fix for  DEVENGAGE-1868, as this does not address the issue with the exporter rendering the `maximum_capacity` attribute if the value is zero.