### PR TITLE
Allow querying for default scripts in data.genesyscloud_script objects

### DIFF
--- a/docs/data-sources/script.md
+++ b/docs/data-sources/script.md
@@ -25,6 +25,10 @@ data "genesyscloud_script" "example-script" {
 
 - `name` (String) Script name.
 
+### Optional
+
+- `published` (Boolean) Filter by published scripts. Use this for querying default scripts. Defaults to `false`.
+
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/genesyscloud/resource_exporter.go
+++ b/genesyscloud/resource_exporter.go
@@ -15,7 +15,7 @@ import (
 )
 
 type ResourceMeta struct {
-	// Name of the resoruce to be used in exports
+	// Name of the resource to be used in exports
 	Name string
 
 	// Prefix to add to the ID when reading state


### PR DESCRIPTION
I noticed while working with a recent export project that scripts cannot reference any of the "Default" scripts using the data source.

I checked in with the Genesys Cloud Outbound / Scripting team, and they have intentionally hard-coded the three "Default" scripts to have their own ids that are consistently the same across all orgs. However, they only show up under the "published" listing of scripts.

Instead of having to "know" these IDs, we can update the the data source to allow querying them using the "published" identifier, which is what this PR does.

Here's an example of how I'm using it:

```
data "genesyscloud_script" "Default_Outbound_Script" {
  name      = "Default Outbound Script"
  published = true
}

resource "genesyscloud_outbound_campaign" "Foo_Campaign" {
  script_id             = data.genesyscloud_script.Default_Outbound_Script.id
  ...
}
```