### PR TITLE
DEVENGAGE-1944: read-only selectors for cobrowse

### DIFF
--- a/docs/resources/webdeployments_configuration.md
+++ b/docs/resources/webdeployments_configuration.md
@@ -51,6 +51,7 @@ resource "genesyscloud_webdeployments_configuration" "exampleConfiguration" {
     enabled             = true
     allow_agent_control = true
     mask_selectors      = [".my-class", "#my-id"]
+    readonly_selectors  = [".my-class", "#my-id"]
   }
   journey_events {
     enabled                   = true
@@ -144,6 +145,7 @@ Optional:
 - `allow_agent_control` (Boolean) Whether agent can take control over customer's screen or not
 - `enabled` (Boolean) Whether or not cobrowse is enabled
 - `mask_selectors` (List of String) List of CSS selectors which should be masked when screen sharing is active
+- `readonly_selectors` (List of String) List of CSS selectors which should be read-only when screen sharing is active
 
 
 <a id="nestedblock--journey_events"></a>

--- a/examples/resources/genesyscloud_webdeployments_configuration/resource.tf
+++ b/examples/resources/genesyscloud_webdeployments_configuration/resource.tf
@@ -26,6 +26,7 @@ resource "genesyscloud_webdeployments_configuration" "exampleConfiguration" {
     enabled             = true
     allow_agent_control = true
     mask_selectors      = [".my-class", "#my-id"]
+    readonly_selectors  = [".my-class", "#my-id"]
   }
   journey_events {
     enabled                   = true

--- a/genesyscloud/resource_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/resource_genesyscloud_webdeployments_configuration.go
@@ -123,6 +123,12 @@ var (
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
+			"readonly_selectors": {
+				Description: "List of CSS selectors which should be read-only when screen sharing is active",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
 		},
 	}
 
@@ -285,7 +291,7 @@ func getAllWebDeploymentConfigurations(ctx context.Context, clientConfig *platfo
 
 func webDeploymentConfigurationExporter() *ResourceExporter {
 	return &ResourceExporter{
-		GetResourcesFunc: getAllWithPooledClient(getAllWebDeploymentConfigurations),
+		GetResourcesFunc:   getAllWithPooledClient(getAllWebDeploymentConfigurations),
 		ExcludedAttributes: []string{"version"},
 	}
 }
@@ -650,11 +656,13 @@ func readCobrowseSettings(d *schema.ResourceData) *platformclientv2.Cobrowsesett
 	enabled, _ := cfg["enabled"].(bool)
 	allowAgentControl, _ := cfg["allow_agent_control"].(bool)
 	maskSelectors := InterfaceListToStrings(cfg["mask_selectors"].([]interface{}))
+	readonlySelectors := InterfaceListToStrings(cfg["readonly_selectors"].([]interface{}))
 
 	return &platformclientv2.Cobrowsesettings{
 		Enabled:           &enabled,
 		AllowAgentControl: &allowAgentControl,
 		MaskSelectors:     &maskSelectors,
+		ReadonlySelectors: &readonlySelectors,
 	}
 }
 
@@ -901,6 +909,7 @@ func flattenCobrowseSettings(cobrowseSettings *platformclientv2.Cobrowsesettings
 		"enabled":             cobrowseSettings.Enabled,
 		"allow_agent_control": cobrowseSettings.AllowAgentControl,
 		"mask_selectors":      cobrowseSettings.MaskSelectors,
+		"readonly_selectors":  cobrowseSettings.ReadonlySelectors,
 	}}
 }
 

--- a/genesyscloud/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/resource_genesyscloud_webdeployments_configuration_test.go
@@ -80,6 +80,7 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 						trueValue,
 						trueValue,
 						[]string{strconv.Quote("selector-one")},
+						[]string{strconv.Quote("selector-one")},
 					),
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -103,6 +104,8 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 					resource.TestCheckResourceAttr(fullResourceName, "cobrowse.0.allow_agent_control", trueValue),
 					resource.TestCheckResourceAttr(fullResourceName, "cobrowse.0.mask_selectors.#", "1"),
 					resource.TestCheckResourceAttr(fullResourceName, "cobrowse.0.mask_selectors.0", "selector-one"),
+					resource.TestCheckResourceAttr(fullResourceName, "cobrowse.0.readonly_selectors.#", "1"),
+					resource.TestCheckResourceAttr(fullResourceName, "cobrowse.0.readonly_selectors.0", "selector-one"),
 					resource.TestCheckResourceAttr(fullResourceName, "journey_events.#", "1"),
 					resource.TestCheckResourceAttr(fullResourceName, "journey_events.0.enabled", trueValue),
 					resource.TestCheckResourceAttr(fullResourceName, "journey_events.0.excluded_query_parameters.#", "1"),
@@ -148,6 +151,7 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 						falseValue,
 						falseValue,
 						[]string{strconv.Quote("selector-one"), strconv.Quote("selector-two")},
+						[]string{strconv.Quote("selector-one"), strconv.Quote("selector-two")},
 					),
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -172,6 +176,9 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 					resource.TestCheckResourceAttr(fullResourceName, "cobrowse.0.mask_selectors.#", "2"),
 					validateStringInArray(fullResourceName, "cobrowse.0.mask_selectors", "selector-one"),
 					validateStringInArray(fullResourceName, "cobrowse.0.mask_selectors", "selector-two"),
+					resource.TestCheckResourceAttr(fullResourceName, "cobrowse.0.readonly_selectors.#", "2"),
+					validateStringInArray(fullResourceName, "cobrowse.0.readonly_selectors", "selector-one"),
+					validateStringInArray(fullResourceName, "cobrowse.0.readonly_selectors", "selector-two"),
 					resource.TestCheckResourceAttr(fullResourceName, "journey_events.#", "1"),
 					resource.TestCheckResourceAttr(fullResourceName, "journey_events.0.enabled", trueValue),
 					resource.TestCheckResourceAttr(fullResourceName, "journey_events.0.excluded_query_parameters.#", "1"),
@@ -318,14 +325,15 @@ func complexConfigurationResource(name, description string, nestedBlocks ...stri
 	`, name, description, strings.Join(nestedBlocks, "\n"))
 }
 
-func generateWebDeploymentConfigCobrowseSettings(cbEnabled, cbAllowAgentControl string, cbMaskSelectors []string) string {
+func generateWebDeploymentConfigCobrowseSettings(cbEnabled, cbAllowAgentControl string, cbMaskSelectors []string, cbReadonlySelectors []string) string {
 	return fmt.Sprintf(`
 	cobrowse {
 		enabled = %s
 		allow_agent_control = %s
 		mask_selectors = [ %s ]
+		readonly_selectors = [ %s ]
 	}
-`, cbEnabled, cbAllowAgentControl, strings.Join(cbMaskSelectors, ", "))
+`, cbEnabled, cbAllowAgentControl, strings.Join(cbMaskSelectors, ", "), strings.Join(cbReadonlySelectors, ", "))
 }
 
 func verifyConfigurationDestroyed(state *terraform.State) error {


### PR DESCRIPTION
Added read-only selectors for Co-browse in webdeployment configuration.
This is similar to mask_selectors added in the [previous PR](https://github.com/MyPureCloud/terraform-provider-genesyscloud/pull/445).