### PR TITLE
Maes 719 add data format to process automation trigger target

### DIFF
--- a/docs/resources/processautomation_trigger.md
+++ b/docs/resources/processautomation_trigger.md
@@ -27,6 +27,9 @@ resource "genesyscloud_processautomation_trigger" "example-trigger" {
   target {
     id   = data.genesyscloud_flow.workflow-trigger.id
     type = "Workflow"
+    workflow_target_settings {
+      data_format = "TopLevelPrimitives"
+    }
   }
   match_criteria = jsonencode([
     {
@@ -68,4 +71,15 @@ Required:
 
 - `id` (String) Id of the target the trigger is configured to hit
 - `type` (String) Type of the target the trigger is configured to hit
+
+Optional:
+
+- `workflow_target_settings` (Block Set, Max: 1) Special settings related to workflow target invocation (see [below for nested schema](#nestedblock--target--workflow_target_settings))
+
+<a id="nestedblock--target--workflow_target_settings"></a>
+### Nested Schema for `target.workflow_target_settings`
+
+Optional:
+
+- `data_format` (String) What format the data should be sent to the workflow in.
 

--- a/docs/resources/processautomation_trigger.md
+++ b/docs/resources/processautomation_trigger.md
@@ -74,12 +74,12 @@ Required:
 
 Optional:
 
-- `workflow_target_settings` (Block Set, Max: 1) Special settings related to workflow target invocation (see [below for nested schema](#nestedblock--target--workflow_target_settings))
+- `workflow_target_settings` (Block Set, Max: 1) Optional config for the target. Until the feature gets enabled will always operate in TopLevelPrimitives mode. (see [below for nested schema](#nestedblock--target--workflow_target_settings))
 
 <a id="nestedblock--target--workflow_target_settings"></a>
 ### Nested Schema for `target.workflow_target_settings`
 
 Optional:
 
-- `data_format` (String) What format the data should be sent to the workflow in.
+- `data_format` (String) The data format to use when invoking target.
 

--- a/examples/resources/genesyscloud_processautomation_trigger/resource.tf
+++ b/examples/resources/genesyscloud_processautomation_trigger/resource.tf
@@ -5,6 +5,9 @@ resource "genesyscloud_processautomation_trigger" "example-trigger" {
   target {
     id   = data.genesyscloud_flow.workflow-trigger.id
     type = "Workflow"
+    workflow_target_settings {
+      data_format = "TopLevelPrimitives"
+    }
   }
   match_criteria = jsonencode([
     {

--- a/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
+++ b/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
@@ -1,5 +1,5 @@
 workflow:
- name: terraform-provider-test-b4456ba8-af85-4b47-bd17-76b8fbd34c00
+ name: terraform-provider-test-c45c860b-8c81-4b72-82dd-001283a38c8c
  division: Home
  startUpRef: "/workflow/states/state[Initial State_10]"
  defaultLanguage: en-us

--- a/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
+++ b/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
@@ -1,5 +1,5 @@
 workflow:
- name: terraform-provider-test-86d41f9e-61ea-4fa2-8fd3-ece22bbd9eee
+ name: terraform-provider-test-b4456ba8-af85-4b47-bd17-76b8fbd34c00
  division: Home
  startUpRef: "/workflow/states/state[Initial State_10]"
  defaultLanguage: en-us

--- a/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
+++ b/examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml
@@ -1,6 +1,6 @@
 workflow:
- name: terraform-provider-test-d7b806a5-87e4-4662-b631-73997cd54be0
- division: New Home
+ name: terraform-provider-test-86d41f9e-61ea-4fa2-8fd3-ece22bbd9eee
+ division: Home
  startUpRef: "/workflow/states/state[Initial State_10]"
  defaultLanguage: en-us
  variables:

--- a/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger_test.go
@@ -15,12 +15,13 @@ func TestAccDataSourceProcessAutomationTrigger(t *testing.T) {
 		triggerResource1 = "test-trigger1"
 		triggerResource2 = "test-trigger2"
 
-		triggerName1     = "Terraform trigger1-" + uuid.NewString()
-		topicName1       = "v2.detail.events.conversation.{id}.customer.end"
-		enabled1         = "true"
-		targetType1      = "Workflow"
-		eventTtlSeconds1 = "60"
-		description1     = "description 1"
+		triggerName1              = "Terraform trigger1-" + uuid.NewString()
+		topicName1                = "v2.detail.events.conversation.{id}.customer.end"
+		enabled1                  = "true"
+		targetType1               = "Workflow"
+		eventTtlSeconds1          = "60"
+		description1              = "description 1"
+		workflowTargetDataFormat1 = "Json"
 
 		flowResource1 = "test_flow1"
 		filePath1     = "../../examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml"
@@ -110,8 +111,11 @@ func TestAccDataSourceProcessAutomationTrigger(t *testing.T) {
 					fmt.Sprintf(`target {
                         id = %s
                         type = "%s"
+						workflow_target_settings {
+							data_format = "%s"
+						}
                     }
-                    `, "genesyscloud_flow."+flowResource1+".id", targetType1),
+                    `, "genesyscloud_flow."+flowResource1+".id", targetType1, workflowTargetDataFormat1),
 					matchCriteria,
 					eventTtlSeconds1,
 					description1,

--- a/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
+++ b/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
@@ -19,9 +19,14 @@ type ProcessAutomationTrigger struct {
 	Description     *string `json:"description,omitempty"`
 }
 
+type WorkflowTargetSettings struct {
+	DataFormat *string `json:"dataFormat,omitempty"`
+}
+
 type Target struct {
-	Type *string `json:"type,omitempty"`
-	Id   *string `json:"id,omitempty"`
+	Type                   *string                 `json:"type,omitempty"`
+	Id                     *string                 `json:"id,omitempty"`
+	WorkflowTargetSettings *WorkflowTargetSettings `json:"workflowTargetSettings,omitempty"`
 }
 
 func (p *ProcessAutomationTrigger) toJSONString() (string, error) {

--- a/genesyscloud/process_automation_trigger/process_automations_triggers_struct_test.go
+++ b/genesyscloud/process_automation_trigger/process_automations_triggers_struct_test.go
@@ -18,13 +18,14 @@ func TestProcessAutomationJSONParsing(t *testing.T) {
 		] 
   `
 	///This was the expected target JSON
-	targetJson := "{\"delayBySeconds\":1000,\"description\":\"My Sample Topic\",\"enabled\":false,\"eventTTLSeconds\":1000,\"id\":\"888923de-8d4c-1000-2001-48f526dc3333\",\"matchCriteria\":[{\"jsonPath\":\"mediaType\",\"operator\":\"Equal\",\"value\":\"CHAT\"}],\"name\":\"Terraform trigger1-0156463b-4b13-434e-a15c-41492e60ad47\",\"target\":{\"id\":\"173223de-8d4c-0000-0001-48f526dc3333\",\"type\":\"Workflow\"},\"topicName\":\"v2.detail.events.conversation.{id}.customer.end\",\"version\":1}"
+	targetJson := "{\"delayBySeconds\":1000,\"description\":\"My Sample Topic\",\"enabled\":false,\"eventTTLSeconds\":1000,\"id\":\"888923de-8d4c-1000-2001-48f526dc3333\",\"matchCriteria\":[{\"jsonPath\":\"mediaType\",\"operator\":\"Equal\",\"value\":\"CHAT\"}],\"name\":\"Terraform trigger1-0156463b-4b13-434e-a15c-41492e60ad47\",\"target\":{\"id\":\"173223de-8d4c-0000-0001-48f526dc3333\",\"type\":\"Workflow\",\"workflowTargetSettings:{\"dataFormat\":\"Json\"}},\"topicName\":\"v2.detail.events.conversation.{id}.customer.end\",\"version\":1}"
 
 	id := "888923de-8d4c-1000-2001-48f526dc3333"
 	topicName := "v2.detail.events.conversation.{id}.customer.end"
 	name := "Terraform trigger1-0156463b-4b13-434e-a15c-41492e60ad47"
 	targetId := "173223de-8d4c-0000-0001-48f526dc3333"
 	targetWorkflow := "Workflow"
+	workflowTargetSettingsDataFormat := "Json"
 	enabled := false
 	eventTTLSeconds := 1000
 	delayBySeconds := 1000
@@ -38,6 +39,9 @@ func TestProcessAutomationJSONParsing(t *testing.T) {
 		Target: &Target{
 			Id:   &targetId,
 			Type: &targetWorkflow,
+			WorkflowTargetSettings: &WorkflowTargetSettings{
+				DataFormat: &workflowTargetSettingsDataFormat,
+			},
 		},
 		MatchCriteria:   &matchCriteriaStr,
 		Enabled:         &enabled,

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -354,13 +354,13 @@ func buildTarget(d *schema.ResourceData) *Target {
 				Id:   &id,
 			}
 
-			if workflowTargetSettingsInput, ok := d.Get("workflow_target_settings").([]interface{}); ok && len(workflowTargetSettingsInput) > 0 {
-				workflowTargetSettingsMap, ok := workflowTargetSettingsInput[0].(map[string]interface{})
-				if ok {
-					dataFormat := workflowTargetSettingsMap["data_format"].(string)
-					target.WorkflowTargetSettings = &WorkflowTargetSettings{
-						DataFormat: &dataFormat,
-					}
+			workflowTargetSettingsInput := targetMap["workflow_target_settings"].(*schema.Set).List()
+			workflowTargetSettingsInputMap := workflowTargetSettingsInput[0].(map[string]interface{})
+
+			if len(workflowTargetSettingsInput) > 0 {
+				dataFormat := workflowTargetSettingsInputMap["data_format"].(string)
+				target.WorkflowTargetSettings = &WorkflowTargetSettings{
+					DataFormat: &dataFormat,
 				}
 			}
 

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -355,9 +355,9 @@ func buildTarget(d *schema.ResourceData) *Target {
 			}
 
 			workflowTargetSettingsInput := targetMap["workflow_target_settings"].(*schema.Set).List()
-			workflowTargetSettingsInputMap := workflowTargetSettingsInput[0].(map[string]interface{})
 
 			if len(workflowTargetSettingsInput) > 0 {
+				workflowTargetSettingsInputMap := workflowTargetSettingsInput[0].(map[string]interface{})
 				dataFormat := workflowTargetSettingsInputMap["data_format"].(string)
 				target.WorkflowTargetSettings = &WorkflowTargetSettings{
 					DataFormat: &dataFormat,

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -24,7 +24,7 @@ import (
 var (
 	workflowTargetSettings = &schema.Resource{
 		Schema: map[string]*schema.Schema{
-			"dataFormat": {
+			"data_format": {
 				Description: "What format the data should be sent to the workflow in.",
 				Type:        schema.TypeString,
 				Required:    false,
@@ -51,7 +51,7 @@ var (
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"workflowTargetSettings": {
+			"workflow_target_settings": {
 				Description: "Special settings related to workflow target invocation",
 				Type:        schema.TypeSet,
 				Required:    false,
@@ -354,10 +354,10 @@ func buildTarget(d *schema.ResourceData) *Target {
 				Id:   &id,
 			}
 
-			if workflowTargetSettingsInput, ok := d.Get("workflowTargetSettings").([]interface{}); ok && len(workflowTargetSettingsInput) > 0 {
+			if workflowTargetSettingsInput, ok := d.Get("workflow_target_settings").([]interface{}); ok && len(workflowTargetSettingsInput) > 0 {
 				workflowTargetSettingsMap, ok := workflowTargetSettingsInput[0].(map[string]interface{})
 				if ok {
-					dataFormat := workflowTargetSettingsMap["dataFormat"].(string)
+					dataFormat := workflowTargetSettingsMap["data_format"].(string)
 					target.WorkflowTargetSettings = &WorkflowTargetSettings{
 						DataFormat: &dataFormat,
 					}
@@ -381,7 +381,10 @@ func flattenTarget(inputTarget *Target) *schema.Set {
 	flattendedTarget := make(map[string]interface{})
 	flattendedTarget["id"] = *inputTarget.Id
 	flattendedTarget["type"] = *inputTarget.Type
-	flattendedTarget["workflowTargetSettings"] = *inputTarget.WorkflowTargetSettings
+
+	if inputTarget.WorkflowTargetSettings != nil {
+		flattendedTarget["workflow_target_settings"] = *inputTarget.WorkflowTargetSettings
+	}
 	targetSet.Add(flattendedTarget)
 
 	return targetSet

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -383,7 +383,12 @@ func flattenTarget(inputTarget *Target) *schema.Set {
 	flattendedTarget["type"] = *inputTarget.Type
 
 	if inputTarget.WorkflowTargetSettings != nil {
-		flattendedTarget["workflow_target_settings"] = *inputTarget.WorkflowTargetSettings
+		worklfowTargetSettingsSet := schema.NewSet(schema.HashResource(target), []interface{}{})
+		flattendedWorkflowTargetSettings := make(map[string]interface{})
+		flattendedWorkflowTargetSettings["data_format"] = *inputTarget.WorkflowTargetSettings.DataFormat
+		worklfowTargetSettingsSet.Add(flattendedWorkflowTargetSettings)
+
+		flattendedTarget["workflow_target_settings"] = worklfowTargetSettingsSet
 	}
 	targetSet.Add(flattendedTarget)
 

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -25,7 +25,7 @@ var (
 	workflowTargetSettings = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"data_format": {
-				Description: "What format the data should be sent to the workflow in.",
+				Description: "The data format to use when invoking target.",
 				Type:        schema.TypeString,
 				Required:    false,
 				Optional:    true,
@@ -52,7 +52,7 @@ var (
 				Required:    true,
 			},
 			"workflow_target_settings": {
-				Description: "Special settings related to workflow target invocation",
+				Description: "Optional config for the target. Until the feature gets enabled will always operate in TopLevelPrimitives mode.",
 				Type:        schema.TypeSet,
 				Required:    false,
 				Optional:    true,
@@ -359,6 +359,9 @@ func buildTarget(d *schema.ResourceData) *Target {
 			if len(workflowTargetSettingsInput) > 0 {
 				workflowTargetSettingsInputMap := workflowTargetSettingsInput[0].(map[string]interface{})
 				dataFormat := workflowTargetSettingsInputMap["data_format"].(string)
+				if dataFormat == "" {
+					return target
+				}
 				target.WorkflowTargetSettings = &WorkflowTargetSettings{
 					DataFormat: &dataFormat,
 				}

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
@@ -138,7 +138,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description1),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
-					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat1),
+					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "target.0.workflow_target_settings.0.data_format", workflowTargetSettingsDataFormat1),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria1),
 				),
 			},
@@ -174,7 +174,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description2),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
-					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat1),
+					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "target.0.workflow_target_settings.0.data_format", workflowTargetSettingsDataFormat1),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria2),
 				),
 			},
@@ -224,7 +224,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description1),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
-					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat2),
+					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "target.0.workflow_target_settings.0.data_format", workflowTargetSettingsDataFormat2),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria1),
 				),
 			},
@@ -260,7 +260,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description2),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
-					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat2),
+					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "target.0.workflow_target_settings.0.data_format", workflowTargetSettingsDataFormat2),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria2),
 				),
 			},
@@ -364,21 +364,6 @@ func validateTargetType(triggerResourceName string, typeVal string) resource.Tes
 
 		if typeVal != triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".type"] {
 			return fmt.Errorf("Type in trigger target was not created correctly. Expect: %s, Actual: %s", typeVal, triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".type"])
-		}
-
-		return nil
-	}
-}
-
-func validateTargetDataFormat(triggerResourceName string, dataFormatVal string) resource.TestCheckFunc {
-	return func(state *terraform.State) error {
-		triggerResource, ok := state.RootModule().Resources[triggerResourceName]
-		if !ok {
-			return fmt.Errorf("Failed to find trigger %s in state", triggerResourceName)
-		}
-
-		if dataFormatVal != triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".workflow_target_settings."+strconv.Itoa(0)+".data_format"] {
-			return fmt.Errorf("Type in trigger workflow target settings data format was not created correctly. Expect: %s, Actual: %s", dataFormatVal, triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".workflow_target_settings.data_format"])
 		}
 
 		return nil

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
@@ -20,19 +20,21 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 	var (
 		triggerResource1 = "test-trigger1"
 
-		triggerName1     = "Terraform trigger1-" + uuid.NewString()
-		topicName1       = "v2.detail.events.conversation.{id}.customer.end"
-		enabled1         = "true"
-		targetType1      = "Workflow"
-		eventTtlSeconds1 = "60"
-		delayBySeconds1  = "60"
-		description1     = "description1"
+		triggerName1                      = "Terraform trigger1-" + uuid.NewString()
+		topicName1                        = "v2.detail.events.conversation.{id}.customer.end"
+		enabled1                          = "true"
+		targetType1                       = "Workflow"
+		workflowTargetSettingsDataFormat1 = "Json"
+		eventTtlSeconds1                  = "60"
+		delayBySeconds1                   = "60"
+		description1                      = "description1"
 
-		triggerName2     = "Terraform trigger2-" + uuid.NewString()
-		enabled2         = "false"
-		eventTtlSeconds2 = "120"
-		delayBySeconds2  = "90"
-		description2     = "description2"
+		triggerName2                      = "Terraform trigger2-" + uuid.NewString()
+		enabled2                          = "false"
+		eventTtlSeconds2                  = "120"
+		delayBySeconds2                   = "90"
+		description2                      = "description2"
+		workflowTargetSettingsDataFormat2 = "TopLevelPrimitives"
 
 		flowResource1 = "test_flow1"
 		filePath1     = "../../examples/resources/genesyscloud_processautomation_trigger/trigger_workflow_example.yaml"
@@ -119,8 +121,11 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					fmt.Sprintf(`target {
                         id = %s
                         type = "%s"
+						workflow_target_settings {
+							data_format = "%s"
+						}
                     }
-                    `, "genesyscloud_flow."+flowResource1+".id", targetType1),
+                    `, "genesyscloud_flow."+flowResource1+".id", targetType1, workflowTargetSettingsDataFormat1),
 					matchCriteria1,
 					eventTtlSeconds1,
 					description1,
@@ -133,6 +138,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description1),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
+					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat1),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria1),
 				),
 			},
@@ -151,8 +157,11 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					fmt.Sprintf(`target {
 			            id = %s
 			            type = "%s"
+						workflow_target_settings {
+							data_format = "%s"
+						}
 			        }
-			        `, "genesyscloud_flow."+flowResource1+".id", targetType1),
+			        `, "genesyscloud_flow."+flowResource1+".id", targetType1, workflowTargetSettingsDataFormat1),
 					matchCriteria2,
 					eventTtlSeconds2,
 					description2,
@@ -165,6 +174,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description2),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
+					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat1),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria2),
 				),
 			},
@@ -197,8 +207,11 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					fmt.Sprintf(`target {
 	                    id = %s
 	                    type = "%s"
+						workflow_target_settings {
+							data_format = "%s"
+						}
 	                }
-	                `, "genesyscloud_flow."+flowResource1+".id", targetType1),
+	                `, "genesyscloud_flow."+flowResource1+".id", targetType1, workflowTargetSettingsDataFormat2),
 					matchCriteria1,
 					delayBySeconds1,
 					description1,
@@ -211,6 +224,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description1),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
+					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat2),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria1),
 				),
 			},
@@ -229,8 +243,11 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					fmt.Sprintf(`target {
 	                    id = %s
 	                    type = "%s"
+						workflow_target_settings {
+							data_format = "%s"
+						}
 	                }
-	                `, "genesyscloud_flow."+flowResource1+".id", targetType1),
+	                `, "genesyscloud_flow."+flowResource1+".id", targetType1, workflowTargetSettingsDataFormat2),
 					matchCriteria2,
 					delayBySeconds2,
 					description2,
@@ -243,6 +260,7 @@ func TestAccResourceProcessAutomationTrigger(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_processautomation_trigger."+triggerResource1, "description", description2),
 					validateTargetFlowId("genesyscloud_flow."+flowResource1, "genesyscloud_processautomation_trigger."+triggerResource1),
 					validateTargetType("genesyscloud_processautomation_trigger."+triggerResource1, targetType1),
+					validateTargetDataFormat("genesyscloud_processautomation_trigger."+triggerResource1, workflowTargetSettingsDataFormat2),
 					testAccCheckMatchCriteria("genesyscloud_processautomation_trigger."+triggerResource1, matchCriteria2),
 				),
 			},
@@ -346,6 +364,21 @@ func validateTargetType(triggerResourceName string, typeVal string) resource.Tes
 
 		if typeVal != triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".type"] {
 			return fmt.Errorf("Type in trigger target was not created correctly. Expect: %s, Actual: %s", typeVal, triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".type"])
+		}
+
+		return nil
+	}
+}
+
+func validateTargetDataFormat(triggerResourceName string, dataFormatVal string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		triggerResource, ok := state.RootModule().Resources[triggerResourceName]
+		if !ok {
+			return fmt.Errorf("Failed to find trigger %s in state", triggerResourceName)
+		}
+
+		if dataFormatVal != triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".workflow_target_settings."+strconv.Itoa(0)+".data_format"] {
+			return fmt.Errorf("Type in trigger workflow target settings data format was not created correctly. Expect: %s, Actual: %s", dataFormatVal, triggerResource.Primary.Attributes["target."+strconv.Itoa(0)+".workflow_target_settings.data_format"])
 		}
 
 		return nil


### PR DESCRIPTION
I could use some help on this, trying to add the newer functionality for specifying the data format that is sent from triggers to the workflow targets. I think i have most of the ground work laid out, but i still dont seem to be sending the new fields correctly to our rest endpoint. And the provider just hangs when i try to run this, but a trigger is created just without this new configuration. 