### PR TITLE
DEVENGAGE-1925: Added primary and secondary sites

### DIFF
--- a/docs/resources/telephony_providers_edges_site.md
+++ b/docs/resources/telephony_providers_edges_site.md
@@ -96,6 +96,8 @@ resource "genesyscloud_telephony_providers_edges_site" "site" {
 - `media_regions_use_latency_based` (Boolean) Latency based on media region Defaults to `false`.
 - `number_plans` (Block List) Number plans for the site. The order of the plans in the resource file determines the priority of the plans. Specifying number plans will not result in the default plans being overwritten. (see [below for nested schema](#nestedblock--number_plans))
 - `outbound_routes` (Block List) Outbound Routes for the site. The default outbound route will not be delete if routes are specified (see [below for nested schema](#nestedblock--outbound_routes))
+- `primary_sites` (List of String) Used for primary phone edge assignment on physical edges only.  List of primary sites the phones can be assigned to. If no primary_sites are defined, the site id for this site will be used as the primary site id.
+- `secondary_sites` (List of String) Used for secondary phone edge assignment on physical edges only.  List of secondary sites the phones can be assigned to.  If no primary_sites or secondary_sites are defined then the current site will defined as primary and secondary.
 
 ### Read-Only
 

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
@@ -223,12 +223,14 @@ func resourceSite() *schema.Resource {
 			"primary_sites": {
 				Description: `Used for primary phone edge assignment on physical edges only.  List of primary sites the phones can be assigned to. If no primary_sites are defined, the site id for this site will be used as the primary site id.`,
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"secondary_sites": {
 				Description: `Used for secondary phone edge assignment on physical edges only.  List of secondary sites the phones can be assigned to.  If no primary_sites or secondary_sites are defined then the current site will defined as primary and secondary. `,
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
@@ -220,6 +220,18 @@ func resourceSite() *schema.Resource {
 					},
 				},
 			},
+			"primary_sites": {
+				Description: `Used for primary phone edge assignment on physical edges only.  List of primary sites the phones can be assigned to. If no primary_sites are defined, the site id for this site will be used as the primary site id.`,
+				Optional:    true,
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"secondary_sites": {
+				Description: `Used for secondary phone edge assignment on physical edges only.  List of secondary sites the phones can be assigned to.  If no primary_sites or secondary_sites are defined then the current site will defined as primary and secondary. `,
+				Optional:    true,
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 }
@@ -276,6 +288,8 @@ func siteExporter() *ResourceExporter {
 		RefAttrs: map[string]*RefAttrSettings{
 			"location_id": {RefType: "genesyscloud_location"},
 			"outbound_routes.external_trunk_base_ids": {RefType: "genesyscloud_telephony_providers_edges_trunkbasesettings"},
+			"primary_sites":   {RefType: "genesyscloud_telephony_providers_edges_site"},
+			"secondary_sites": {RefType: "genesyscloud_telephony_providers_edges_site"},
 		},
 	}
 }
@@ -312,6 +326,7 @@ func createSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	description := d.Get("description").(string)
 	mediaRegionsUseLatencyBased := d.Get("media_regions_use_latency_based").(bool)
 	edgeAutoUpdateConfig, err := buildSdkEdgeAutoUpdateConfig(d)
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -375,7 +390,13 @@ func createSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	d.SetId(*site.Id)
 
-	diagErr := updateSiteNumberPlans(d, edgesAPI)
+	log.Printf("Creating updating site with primary/secondary:  %s", *site.Id)
+	diagErr := updatePrimarySecondarySites(d, *site.Id, edgesAPI)
+	if diagErr != nil {
+		return diagErr
+	}
+
+	diagErr = updateSiteNumberPlans(d, edgesAPI)
 	if diagErr != nil {
 		return diagErr
 	}
@@ -435,6 +456,14 @@ func readSite(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		d.Set("caller_id", currentSite.CallerId)
 		d.Set("caller_name", currentSite.CallerName)
 
+		if currentSite.PrimarySites != nil {
+			d.Set("primary_sites", sdkDomainEntityRefArrToList(*currentSite.PrimarySites))
+		}
+
+		if currentSite.SecondarySites != nil {
+			d.Set("secondary_sites", sdkDomainEntityRefArrToList(*currentSite.SecondarySites))
+		}
+
 		if retryErr := readSiteNumberPlans(d, edgesAPI); retryErr != nil {
 			return retryErr
 		}
@@ -455,6 +484,9 @@ func updateSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	description := d.Get("description").(string)
 	mediaRegionsUseLatencyBased := d.Get("media_regions_use_latency_based").(bool)
 	edgeAutoUpdateConfig, err := buildSdkEdgeAutoUpdateConfig(d)
+	primarySites := InterfaceListToStrings(d.Get("primary_sites").([]interface{}))
+	secondarySites := InterfaceListToStrings(d.Get("secondary_sites").([]interface{}))
+
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -505,6 +537,14 @@ func updateSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	if description != "" {
 		site.Description = &description
+	}
+
+	if len(primarySites) > 0 {
+		site.PrimarySites = buildSdkDomainEntityRefArr(d, "primary_sites")
+	}
+
+	if len(secondarySites) > 0 {
+		site.SecondarySites = buildSdkDomainEntityRefArr(d, "secondary_sites")
 	}
 
 	edgesAPI := platformclientv2.NewTelephonyProvidersEdgeApiWithConfig(sdkConfig)
@@ -602,6 +642,49 @@ func nameInOutboundRoutes(name string, outboundRoutes []platformclientv2.Outboun
 	}
 
 	return nil, false
+}
+
+// Contains the logic to determine if a primary or secondary site need to be updated.
+func updatePrimarySecondarySites(d *schema.ResourceData, siteId string, edgesAPI *platformclientv2.TelephonyProvidersEdgeApi) diag.Diagnostics {
+	primarySites := InterfaceListToStrings(d.Get("primary_sites").([]interface{}))
+	secondarySites := InterfaceListToStrings(d.Get("secondary_sites").([]interface{}))
+
+	site, resp, err := edgesAPI.GetTelephonyProvidersEdgesSite(siteId)
+
+	if resp.StatusCode != 200 {
+		return diag.Errorf("Unable to retrieve site record after site %s was created, but unable to update the primary or secondary site.  Status code %d. RespBody %s", siteId, resp.StatusCode, resp.RawBody)
+	}
+
+	if err != nil {
+		return diag.Errorf("Unable to retrieve site record after site %s was created, but unable to update the primary or secondary site.  Err: %s", siteId, err)
+	}
+
+	if len(primarySites) == 0 && len(secondarySites) > 0 {
+		der := platformclientv2.Domainentityref{Id: &siteId}
+		derArr := make([]platformclientv2.Domainentityref, 1)
+		derArr[0] = der
+		site.PrimarySites = &derArr
+	}
+
+	if len(primarySites) > 0 {
+		site.PrimarySites = buildSdkDomainEntityRefArr(d, "primary_sites")
+	}
+
+	if len(secondarySites) > 0 {
+		site.SecondarySites = buildSdkDomainEntityRefArr(d, "secondary_sites")
+	}
+
+	_, resp, err = edgesAPI.PutTelephonyProvidersEdgesSite(siteId, *site)
+
+	if resp.StatusCode != 200 {
+		return diag.Errorf("Site %s was created, but unable to update the primary or secondary site.  Status code %d. RespBody %s", siteId, resp.StatusCode, resp.RawBody)
+	}
+
+	if err != nil {
+		return diag.Errorf("[Site %s was created, but unable to update the primary or secondary site.  Err: %s", siteId, err)
+	}
+
+	return nil
 }
 
 func updateSiteNumberPlans(d *schema.ResourceData, edgesAPI *platformclientv2.TelephonyProvidersEdgeApi) diag.Diagnostics {


### PR DESCRIPTION
Hey guys,

I have added primary_sites and secondary_sites attributes to the site resource.  Please note there were no enhancements to the test because these fields are only applicable when working with physical edges.  I had to borrow a physical edge in test and manually tested the code.  Let me know if you have any questions or concerns