### PR TITLE
Campaigns, campaign rules, and sequences can be turned off at point of destroy

### DIFF
--- a/genesyscloud/resource_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/resource_genesyscloud_outbound_campaignrule.go
@@ -354,6 +354,17 @@ func deleteOutboundCampaignRule(ctx context.Context, d *schema.ResourceData, met
 	sdkConfig := meta.(*ProviderMeta).ClientConfig
 	outboundApi := platformclientv2.NewOutboundApiWithConfig(sdkConfig)
 
+	ruleEnabled := d.Get("enabled").(bool)
+	if ruleEnabled {
+		// Have to disable rule before we can delete
+		log.Printf("Disabling Outbound Campaign Rule")
+		d.Set("enabled", false)
+		diagErr := updateOutboundCampaignRule(ctx, d, meta)
+		if diagErr != nil {
+			return diagErr
+		}
+	}
+
 	diagErr := retryWhen(isStatus400, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
 		log.Printf("Deleting Outbound Campaign Rule")
 		resp, err := outboundApi.DeleteOutboundCampaignrule(d.Id())

--- a/genesyscloud/resource_genesyscloud_outbound_sequence_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_sequence_test.go
@@ -123,6 +123,151 @@ data "genesyscloud_auth_division_home" "home" {}
 	})
 }
 
+func TestAccResourceOutboundSequenceStatus(t *testing.T) {
+	t.Parallel()
+	var (
+		// Sequence
+		sequenceResource = "outbound_sequence"
+		sequenceName1    = "Sequence " + uuid.NewString()
+		sequenceName2    = "Sequence " + uuid.NewString()
+
+		// Campaign resources
+		campaignResourceId    = "campaign_resource"
+		campaignName          = "Campaign " + uuid.NewString()
+		contactListResourceId = "contact_list"
+		carResourceId         = "car"
+		siteId                = "site"
+		outboundFlowFilePath  = "../examples/resources/genesyscloud_flow/outboundcall_flow_example.yaml"
+		flowName              = "test flow " + uuid.NewString()
+		emergencyNumber       = "+13172947330"
+	)
+
+	// necessary to avoid errors during site creation
+	err := authorizeSdk()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = deleteLocationWithNumber(emergencyNumber)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { TestAccPreCheck(t) },
+		ProviderFactories: ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// Create
+				Config: fmt.Sprintf(`
+data "genesyscloud_auth_division_home" "home" {}
+`) + generateOutboundCampaignBasic(
+					campaignResourceId,
+					campaignName,
+					contactListResourceId,
+					siteId,
+					emergencyNumber,
+					carResourceId,
+					nullValue,
+					outboundFlowFilePath,
+					"sequence-test-flow",
+					flowName,
+					"${data.genesyscloud_auth_division_home.home.name}",
+					"sequence-test-location",
+					"sequence-test-wrapupcode",
+				) + generateOutboundSequence(
+					sequenceResource,
+					sequenceName1,
+					[]string{"genesyscloud_outbound_campaign." + campaignResourceId + ".id"},
+					strconv.Quote("on"),
+					trueValue,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "name", sequenceName1),
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "status", "on"),
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "repeat", trueValue),
+					resource.TestCheckResourceAttrPair("genesyscloud_outbound_sequence."+sequenceResource, "campaign_ids.0",
+						"genesyscloud_outbound_campaign."+campaignResourceId, "id"),
+				),
+			},
+			{
+				// Update with a new name, status and repeat value
+				Config: fmt.Sprintf(`
+data "genesyscloud_auth_division_home" "home" {}
+`) + generateOutboundCampaignBasic(
+					campaignResourceId,
+					campaignName,
+					contactListResourceId,
+					siteId,
+					emergencyNumber,
+					carResourceId,
+					nullValue,
+					outboundFlowFilePath,
+					"sequence-test-flow",
+					flowName,
+					"${data.genesyscloud_auth_division_home.home.name}",
+					"sequence-test-location",
+					"sequence-test-wrapupcode",
+				) + generateOutboundSequence(
+					sequenceResource,
+					sequenceName2,
+					[]string{"genesyscloud_outbound_campaign." + campaignResourceId + ".id"},
+					strconv.Quote("off"),
+					falseValue,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "name", sequenceName2),
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "status", "off"),
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "repeat", falseValue),
+					resource.TestCheckResourceAttrPair("genesyscloud_outbound_sequence."+sequenceResource, "campaign_ids.0",
+						"genesyscloud_outbound_campaign."+campaignResourceId, "id"),
+				),
+			},
+			{
+				// Turn back on to test that the sequence can be turned back on again, and ensure that the destroy
+				// command can handle destroying a sequence that is "on"
+				Config: fmt.Sprintf(`
+data "genesyscloud_auth_division_home" "home" {}
+`) + generateOutboundCampaignBasic(
+					campaignResourceId,
+					campaignName,
+					contactListResourceId,
+					siteId,
+					emergencyNumber,
+					carResourceId,
+					nullValue,
+					outboundFlowFilePath,
+					"sequence-test-flow",
+					flowName,
+					"${data.genesyscloud_auth_division_home.home.name}",
+					"sequence-test-location",
+					"sequence-test-wrapupcode",
+				) + generateOutboundSequence(
+					sequenceResource,
+					sequenceName2,
+					[]string{"genesyscloud_outbound_campaign." + campaignResourceId + ".id"},
+					strconv.Quote("on"),
+					falseValue,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "name", sequenceName2),
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "status", "on"),
+					resource.TestCheckResourceAttr("genesyscloud_outbound_sequence."+sequenceResource, "repeat", falseValue),
+					resource.TestCheckResourceAttrPair("genesyscloud_outbound_sequence."+sequenceResource, "campaign_ids.0",
+						"genesyscloud_outbound_campaign."+campaignResourceId, "id"),
+				),
+			},
+			{
+				// Import/Read
+				ResourceName:      "genesyscloud_outbound_sequence." + sequenceResource,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+		CheckDestroy: testVerifyOutboundSequenceDestroyed,
+	})
+}
+
 func generateOutboundSequence(
 	resourceId string,
 	name string,


### PR DESCRIPTION
In conjunction with [this PR](https://github.com/MyPureCloud/terraform-provider-genesyscloud/pull/533) I added functionality and tests to ensure that campaigns, campaign rules, and sequences can be turned off at point of destroy. 

Otherwise, we see the following errors when running destroy:

```
│ Error: Exhausted retries. Last error: [{0 Failed to delete Outbound Campaign: API Error: 400 - Cannot delete a campaign when it is running (f0143ffa-3ba8-4ef2-a1de-17e046f1fe14)  []}]
```

```
│ Error: Exhausted retries. Last error: [{0 Failed to delete Outbound Campaign Rule: API Error: 400 - Cannot delete an enabled campaign rule (ede90978-2d89-4b7c-8ed8-7072415ee8c4)  []}]
```

Since I had also added enable functionality to the outbound sequences resource in the prior PR, I went ahead and added a test to ensure we could still delete with an enabled sequence (the API doesn't require you to disable it before deleting).
