### PR TITLE
DEVENGAGE-2080 Document variation hyperlink bug

### DIFF
--- a/genesyscloud/resource_genesyscloud_knowledge_document_variation.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_document_variation.go
@@ -12,11 +12,12 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 
+	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
+	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mypurecloud/platform-client-sdk-go/v105/platformclientv2"
-	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
-	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 )
 
 var (
@@ -624,11 +625,15 @@ func buildDocumentText(textIn map[string]interface{}) *platformclientv2.Document
 			Text: &textString,
 		}
 		if marks, ok := text["marks"].(*schema.Set); ok {
-			markArr := lists.SetToStringList(marks)
-			textOut.Marks = markArr
+			if marks.Len() > 0 {
+				markArr := lists.SetToStringList(marks)
+				textOut.Marks = markArr
+			}
 		}
 		if hyperlink, ok := text["hyperlink"].(string); ok {
-			textOut.Hyperlink = &hyperlink
+			if len(hyperlink) > 0 {
+				textOut.Hyperlink = &hyperlink
+			}
 		}
 		return &textOut
 	}
@@ -655,7 +660,9 @@ func buildDocumentImage(imageIn map[string]interface{}) *platformclientv2.Docume
 			Url: &url,
 		}
 		if hyperlink, ok := image["hyperlink"].(string); ok {
-			imageOut.Hyperlink = &hyperlink
+			if len(hyperlink) > 0 {
+				imageOut.Hyperlink = &hyperlink
+			}
 		}
 		return &imageOut
 	}
@@ -738,11 +745,11 @@ func flattenDocumentText(textIn platformclientv2.Documenttext) []interface{} {
 	if textIn.Text != nil {
 		textOut["text"] = *textIn.Text
 	}
-	if textIn.Marks != nil {
+	if textIn.Marks != nil && len(*textIn.Marks) > 0 {
 		markSet := lists.StringListToSet(*textIn.Marks)
 		textOut["marks"] = markSet
 	}
-	if textIn.Hyperlink != nil {
+	if textIn.Hyperlink != nil && len(*textIn.Hyperlink) > 0 {
 		textOut["hyperlink"] = *textIn.Hyperlink
 	}
 
@@ -836,7 +843,7 @@ func flattenDocumentImage(imageIn platformclientv2.Documentbodyimage) []interfac
 	if imageIn.Url != nil {
 		imageOut["url"] = *imageIn.Url
 	}
-	if imageIn.Hyperlink != nil {
+	if imageIn.Hyperlink != nil && len(*imageIn.Hyperlink) > 0 {
 		imageOut["hyperlink"] = *imageIn.Hyperlink
 	}
 

--- a/genesyscloud/resource_genesyscloud_knowledge_document_variation.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_document_variation.go
@@ -625,10 +625,8 @@ func buildDocumentText(textIn map[string]interface{}) *platformclientv2.Document
 			Text: &textString,
 		}
 		if marks, ok := text["marks"].(*schema.Set); ok {
-			if marks.Len() > 0 {
-				markArr := lists.SetToStringList(marks)
-				textOut.Marks = markArr
-			}
+			markArr := lists.SetToStringList(marks)
+			textOut.Marks = markArr
 		}
 		if hyperlink, ok := text["hyperlink"].(string); ok {
 			if len(hyperlink) > 0 {
@@ -745,7 +743,7 @@ func flattenDocumentText(textIn platformclientv2.Documenttext) []interface{} {
 	if textIn.Text != nil {
 		textOut["text"] = *textIn.Text
 	}
-	if textIn.Marks != nil && len(*textIn.Marks) > 0 {
+	if textIn.Marks != nil {
 		markSet := lists.StringListToSet(*textIn.Marks)
 		textOut["marks"] = markSet
 	}


### PR DESCRIPTION
The `resource_genesyscloud_knowledge_document_variation` resource was failing on import when the `hyperlink` field was an empty string