### PR TITLE
Devengage 1992 add scripts publishing

### DIFF
--- a/docs/data-sources/telephony_providers_edges_did_pool.md
+++ b/docs/data-sources/telephony_providers_edges_did_pool.md
@@ -25,7 +25,7 @@ data "genesyscloud_telephony_providers_edges_did_pool" "didPool" {
 ### Required
 
 - `end_phone_number` (String) Ending phone number of the DID Pool range.
-- `start_phone_number` (String) Starting phone number of the DID Pool range.
+- `start_phone_number` (String) Starting phone number of the DID Pool range. Must be in an E.164 number format.
 
 ### Read-Only
 

--- a/docs/resources/architect_ivr.md
+++ b/docs/resources/architect_ivr.md
@@ -44,7 +44,7 @@ resource "genesyscloud_architect_ivr" "sample_ivr" {
 - `closed_hours_flow_id` (String) ID of inbound call flow for closed hours.
 - `description` (String) IVR Config description.
 - `division_id` (String) Division ID.
-- `dnis` (Set of String) The phone number(s) to contact the IVR by. (Note: An array with a length greater than 50 will be broken into chunks and uploaded in subsequent PUT requests.)
+- `dnis` (Set of String) The phone number(s) to contact the IVR by. Each phone number in the array must be in an E.164 number format. (Note: An array with a length greater than 50 will be broken into chunks and uploaded in subsequent PUT requests.)
 - `holiday_hours_flow_id` (String) ID of inbound call flow for holidays.
 - `open_hours_flow_id` (String) ID of inbound call flow for open hours.
 - `schedule_group_id` (String) Schedule group ID.

--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -32,7 +32,7 @@ resource "genesyscloud_group" "sample_group" {
   owner_ids     = [genesyscloud_user.test-user.id]
   member_ids    = [genesyscloud_user.test-user.id]
   addresses {
-    number = "3174181234"
+    number = "+13174181234"
     type   = "GROUPRING"
   }
 }
@@ -64,7 +64,7 @@ resource "genesyscloud_group" "sample_group" {
 
 Required:
 
-- `number` (String) Phone number for this contact type.
+- `number` (String) Phone number for this contact type.  Must be in an E.164 number format.
 - `type` (String) Contact type of the address. (GROUPRING | GROUPPHONE)
 
 Optional:

--- a/docs/resources/location.md
+++ b/docs/resources/location.md
@@ -76,7 +76,7 @@ Optional:
 
 Required:
 
-- `number` (String) Emergency phone number.
+- `number` (String) Emergency phone number.  Must be in an E.164 number format.
 
 Optional:
 

--- a/docs/resources/outbound_dnclist.md
+++ b/docs/resources/outbound_dnclist.md
@@ -56,5 +56,5 @@ resource "genesyscloud_outbound_dnclist" "dnc_list" {
 Optional:
 
 - `expiration_date` (String) Expiration date for DNC phone numbers in yyyy-MM-ddTHH:mmZ format.
-- `phone_numbers` (List of String) Phone numbers to add to a DNC list. Only possible if the dncSourceType is rds.
+- `phone_numbers` (List of String) Phone numbers to add to a DNC list. Only possible if the dncSourceType is rds.  Phone numbers must be in an E.164 number format.
 

--- a/docs/resources/telephony_providers_edges_did_pool.md
+++ b/docs/resources/telephony_providers_edges_did_pool.md
@@ -35,8 +35,8 @@ resource "genesyscloud_telephony_providers_edges_did_pool" "example_did_pool" {
 
 ### Required
 
-- `end_phone_number` (String) Ending phone number of the DID Pool range. Changing the end_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.
-- `start_phone_number` (String) Starting phone number of the DID Pool range. Changing the start_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.
+- `end_phone_number` (String) Ending phone number of the DID Pool range.  Phone number must be in an E.164 number format. Changing the end_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.
+- `start_phone_number` (String) Starting phone number of the DID Pool range. Phone number must be in a E.164 number format. Changing the start_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.
 
 ### Optional
 

--- a/docs/resources/telephony_providers_edges_phone.md
+++ b/docs/resources/telephony_providers_edges_phone.md
@@ -56,7 +56,7 @@ resource "genesyscloud_telephony_providers_edges_phone" "example_phone" {
 ### Optional
 
 - `capabilities` (Block List, Max: 1) Phone Capabilities. (see [below for nested schema](#nestedblock--capabilities))
-- `line_addresses` (List of String) Ordered list of Line DIDs for standalone phones.
+- `line_addresses` (List of String) Ordered list of Line DIDs for standalone phones.  Each phone number must be in an E.164 phone number format.
 - `line_base_settings_id` (String) Line Base Settings ID.
 - `phone_meta_base_id` (String) Phone Meta Base ID.
 - `state` (String) Indicates if the resource is active, inactive, or deleted. Valid values: active, inactive, deleted. Defaults to `active`.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -45,7 +45,7 @@ resource "genesyscloud_user" "example_user" {
       type    = "HOME"
     }
     phone_numbers {
-      number     = "3174181234"
+      number     = "+13174181234"
       media_type = "PHONE"
       type       = "MOBILE"
     }

--- a/examples/resources/genesyscloud_group/resource.tf
+++ b/examples/resources/genesyscloud_group/resource.tf
@@ -7,7 +7,7 @@ resource "genesyscloud_group" "sample_group" {
   owner_ids     = [genesyscloud_user.test-user.id]
   member_ids    = [genesyscloud_user.test-user.id]
   addresses {
-    number = "3174181234"
+    number = "+13174181234"
     type   = "GROUPRING"
   }
 }

--- a/examples/resources/genesyscloud_script/apis.md
+++ b/examples/resources/genesyscloud_script/apis.md
@@ -2,3 +2,4 @@
 * [GET /api/v2/scripts](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-scripts)
 * [GET /api/v2/scripts/{scriptId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-scripts--scriptId-)
 * [GET /api/v2/scripts/uploads/{uploadId}/status](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-scripts-uploads--uploadId--status)
+* [POST /api/v2/scripts/published](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-scripts-published)

--- a/examples/resources/genesyscloud_user/resource.tf
+++ b/examples/resources/genesyscloud_user/resource.tf
@@ -16,7 +16,7 @@ resource "genesyscloud_user" "example_user" {
       type    = "HOME"
     }
     phone_numbers {
-      number     = "3174181234"
+      number     = "+13174181234"
       media_type = "PHONE"
       type       = "MOBILE"
     }

--- a/genesyscloud/data_source_genesyscloud_architect_datatable.go
+++ b/genesyscloud/data_source_genesyscloud_architect_datatable.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceArchitectDatatable() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_architect_emergencygroup.go
+++ b/genesyscloud/data_source_genesyscloud_architect_emergencygroup.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceArchitectEmergencyGroup() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_architect_ivr.go
+++ b/genesyscloud/data_source_genesyscloud_architect_ivr.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceArchitectIvr() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_architect_schedulegroups.go
+++ b/genesyscloud/data_source_genesyscloud_architect_schedulegroups.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceArchitectScheduleGroups() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_architect_schedules.go
+++ b/genesyscloud/data_source_genesyscloud_architect_schedules.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceSchedule() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/data_source_genesyscloud_architect_user_prompt.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceUserPrompt() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_auth_division.go
+++ b/genesyscloud/data_source_genesyscloud_auth_division.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceAuthDivision() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_auth_division_home.go
+++ b/genesyscloud/data_source_genesyscloud_auth_division_home.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceAuthDivisionHome() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_auth_role.go
+++ b/genesyscloud/data_source_genesyscloud_auth_role.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceAuthRole() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_employeeperformance_externalmetrics_definition.go
+++ b/genesyscloud/data_source_genesyscloud_employeeperformance_externalmetrics_definition.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceEmployeeperformanceExternalmetricsDefinition() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_externalcontacts_contact.go
+++ b/genesyscloud/data_source_genesyscloud_externalcontacts_contact.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceExternalContactsContact() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_flow.go
+++ b/genesyscloud/data_source_genesyscloud_flow.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceFlow() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_flow_milestone.go
+++ b/genesyscloud/data_source_genesyscloud_flow_milestone.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceFlowMilestone() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_flow_outcome.go
+++ b/genesyscloud/data_source_genesyscloud_flow_outcome.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceFlowOutcome() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_group.go
+++ b/genesyscloud/data_source_genesyscloud_group.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceGroup() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_integration.go
+++ b/genesyscloud/data_source_genesyscloud_integration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceIntegration() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_integration_action.go
+++ b/genesyscloud/data_source_genesyscloud_integration_action.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceIntegrationAction() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_integration_credential.go
+++ b/genesyscloud/data_source_genesyscloud_integration_credential.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceIntegrationCredential() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_journey_action_map.go
+++ b/genesyscloud/data_source_genesyscloud_journey_action_map.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceJourneyActionMap() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_journey_action_template.go
+++ b/genesyscloud/data_source_genesyscloud_journey_action_template.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceJourneyActionTemplate() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_journey_outcome.go
+++ b/genesyscloud/data_source_genesyscloud_journey_outcome.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceJourneyOutcome() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_journey_segment.go
+++ b/genesyscloud/data_source_genesyscloud_journey_segment.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceJourneySegment() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_knowledge_category.go
+++ b/genesyscloud/data_source_genesyscloud_knowledge_category.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceKnowledgeCategory() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/data_source_genesyscloud_knowledge_knowledgebase.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceKnowledgeKnowledgebase() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_knowledge_label.go
+++ b/genesyscloud/data_source_genesyscloud_knowledge_label.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceKnowledgeLabel() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_location.go
+++ b/genesyscloud/data_source_genesyscloud_location.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceLocation() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_oauth_client.go
+++ b/genesyscloud/data_source_genesyscloud_oauth_client.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOAuthClient() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_organizations_me.go
+++ b/genesyscloud/data_source_genesyscloud_organizations_me.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOrganizationsMe() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_attemptlimit.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_attemptlimit.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundAttemptLimit() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_callabletimeset.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_callabletimeset.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundCallabletimeset() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_callanalysisresponseset.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_callanalysisresponseset.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundCallAnalysisResponseSet() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_campaign.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundCampaign() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_campaignrule.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundCampaignRule() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_contactlist.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_contactlist.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundContactList() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_contactlistfilter.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_contactlistfilter.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundContactListFilter() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_dnclist.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_dnclist.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundDncList() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_messagingcampaign.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_messagingcampaign.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundMessagingcampaign() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_messagingcampaign_test.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_messagingcampaign_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 /*

--- a/genesyscloud/data_source_genesyscloud_outbound_ruleset.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_ruleset.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundRuleset() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_outbound_sequence.go
+++ b/genesyscloud/data_source_genesyscloud_outbound_sequence.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceOutboundSequence() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_quality_forms_evaluation.go
+++ b/genesyscloud/data_source_genesyscloud_quality_forms_evaluation.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceQualityFormsEvaluations() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/data_source_genesyscloud_quality_forms_survey.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceQualityFormsSurvey() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_recording_media_retention_policy.go
+++ b/genesyscloud/data_source_genesyscloud_recording_media_retention_policy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRecordingMediaRetentionPolicy() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_responsemanagement_library.go
+++ b/genesyscloud/data_source_genesyscloud_responsemanagement_library.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceResponsemanagementLibrary() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_responsemanagement_response.go
+++ b/genesyscloud/data_source_genesyscloud_responsemanagement_response.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceResponsemanagementResponse() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/data_source_genesyscloud_responsemanagement_responseasset.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceResponseManagamentResponseAsset() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_routing_email_domain.go
+++ b/genesyscloud/data_source_genesyscloud_routing_email_domain.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 // Returns the schema for the routing email domain

--- a/genesyscloud/data_source_genesyscloud_routing_email_domain_test.go
+++ b/genesyscloud/data_source_genesyscloud_routing_email_domain_test.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func cleanupRoutingEmailDomains() {

--- a/genesyscloud/data_source_genesyscloud_routing_language.go
+++ b/genesyscloud/data_source_genesyscloud_routing_language.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRoutingLanguage() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_routing_queue.go
+++ b/genesyscloud/data_source_genesyscloud_routing_queue.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRoutingQueue() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_routing_settings.go
+++ b/genesyscloud/data_source_genesyscloud_routing_settings.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRoutingSettings() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_routing_skill.go
+++ b/genesyscloud/data_source_genesyscloud_routing_skill.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRoutingSkill() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_routing_skill_group.go
+++ b/genesyscloud/data_source_genesyscloud_routing_skill_group.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRoutingSkillGroup() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_routing_sms_addresses.go
+++ b/genesyscloud/data_source_genesyscloud_routing_sms_addresses.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRoutingSmsAddress() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_routing_wrapupcode.go
+++ b/genesyscloud/data_source_genesyscloud_routing_wrapupcode.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceRoutingWrapupcode() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_script.go
+++ b/genesyscloud/data_source_genesyscloud_script.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceScript() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_station.go
+++ b/genesyscloud/data_source_genesyscloud_station.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceStation() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_did.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_did.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceDid() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_did_pool.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceDidPool() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_did_pool.go
@@ -17,7 +17,7 @@ func dataSourceDidPool() *schema.Resource {
 		ReadContext: ReadWithPooledClient(dataSourceDidPoolRead),
 		Schema: map[string]*schema.Schema{
 			"start_phone_number": {
-				Description:      "Starting phone number of the DID Pool range.",
+				Description:      "Starting phone number of the DID Pool range. Must be in an E.164 number format.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validatePhoneNumber,

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_edge_group.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_edge_group.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceEdgeGroup() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_extension_pool.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_extension_pool.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceExtensionPool() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_linebasesettings.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_linebasesettings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceLineBaseSettings() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_phone.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourcePhone() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_phonebasesettings.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_phonebasesettings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourcePhoneBaseSettings() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_site.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceSite() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_telephony_providers_edges_trunk.go
+++ b/genesyscloud/data_source_genesyscloud_telephony_providers_edges_trunk.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceTrunk() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_user.go
+++ b/genesyscloud/data_source_genesyscloud_user.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceUser() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/data_source_genesyscloud_webdeployments_configuration.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceWebDeploymentsConfiguration() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_webdeployments_deployment.go
+++ b/genesyscloud/data_source_genesyscloud_webdeployments_deployment.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceWebDeploymentsDeployment() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_widget_deployment.go
+++ b/genesyscloud/data_source_genesyscloud_widget_deployment.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func dataSourceWidgetDeployments() *schema.Resource {

--- a/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type ProcessAutomationTriggers struct {

--- a/genesyscloud/process_automation_trigger/process_automation_triggers_proxy.go
+++ b/genesyscloud/process_automation_trigger/process_automation_triggers_proxy.go
@@ -9,7 +9,7 @@ import (
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func postProcessAutomationTrigger(pat *ProcessAutomationTrigger, api *platformclientv2.IntegrationsApi) (*ProcessAutomationTrigger, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
+++ b/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
@@ -3,7 +3,7 @@ package process_automation_trigger
 import (
 	"encoding/json"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type ProcessAutomationTrigger struct {

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceProcessAutomationTrigger(t *testing.T) {

--- a/genesyscloud/provider.go
+++ b/genesyscloud/provider.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var providerResources map[string]*schema.Resource

--- a/genesyscloud/provider_test.go
+++ b/genesyscloud/provider_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/proxies/architect_api/architect_ivr.go
+++ b/genesyscloud/proxies/architect_api/architect_ivr.go
@@ -6,7 +6,7 @@ import (
 	utillists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type postArchitectIvrFunc func(*ArchitectIvrProxy, platformclientv2.Ivr) (*platformclientv2.Ivr, *platformclientv2.APIResponse, error)

--- a/genesyscloud/proxies/architect_api/architect_ivr_test.go
+++ b/genesyscloud/proxies/architect_api/architect_ivr_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestUploadIvrDnisChunksSuccess(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_architect_datatable.go
+++ b/genesyscloud/resource_genesyscloud_architect_datatable.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_architect_datatable_row.go
+++ b/genesyscloud/resource_genesyscloud_architect_datatable_row.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 // Row IDs structured as {table-id}/{key-value}

--- a/genesyscloud/resource_genesyscloud_architect_datatable_row_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_datatable_row_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceArchitectDatatableRow(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_architect_datatable_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_datatable_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceArchitectDatatable(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_architect_emergencygroup.go
+++ b/genesyscloud/resource_genesyscloud_architect_emergencygroup.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllEmergencyGroups(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_architect_emergencygroup_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_emergencygroup_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceArchitectEmergencyGroups(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/resource_genesyscloud_architect_ivr.go
@@ -86,7 +86,7 @@ func resourceArchitectIvrConfig() *schema.Resource {
 				Optional:    true,
 			},
 			"dnis": {
-				Description: fmt.Sprintf("The phone number(s) to contact the IVR by. (Note: An array with a length greater than %v will be broken into chunks and uploaded in subsequent PUT requests.)", maxDnisPerRequest),
+				Description: fmt.Sprintf("The phone number(s) to contact the IVR by. Each phone number in the array must be in an E.164 number format. (Note: An array with a length greater than %v will be broken into chunks and uploaded in subsequent PUT requests.)", maxDnisPerRequest),
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,

--- a/genesyscloud/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/resource_genesyscloud_architect_ivr.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 const maxDnisPerRequest = 50

--- a/genesyscloud/resource_genesyscloud_architect_ivr_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_ivr_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type ivrConfigStruct struct {

--- a/genesyscloud/resource_genesyscloud_architect_schedulegroups.go
+++ b/genesyscloud/resource_genesyscloud_architect_schedulegroups.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllArchitectScheduleGroups(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_architect_schedulegroups_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_schedulegroups_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceArchitectScheduleGroups(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_architect_schedules.go
+++ b/genesyscloud/resource_genesyscloud_architect_schedules.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/leekchan/timeutil"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllArchitectSchedules(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_architect_schedules_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_schedules_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceArchitectSchedules(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/resource_genesyscloud_architect_user_prompt.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type PromptAudioData struct {

--- a/genesyscloud/resource_genesyscloud_architect_user_prompt_test.go
+++ b/genesyscloud/resource_genesyscloud_architect_user_prompt_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceUserPromptBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_auth_division.go
+++ b/genesyscloud/resource_genesyscloud_auth_division.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllAuthDivisions(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_auth_division_test.go
+++ b/genesyscloud/resource_genesyscloud_auth_division_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceAuthDivisionBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_auth_role.go
+++ b/genesyscloud/resource_genesyscloud_auth_role.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_auth_role_test.go
+++ b/genesyscloud/resource_genesyscloud_auth_role_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceAuthRoleDefault(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_employeeperformance_externalmetrics_definition.go
+++ b/genesyscloud/resource_genesyscloud_employeeperformance_externalmetrics_definition.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceEmployeeperformanceExternalmetricsDefinition() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_employeeperformance_externalmetrics_definition_test.go
+++ b/genesyscloud/resource_genesyscloud_employeeperformance_externalmetrics_definition_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceEmployeePerformanceExternalMetricsDefintions(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_externalcontacts_contact.go
+++ b/genesyscloud/resource_genesyscloud_externalcontacts_contact.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_externalcontacts_contact_test.go
+++ b/genesyscloud/resource_genesyscloud_externalcontacts_contact_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceExternalContacts(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_flow.go
+++ b/genesyscloud/resource_genesyscloud_flow.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllFlows(ctx context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_flow_milestone.go
+++ b/genesyscloud/resource_genesyscloud_flow_milestone.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllFlowMilestones(ctx context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_flow_milestone_test.go
+++ b/genesyscloud/resource_genesyscloud_flow_milestone_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceFlowMilestone(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_flow_outcome.go
+++ b/genesyscloud/resource_genesyscloud_flow_outcome.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllFlowOutcomes(ctx context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_flow_test.go
+++ b/genesyscloud/resource_genesyscloud_flow_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 // lockFlow will search for a specific flow and then lock it.  This is to specifically test the force_unlock flag where I want to create a flow,  simulate some one locking it and then attempt to

--- a/genesyscloud/resource_genesyscloud_group.go
+++ b/genesyscloud/resource_genesyscloud_group.go
@@ -23,7 +23,7 @@ var (
 	groupAddressResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"number": {
-				Description:      "Phone number for this contact type.",
+				Description:      "Phone number for this contact type.  Must be in an E.164 number format.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validatePhoneNumber,

--- a/genesyscloud/resource_genesyscloud_group.go
+++ b/genesyscloud/resource_genesyscloud_group.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/resource_genesyscloud_group_roles.go
+++ b/genesyscloud/resource_genesyscloud_group_roles.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func groupRolesExporter() *ResourceExporter {

--- a/genesyscloud/resource_genesyscloud_group_test.go
+++ b/genesyscloud/resource_genesyscloud_group_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceGroupBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_idp_adfs.go
+++ b/genesyscloud/resource_genesyscloud_idp_adfs.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllIdpAdfs(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_idp_adfs_test.go
+++ b/genesyscloud/resource_genesyscloud_idp_adfs_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIdpAdfs(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_idp_generic.go
+++ b/genesyscloud/resource_genesyscloud_idp_generic.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllIdpGeneric(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_idp_generic_test.go
+++ b/genesyscloud/resource_genesyscloud_idp_generic_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIdpGeneric(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_idp_gsuite.go
+++ b/genesyscloud/resource_genesyscloud_idp_gsuite.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllIdpGsuite(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_idp_gsuite_test.go
+++ b/genesyscloud/resource_genesyscloud_idp_gsuite_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIdpGsuite(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_idp_okta.go
+++ b/genesyscloud/resource_genesyscloud_idp_okta.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllIdpOkta(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_idp_okta_test.go
+++ b/genesyscloud/resource_genesyscloud_idp_okta_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIdpOkta(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_idp_onelogin.go
+++ b/genesyscloud/resource_genesyscloud_idp_onelogin.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllIdpOnelogin(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_idp_onelogin_test.go
+++ b/genesyscloud/resource_genesyscloud_idp_onelogin_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIdpOnelogin(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_idp_ping.go
+++ b/genesyscloud/resource_genesyscloud_idp_ping.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllIdpPing(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_idp_ping_test.go
+++ b/genesyscloud/resource_genesyscloud_idp_ping_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIdpPing(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_idp_salesforce.go
+++ b/genesyscloud/resource_genesyscloud_idp_salesforce.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllIdpSalesforce(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_idp_salesforce_test.go
+++ b/genesyscloud/resource_genesyscloud_idp_salesforce_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIdpSalesforce(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_integration.go
+++ b/genesyscloud/resource_genesyscloud_integration.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/resource_genesyscloud_integration_action.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_integration_action_test.go
+++ b/genesyscloud/resource_genesyscloud_integration_action_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIntegrationAction(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/resource_genesyscloud_integration_credential.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllCredentials(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_integration_credential_test.go
+++ b/genesyscloud/resource_genesyscloud_integration_credential_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceCredential(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_integration_test.go
+++ b/genesyscloud/resource_genesyscloud_integration_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceIntegration(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_journey_action_map.go
+++ b/genesyscloud/resource_genesyscloud_journey_action_map.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_journey_action_map_test.go
+++ b/genesyscloud/resource_genesyscloud_journey_action_map_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 const resourceName = "genesyscloud_journey_action_map"

--- a/genesyscloud/resource_genesyscloud_journey_action_template.go
+++ b/genesyscloud/resource_genesyscloud_journey_action_template.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_journey_action_template_test.go
+++ b/genesyscloud/resource_genesyscloud_journey_action_template_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 const ActionTemplateResourceName = "genesyscloud_journey_action_template"

--- a/genesyscloud/resource_genesyscloud_journey_outcome.go
+++ b/genesyscloud/resource_genesyscloud_journey_outcome.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_journey_outcome_test.go
+++ b/genesyscloud/resource_genesyscloud_journey_outcome_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceJourneyOutcome(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_journey_segment.go
+++ b/genesyscloud/resource_genesyscloud_journey_segment.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_journey_segment_test.go
+++ b/genesyscloud/resource_genesyscloud_journey_segment_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceJourneySegmentCustomer(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_category.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_category.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_knowledge_category_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_category_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceKnowledgeCategoryBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_document.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_document.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_knowledge_document_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_document_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceKnowledgeDocumentBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_document_variation.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_document_variation.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_knowledge_document_variation_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_document_variation_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceKnowledgeDocumentVariationBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllKnowledgeKnowledgebases(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_knowledge_knowledgebase_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_knowledgebase_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceKnowledgeKnowledgebaseBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_label.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_label.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_knowledge_label_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_label_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceKnowledgeLabelBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_v1_category.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_v1_category.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_knowledge_v1_category_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_v1_category_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceKnowledgeV1CategoryBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_v1_document.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_v1_document.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_knowledge_v1_document_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_v1_document_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceKnowledgeV1DocumentBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_location.go
+++ b/genesyscloud/resource_genesyscloud_location.go
@@ -86,7 +86,7 @@ func resourceLocation() *schema.Resource {
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"number": {
-							Description:      "Emergency phone number.",
+							Description:      "Emergency phone number.  Must be in an E.164 number format.",
 							Type:             schema.TypeString,
 							Required:         true,
 							ValidateDiagFunc: validatePhoneNumber,

--- a/genesyscloud/resource_genesyscloud_location.go
+++ b/genesyscloud/resource_genesyscloud_location.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/resource_genesyscloud_location_test.go
+++ b/genesyscloud/resource_genesyscloud_location_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceLocationBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_oauth_client.go
+++ b/genesyscloud/resource_genesyscloud_oauth_client.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_orgauthorization_pairing.go
+++ b/genesyscloud/resource_genesyscloud_orgauthorization_pairing.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceOrgauthorizationPairing() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_outbound_attemptlimit.go
+++ b/genesyscloud/resource_genesyscloud_outbound_attemptlimit.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_attemptlimit_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_attemptlimit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundAttemptLimit(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_callabletimeset.go
+++ b/genesyscloud/resource_genesyscloud_outbound_callabletimeset.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_callabletimeset_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_callabletimeset_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundCallabletimeset(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_callanalysisresponseset.go
+++ b/genesyscloud/resource_genesyscloud_outbound_callanalysisresponseset.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_callanalysisresponseset_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_callanalysisresponseset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceCallAnalysisResponseSet(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/resource_genesyscloud_outbound_campaign.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_campaign_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_campaign_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 // Add a special generator DEVENGAGE-1646.  Basically, the API makes it look like you need a full phone_columns field here.  However, the API ignores the type because the devs reused the phone_columns object.  However,

--- a/genesyscloud/resource_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/resource_genesyscloud_outbound_campaignrule.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_campaignrule_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_campaignrule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundCampaignRuleBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_contactlist.go
+++ b/genesyscloud/resource_genesyscloud_outbound_contactlist.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_contactlist_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_contactlist_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundContactListBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_contactlistfilter.go
+++ b/genesyscloud/resource_genesyscloud_outbound_contactlistfilter.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_contactlistfilter_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_contactlistfilter_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundContactListFilter(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_dnclist.go
+++ b/genesyscloud/resource_genesyscloud_outbound_dnclist.go
@@ -120,7 +120,7 @@ func resourceOutboundDncList() *schema.Resource {
 							ValidateDiagFunc: validateDateTime,
 						},
 						`phone_numbers`: {
-							Description: `Phone numbers to add to a DNC list. Only possible if the dncSourceType is rds.`,
+							Description: `Phone numbers to add to a DNC list. Only possible if the dncSourceType is rds.  Phone numbers must be in an E.164 number format.`,
 							Optional:    true,
 							Type:        schema.TypeList,
 							Elem: &schema.Schema{

--- a/genesyscloud/resource_genesyscloud_outbound_dnclist.go
+++ b/genesyscloud/resource_genesyscloud_outbound_dnclist.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllOutboundDncLists(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_outbound_dnclist_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_dnclist_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundDncListRdsListType(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_messagingcampaign.go
+++ b/genesyscloud/resource_genesyscloud_outbound_messagingcampaign.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_messagingcampaign_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_messagingcampaign_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 /*

--- a/genesyscloud/resource_genesyscloud_outbound_ruleset.go
+++ b/genesyscloud/resource_genesyscloud_outbound_ruleset.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_ruleset_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_ruleset_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundRulesetNoRules(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_sequence.go
+++ b/genesyscloud/resource_genesyscloud_outbound_sequence.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceOutboundSequence() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_outbound_sequence_test.go
+++ b/genesyscloud/resource_genesyscloud_outbound_sequence_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceOutboundSequence(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_outbound_settings.go
+++ b/genesyscloud/resource_genesyscloud_outbound_settings.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_outbound_wrapupcodemappings.go
+++ b/genesyscloud/resource_genesyscloud_outbound_wrapupcodemappings.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getOutboundWrapupCodeMappings(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_quality_forms_evaluation_test.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_evaluation_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceEvaluationFormBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_survey.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_quality_forms_survey_test.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_survey_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type surveyFormStruct struct {

--- a/genesyscloud/resource_genesyscloud_recording_media_retention_policy.go
+++ b/genesyscloud/resource_genesyscloud_recording_media_retention_policy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type EvaluationFormQuestionGroupStruct struct {

--- a/genesyscloud/resource_genesyscloud_recording_media_retention_policy_test.go
+++ b/genesyscloud/resource_genesyscloud_recording_media_retention_policy_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type Mediapolicies struct {

--- a/genesyscloud/resource_genesyscloud_responsemanagement_library.go
+++ b/genesyscloud/resource_genesyscloud_responsemanagement_library.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceResponsemanagementLibrary() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_responsemanagement_library_test.go
+++ b/genesyscloud/resource_genesyscloud_responsemanagement_library_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceResponseManagementLibrary(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_responsemanagement_response.go
+++ b/genesyscloud/resource_genesyscloud_responsemanagement_response.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_responsemanagement_response_test.go
+++ b/genesyscloud/resource_genesyscloud_responsemanagement_response_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceResponseManagementResponse(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/resource_genesyscloud_responsemanagement_responseasset.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceResponseManagamentResponseAsset() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_responsemanagement_responseasset_test.go
+++ b/genesyscloud/resource_genesyscloud_responsemanagement_responseasset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResponseManagementResponseAsset(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_routing_email_domain.go
+++ b/genesyscloud/resource_genesyscloud_routing_email_domain.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllRoutingEmailDomains(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_routing_email_domain_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_email_domain_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceRoutingEmailDomainSub(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_routing_email_route.go
+++ b/genesyscloud/resource_genesyscloud_routing_email_route.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_email_route_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceRoutingEmailRoute(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_routing_language.go
+++ b/genesyscloud/resource_genesyscloud_routing_language.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllRoutingLanguages(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_routing_language_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_language_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceRoutingLanguageBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/resource_genesyscloud_routing_queue.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_routing_queue_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_queue_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceRoutingQueueBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/resource_genesyscloud_routing_settings.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceRoutingSettings() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_routing_skill.go
+++ b/genesyscloud/resource_genesyscloud_routing_skill.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllRoutingSkills(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_routing_skill_group.go
+++ b/genesyscloud/resource_genesyscloud_routing_skill_group.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type SkillGroupsRequest struct {

--- a/genesyscloud/resource_genesyscloud_routing_skill_group_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_skill_group_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func testAccCheckSkillConditions(resourceName string, targetSkillConditionJson string) resource.TestCheckFunc {

--- a/genesyscloud/resource_genesyscloud_routing_skill_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_skill_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceRoutingSkillBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_routing_sms_addresses.go
+++ b/genesyscloud/resource_genesyscloud_routing_sms_addresses.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceRoutingSmsAddress() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_routing_sms_addresses_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_sms_addresses_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceRoutingSmsAddressesProdOrg(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/resource_genesyscloud_routing_utilization.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_routing_wrapupcode.go
+++ b/genesyscloud/resource_genesyscloud_routing_wrapupcode.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllRoutingWrapupCodes(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_routing_wrapupcode_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_wrapupcode_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceRoutingWrapupcode(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -62,14 +62,14 @@ func resourceTelephonyDidPool() *schema.Resource {
 		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			"start_phone_number": {
-				Description:      "Starting phone number of the DID Pool range. Changing the start_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.",
+				Description:      "Starting phone number of the DID Pool range. Phone number must be in a E.164 number format. Changing the start_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
 				ValidateDiagFunc: validatePhoneNumber,
 			},
 			"end_phone_number": {
-				Description:      "Ending phone number of the DID Pool range. Changing the end_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.",
+				Description:      "Ending phone number of the DID Pool range.  Phone number must be in an E.164 number format. Changing the end_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllDidPools(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_did_pool_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_did_pool_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type didPoolStruct struct {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_edge_group.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_edge_group.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceEdgeGroup() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_edge_group_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_edge_group_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceEdgeGroup(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_extension_pool.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_extension_pool.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllExtensionPools(_ context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_extension_pool_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_extension_pool_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type extensionPoolStruct struct {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -125,7 +125,7 @@ func resourcePhone() *schema.Resource {
 				Optional:    true,
 			},
 			"line_addresses": {
-				Description: "Ordered list of Line DIDs for standalone phones.",
+				Description: "Ordered list of Line DIDs for standalone phones.  Each phone number must be in an E.164 phone number format.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_phone_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type phoneConfig struct {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourcePhoneBaseSettings() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_phonebasesettings_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_phonebasesettings_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourcePhoneBaseSettings(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/leekchan/timeutil"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceSite() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_site_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceSite(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_trunk.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_trunk.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceTrunk() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func resourceTrunkBaseSettings() *schema.Resource {

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceTrunkBaseSettings(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -24,7 +24,7 @@ var (
 	phoneNumberResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"number": {
-				Description:      "Phone number. Defaults to US country code.",
+				Description:      "Phone number. Phone number must be in an E.164 number format.",
 				Type:             schema.TypeString,
 				Optional:         true,
 				ValidateDiagFunc: validatePhoneNumber,

--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/resource_genesyscloud_user_roles.go
+++ b/genesyscloud/resource_genesyscloud_user_roles.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func userRolesExporter() *ResourceExporter {

--- a/genesyscloud/resource_genesyscloud_user_test.go
+++ b/genesyscloud/resource_genesyscloud_user_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceUserBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/resource_genesyscloud_webdeployments_configuration.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/resource_genesyscloud_webdeployments_configuration_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceWebDeploymentsConfiguration(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_webdeployments_deployment.go
+++ b/genesyscloud/resource_genesyscloud_webdeployments_deployment.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func getAllWebDeployments(ctx context.Context, clientConfig *platformclientv2.Configuration) (ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_webdeployments_deployment_test.go
+++ b/genesyscloud/resource_genesyscloud_webdeployments_deployment_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func TestAccResourceWebDeploymentsDeployment(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_widget_deployment.go
+++ b/genesyscloud/resource_genesyscloud_widget_deployment.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 const (

--- a/genesyscloud/resource_genesyscloud_widget_deployment_test.go
+++ b/genesyscloud/resource_genesyscloud_widget_deployment_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type widgetDeploymentConfig struct {

--- a/genesyscloud/sdk_client_pool.go
+++ b/genesyscloud/sdk_client_pool.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 // SDKClientPool holds a pool of client configs for the Genesys Cloud SDK. One should be

--- a/genesyscloud/user_group_role_common.go
+++ b/genesyscloud/user_group_role_common.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 var (

--- a/genesyscloud/util_basesetting_properties.go
+++ b/genesyscloud/util_basesetting_properties.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func buildBaseSettingsProperties(d *schema.ResourceData) *map[string]interface{} {

--- a/genesyscloud/util_divisions.go
+++ b/genesyscloud/util_divisions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 type JsonMap map[string]interface{}

--- a/genesyscloud/util_domainentities.go
+++ b/genesyscloud/util_domainentities.go
@@ -2,7 +2,7 @@ package genesyscloud
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func buildSdkDomainEntityRef(d *schema.ResourceData, idAttr string) *platformclientv2.Domainentityref {

--- a/genesyscloud/util_retries.go
+++ b/genesyscloud/util_retries.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v103/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
 )
 
 func WithRetries(ctx context.Context, timeout time.Duration, method func() *resource.RetryError) diag.Diagnostics {

--- a/genesyscloud/validators.go
+++ b/genesyscloud/validators.go
@@ -24,7 +24,7 @@ func validatePhoneNumber(number interface{}, _ cty.Path) diag.Diagnostics {
 
 		formattedNum := phonenumbers.Format(phoneNumber, phonenumbers.E164)
 		if formattedNum != numberStr {
-			return diag.Errorf("Failed to parse number in an E164 format.  Passed %s and expected: %s", numberStr, formattedNum)
+			return diag.Errorf("Failed to parse number in an E.164 format.  Passed %s and expected: %s", numberStr, formattedNum)
 		}
 		return nil
 	}

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/hashicorp/terraform-plugin-docs v0.16.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.27.0
 	github.com/leekchan/timeutil v0.0.0-20150802142658-28917288c48d
-	github.com/mypurecloud/platform-client-sdk-go/v103 v103.0.0
+	github.com/mypurecloud/platform-client-sdk-go/v105 v105.0.0
 	github.com/nyaruka/phonenumbers v1.1.7
 	github.com/zclconf/go-cty v1.13.2
 	gonum.org/v1/gonum v0.13.0

--- a/go.sum
+++ b/go.sum
@@ -263,6 +263,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mypurecloud/platform-client-sdk-go/v103 v103.0.0 h1:eEpS1MlxNCGuJft6ARXJl84w5DjezpGiDpumD0HP0iQ=
 github.com/mypurecloud/platform-client-sdk-go/v103 v103.0.0/go.mod h1:B1ADSgicRofiXIxo9U8FvpwBLH9ggWF2jw+3Bpa7ftU=
+github.com/mypurecloud/platform-client-sdk-go/v105 v105.0.0 h1:uRyobq6Sm9VvBxXOh1J6hQqY5mXdzGKvgMf08M4lcnQ=
+github.com/mypurecloud/platform-client-sdk-go/v105 v105.0.0/go.mod h1:8AM1Gtr5W0I4w60iBpJomjicsydCcgydPR0uPqXPR6E=
 github.com/nishanths/predeclared v0.0.0-20200524104333-86fad755b4d3/go.mod h1:nt3d53pc1VYcphSCIaYAJtnPYnr3Zyn8fMq2wvPGPso=
 github.com/nyaruka/phonenumbers v1.1.7 h1:5UUI9hE79Kk0dymSquXbMYB7IlNDNhvu2aNlJpm9et8=
 github.com/nyaruka/phonenumbers v1.1.7/go.mod h1:DC7jZd321FqUe+qWSNcHi10tyIyGNXGcNbfkPvdp1Vs=

--- a/test/data/resource/genesyscloud_script/test_script.json
+++ b/test/data/resource/genesyscloud_script/test_script.json
@@ -209,7 +209,8 @@
                                 "value": {}
                             },
                             "value": {
-                                "typeName": "variable"
+                                "typeName": "variable",
+                                "value": "MyCheckBox"
                             },
                             "changeAction": {
                                 "typeName": "action",


### PR DESCRIPTION
Hi @charliecon @dginty4 @HemanthDogiparthi12 

This work makes sure that we publish a script after we create it.  Previously the scripts team did not make their publish endpoint available.  The endpoint is available and I implemented the publication work.  I also added code to filter out any scripts from the getAll call that were not published.

Thanks,
    John