### PR TITLE
DEVENGAGE-2022 Allow exported resources to be split into multiple files

### DIFF
--- a/genesyscloud/tfexporter/export_common.go
+++ b/genesyscloud/tfexporter/export_common.go
@@ -260,3 +260,7 @@ func isDirEmpty(path string) (bool, diag.Diagnostics) {
 	}
 	return false, diag.FromErr(err)
 }
+
+func createUnresolvedAttrKey(attr unresolvableAttributeInfo) string {
+	return fmt.Sprintf("%s_%s_%s", attr.ResourceType, attr.ResourceName, attr.Name)
+}

--- a/genesyscloud/tfexporter/export_common.go
+++ b/genesyscloud/tfexporter/export_common.go
@@ -16,10 +16,14 @@ import (
 )
 
 const (
-	defaultTfJSONFile  = "genesyscloud.tf.json"
-	defaultTfHCLFile   = "genesyscloud.tf"
-	defaultTfVarsFile  = "terraform.tfvars"
-	defaultTfStateFile = "terraform.tfstate"
+	defaultTfJSONFile          = "genesyscloud.tf.json"
+	defaultTfHCLFile           = "genesyscloud.tf"
+	defaultTfHCLProviderFile   = "provider.tf"
+	defaultTfJSONProviderFile  = "provider.tf.json"
+	defaultTfHCLVariablesFile  = "variables.tf"
+	defaultTfJSONVariablesFile = "variables.tf.json"
+	defaultTfVarsFile          = "terraform.tfvars"
+	defaultTfStateFile         = "terraform.tfstate"
 )
 
 // Common Exporter interface to abstract away whether we are using HCL or JSON as our exporter

--- a/genesyscloud/tfexporter/export_common.go
+++ b/genesyscloud/tfexporter/export_common.go
@@ -105,7 +105,7 @@ func IncludeFilterResourceByRegex(result resourceExporter.ResourceIDMetaMap, nam
 	}
 
 	for _, pattern := range newFilters {
-		for k, _ := range result {
+		for k := range result {
 			match, _ := regexp.MatchString(pattern, result[k].Name)
 
 			if match {
@@ -133,7 +133,7 @@ func ExcludeFilterResourceByRegex(result resourceExporter.ResourceIDMetaMap, nam
 
 	newResourceMap := make(resourceExporter.ResourceIDMetaMap)
 
-	for k, _ := range result {
+	for k := range result {
 		for _, pattern := range newFilters {
 
 			match, _ := regexp.MatchString(pattern, result[k].Name)

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -386,17 +386,6 @@ func (g *GenesysCloudResourceExporter) generateOutputFiles() diag.Diagnostics {
 	return nil
 }
 
-func (g *GenesysCloudResourceExporter) postProcessHclBytes(resource []byte) []byte {
-	resourceStr := string(resource)
-	for placeholderId, val := range attributesDecoded {
-		resourceStr = strings.Replace(resourceStr, fmt.Sprintf("\"%s\"", placeholderId), val, -1)
-	}
-
-	resourceStr = correctInterpolatedFileShaFunctions(resourceStr)
-
-	return []byte(resourceStr)
-}
-
 func (g *GenesysCloudResourceExporter) sourceForVersion(version string) string {
 	providerSource := "registry.terraform.io/mypurecloud/genesyscloud"
 	if g.version == "0.1.0" {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
@@ -1,7 +1,6 @@
 package tfexporter
 
 import (
-	"fmt"
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	"testing"
 )
@@ -14,7 +13,7 @@ type PostProcessHclBytesTestCase struct {
 
 func TestPostProcessHclBytesFunc(t *testing.T) {
 	testCase1 := PostProcessHclBytesTestCase{
-		original: fmt.Sprintf(`
+		original: `
 		resource "example_resource" "example" {
 			file_content_hash = "${filesha256(\"file.json\")}"
 			another_field     = filesha256("file2.json")
@@ -29,8 +28,8 @@ func TestPostProcessHclBytesFunc(t *testing.T) {
 			file_content_hash = filesha256(var.file_path)
 			another_file      = "${filesha256(\"file.json\")}"
 			another_field     = "${var.foo}" 
-		}`),
-		expected: fmt.Sprintf(`
+		}`,
+		expected: `
 		resource "example_resource" "example" {
 			file_content_hash = "${filesha256("file.json")}"
 			another_field     = filesha256("file2.json")
@@ -45,7 +44,7 @@ func TestPostProcessHclBytesFunc(t *testing.T) {
 			file_content_hash = filesha256(var.file_path)
 			another_file      = "${filesha256("file.json")}"
 			another_field     = "${var.foo}" 
-		}`),
+		}`,
 	}
 
 	testCase2 := PostProcessHclBytesTestCase{
@@ -55,20 +54,20 @@ func TestPostProcessHclBytesFunc(t *testing.T) {
 				"hello": "world"
 			})`,
 		},
-		original: fmt.Sprintf(`
+		original: `
 		resource "foo" "bar" {
 			json_data1        = "123"
 			file_content_hash = "${filesha256(\"file.json\")}"
 			json_data2        = "456"
-		}`),
-		expected: fmt.Sprintf(`
+		}`,
+		expected: `
 		resource "foo" "bar" {
 			json_data1        = jsonencode({ "foo": "bar" })
 			file_content_hash = "${filesha256("file.json")}"
 			json_data2        = jsonencode({
 				"hello": "world"
 			})
-		}`),
+		}`,
 	}
 
 	testCases := make([]PostProcessHclBytesTestCase, 0)

--- a/genesyscloud/tfexporter/hcl_exporter.go
+++ b/genesyscloud/tfexporter/hcl_exporter.go
@@ -208,7 +208,7 @@ func instanceStateToHCLBlock(resType, resName string, json gcloud.JsonMap) []byt
 
 	addBody(body, json)
 
-	newCopy := strings.Replace(fmt.Sprintf("%s", f.Bytes()), "$${", "${", -1)
+	newCopy := strings.Replace(string(f.Bytes()), "$${", "${", -1)
 	return []byte(newCopy)
 }
 

--- a/genesyscloud/tfexporter/hcl_exporter.go
+++ b/genesyscloud/tfexporter/hcl_exporter.go
@@ -16,6 +16,8 @@ import (
    This file contains all of the functions used to export HCL functions.
 */
 
+const resourceHCLFileExt = "tf"
+
 type resourceHCLBlock [][]byte
 
 type HCLExporter struct {
@@ -40,11 +42,11 @@ func NewHClExporter(resourceTypesHCLBlocks map[string]resourceHCLBlock, unresolv
 }
 
 func (h *HCLExporter) exportHCLConfig() diag.Diagnostics {
-	if h.splitFilesByResource {
-		// Multiple files export
+	providerBlock := createHCLProviderBlock(h.providerSource, h.version)
+	variablesBlock := createHCLVariablesBlock(h.unresolvedAttrs)
 
+	if h.splitFilesByResource {
 		// Provider file
-		providerBlock := createHCLProviderBlock(h.providerSource, h.version)
 		providerHCLFilePath := filepath.Join(h.dirPath, defaultTfHCLProviderFile)
 		if providerHCLFilePath == "" {
 			return diag.Errorf("Failed to create file path %s", providerHCLFilePath)
@@ -54,7 +56,6 @@ func (h *HCLExporter) exportHCLConfig() diag.Diagnostics {
 		}
 
 		// Variables file
-		variablesBlock := createHCLVariablesBlock(h.unresolvedAttrs)
 		variablesHCLFilePath := filepath.Join(h.dirPath, defaultTfHCLVariablesFile)
 		if variablesHCLFilePath == "" {
 			return diag.Errorf("Failed to create file path %s", variablesHCLFilePath)
@@ -65,7 +66,7 @@ func (h *HCLExporter) exportHCLConfig() diag.Diagnostics {
 
 		// Resource files
 		for resType, resBlock := range h.resourceTypesHCLBlocks {
-			resourceHCLFilePath := filepath.Join(h.dirPath, fmt.Sprintf("%s.%s", resType, "tf"))
+			resourceHCLFilePath := filepath.Join(h.dirPath, fmt.Sprintf("%s.%s", resType, resourceHCLFileExt))
 			if resourceHCLFilePath == "" {
 				return diag.Errorf("Failed to create file path %s", resourceHCLFilePath)
 			}
@@ -75,8 +76,6 @@ func (h *HCLExporter) exportHCLConfig() diag.Diagnostics {
 		}
 	} else {
 		// Single file export
-		providerBlock := createHCLProviderBlock(h.providerSource, h.version)
-		variablesBlock := createHCLVariablesBlock(h.unresolvedAttrs)
 		allBlockSlice := make([][]byte, 0)
 		allBlockSlice = append(allBlockSlice, providerBlock)
 

--- a/genesyscloud/tfexporter/hcl_exporter.go
+++ b/genesyscloud/tfexporter/hcl_exporter.go
@@ -98,6 +98,10 @@ func createHCLProviderBlock(providerSource string, version string) []byte {
 		"source":  zclconfCty.StringVal(providerSource),
 		"version": zclconfCty.StringVal(version),
 	}))
+
+	// side effect assign to terraformHCLBlock. This is for testing.
+	terraformHCLBlock = string(rootFile.Bytes())
+
 	return rootFile.Bytes()
 }
 

--- a/genesyscloud/tfexporter/json_exporter.go
+++ b/genesyscloud/tfexporter/json_exporter.go
@@ -56,7 +56,7 @@ func (j *JsonExporter) exportJSONConfig() diag.Diagnostics {
 		tfVars := make(map[string]interface{})
 		variable := make(map[string]gcloud.JsonMap)
 		for _, attr := range j.unresolvedAttrs {
-			key := fmt.Sprintf("%s_%s_%s", attr.ResourceType, attr.ResourceName, attr.Name)
+			key := createUnresolvedAttrKey(attr)
 			variable[key] = make(gcloud.JsonMap)
 			tfVars[key] = make(gcloud.JsonMap)
 			variable[key]["description"] = attr.Schema.Description

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
@@ -94,7 +94,7 @@ func ResourceTfExport() *schema.Resource {
 				ForceNew:    true,
 			},
 			"split_files_by_resource": {
-				Description: "Split export files by resource type.",
+				Description: "Split export files by resource type. This will also split the terraform provider and variable declarations into their own files.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
@@ -176,16 +176,16 @@ func readTfExport(_ context.Context, d *schema.ResourceData, _ interface{}) diag
 }
 
 // Delete everything (files and subdirectories) inside the export directory
+// not including the directory itself
 func deleteTfExport(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
 	exportPath := d.Id()
-	err := filepath.Walk(exportPath, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		return os.RemoveAll(path)
-	})
+	dir, err := os.ReadDir(exportPath)
 	if err != nil {
 		return diag.FromErr(err)
 	}
+	for _, d := range dir {
+		os.RemoveAll(filepath.Join(exportPath, d.Name()))
+	}
+
 	return nil
 }

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
@@ -3,10 +3,8 @@ package tfexporter
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"log"
 	"os"
-	"path"
+	"path/filepath"
 
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 
@@ -95,6 +93,13 @@ func ResourceTfExport() *schema.Resource {
 				Default:     false,
 				ForceNew:    true,
 			},
+			"split_files_by_resource": {
+				Description: "Split export files by resource type.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				ForceNew:    true,
+			},
 			"log_permission_errors": {
 				Description: "Log permission/product issues rather than fail.",
 				Type:        schema.TypeBool,
@@ -128,7 +133,7 @@ func createTfExport(ctx context.Context, d *schema.ResourceData, meta interface{
 			return diagErr
 		}
 
-		d.SetId(gre.exportFilePath)
+		d.SetId(gre.exportDirPath)
 		return nil
 	}
 
@@ -139,7 +144,7 @@ func createTfExport(ctx context.Context, d *schema.ResourceData, meta interface{
 			return diagErr
 		}
 
-		d.SetId(gre.exportFilePath)
+		d.SetId(gre.exportDirPath)
 		return nil
 	}
 
@@ -150,52 +155,37 @@ func createTfExport(ctx context.Context, d *schema.ResourceData, meta interface{
 		return diagErr
 	}
 
-	d.SetId(gre.exportFilePath)
+	d.SetId(gre.exportDirPath)
 
 	return nil
 }
 
+// If the output directory doesn't exist or empty, mark the resource for creation.
 func readTfExport(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	// If the output config file doesn't exist, mark the resource for creation.
 	path := d.Id()
 	if _, err := os.Stat(path); os.IsNotExist(err) {
 		d.SetId("")
 		return nil
 	}
+	if isEmpty, diagErr := isDirEmpty(path); isEmpty || diagErr != nil {
+		d.SetId("")
+		return diagErr
+	}
+
 	return nil
 }
 
+// Delete everything (files and subdirectories) inside the export directory
 func deleteTfExport(_ context.Context, d *schema.ResourceData, _ interface{}) diag.Diagnostics {
-	configPath := d.Id()
-	if _, err := os.Stat(configPath); err == nil {
-		log.Printf("Deleting export config %s", configPath)
-		os.Remove(configPath)
-	}
-
-	stateFile, _ := getFilePath(d, defaultTfStateFile)
-	if _, err := os.Stat(stateFile); err == nil {
-		log.Printf("Deleting export state %s", stateFile)
-		os.Remove(stateFile)
-	}
-
-	tfVarsFile, _ := getFilePath(d, defaultTfVarsFile)
-	if _, err := os.Stat(tfVarsFile); err == nil {
-		log.Printf("Deleting export vars %s", tfVarsFile)
-		os.Remove(tfVarsFile)
-	}
-
-	// delete left over folders e.g. prompt audio data
-	dir, _ := getFilePath(d, "")
-	contents, err := ioutil.ReadDir(dir)
-	if err == nil {
-		for _, c := range contents {
-			if c.IsDir() {
-				pathToLeftoverDir := path.Join(dir, c.Name())
-				log.Printf("Deleting leftover directory %s", pathToLeftoverDir)
-				_ = os.RemoveAll(pathToLeftoverDir)
-			}
+	exportPath := d.Id()
+	err := filepath.Walk(exportPath, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
 		}
+		return os.RemoveAll(path)
+	})
+	if err != nil {
+		return diag.FromErr(err)
 	}
-
 	return nil
 }

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -14,6 +14,7 @@ import (
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	"testing"
+	"time"
 
 	"terraform-provider-genesyscloud/genesyscloud/util/testrunner"
 
@@ -347,13 +348,14 @@ func TestAccResourceTfExportIncludeFilterResourcesByType(t *testing.T) {
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue"),
 			},
+			falseValue,
+			falseValue,
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[1].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[2].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[3].ResourceName),
 			},
-			falseValue,
 		)
 
 	resource.Test(t, resource.TestCase{
@@ -401,13 +403,14 @@ func TestAccResourceTfExportIncludeFilterResourcesByRegEx(t *testing.T) {
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue::-prod"),
 			},
+			falseValue,
+			falseValue,
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[1].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[2].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[3].ResourceName),
 			},
-			falseValue,
 		)
 
 	resource.Test(t, resource.TestCase{
@@ -464,13 +467,14 @@ func TestAccResourceTfExportIncludeFilterResourcesByRegExExclusiveToResource(t *
 				strconv.Quote("genesyscloud_routing_queue::-prod$"),
 				strconv.Quote("genesyscloud_routing_wrapupcode"),
 			},
+			falseValue,
+			falseValue,
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[1].ResourceName),
 				strconv.Quote("genesyscloud_routing_wrapupcode." + wrapupCodeResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_wrapupcode." + wrapupCodeResources[1].ResourceName),
 			},
-			falseValue,
 		)
 
 	resource.Test(t, resource.TestCase{
@@ -522,6 +526,8 @@ func TestAccResourceTfExportExcludeFilterResourcesByRegEx(t *testing.T) {
 				strconv.Quote("genesyscloud_user_roles"),
 				strconv.Quote("genesyscloud_flow"),
 			},
+			falseValue,
+			falseValue,
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[1].ResourceName),
@@ -529,7 +535,6 @@ func TestAccResourceTfExportExcludeFilterResourcesByRegEx(t *testing.T) {
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[3].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[4].ResourceName),
 			},
-			falseValue,
 		)
 
 	resource.Test(t, resource.TestCase{
@@ -588,6 +593,8 @@ func TestAccResourceTfExportExcludeFilterResourcesByRegExExclusiveToResource(t *
 				strconv.Quote("genesyscloud_user_roles"),
 				strconv.Quote("genesyscloud_flow"),
 			},
+			falseValue,
+			falseValue,
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[1].ResourceName),
@@ -596,7 +603,6 @@ func TestAccResourceTfExportExcludeFilterResourcesByRegExExclusiveToResource(t *
 				strconv.Quote("genesyscloud_routing_wrapupcode." + wrapupCodeResources[1].ResourceName),
 				strconv.Quote("genesyscloud_routing_wrapupcode." + wrapupCodeResources[2].ResourceName),
 			},
-			falseValue,
 		)
 
 	resource.Test(t, resource.TestCase{
@@ -1089,18 +1095,18 @@ func TestAccResourceTfExportSplitFilesAsHCL(t *testing.T) {
 		}
 
 		queueResources = []QueueExport{
-			{ResourceName: "test-queue-1", Name: "test-queue-1-" + uniquePostfix, Description: "This is a test queue", AcwTimeoutMs: 200000},
-			{ResourceName: "test-queue-2", Name: "test-queue-1-" + uniquePostfix, Description: "This is a test queue too", AcwTimeoutMs: 200000},
+			{ResourceName: "test-queue-1", Name: "test-queue-1-" + uuid.NewString() + uniquePostfix, Description: "This is a test queue", AcwTimeoutMs: 200000},
+			{ResourceName: "test-queue-2", Name: "test-queue-1-" + uuid.NewString() + uniquePostfix, Description: "This is a test queue too", AcwTimeoutMs: 200000},
 		}
 
 		userResources = []UserExport{
-			{ResourceName: "test-user-1", Name: "test-user-1", Email: "-test-user-1@test.com-" + uniquePostfix, State: "active"},
-			{ResourceName: "test-user-2", Name: "test-user-2", Email: "-test-user-2@test.com-" + uniquePostfix, State: "active"},
+			{ResourceName: "test-user-1", Name: "test-user-1", Email: "test-user-1" + uuid.NewString() + "@test.com" + uniquePostfix, State: "active"},
+			{ResourceName: "test-user-2", Name: "test-user-2", Email: "test-user-2" + uuid.NewString() + "@test.com" + uniquePostfix, State: "active"},
 		}
 
 		wrapupCodeResources = []WrapupcodeExport{
-			{ResourceName: "test-wrapupcode-1", Name: "-test-wrapupcode-1-" + uniquePostfix},
-			{ResourceName: "test-wrapupcode-2", Name: "-test-wrapupcode-2-" + uniquePostfix},
+			{ResourceName: "test-wrapupcode-1", Name: "test-wrapupcode-1-" + uuid.NewString() + uniquePostfix},
+			{ResourceName: "test-wrapupcode-2", Name: "test-wrapupcode-2-" + uuid.NewString() + uniquePostfix},
 		}
 	)
 	defer os.RemoveAll(exportTestDir)
@@ -1118,6 +1124,8 @@ func TestAccResourceTfExportSplitFilesAsHCL(t *testing.T) {
 				strconv.Quote("genesyscloud_user::" + uniquePostfix + "$"),
 				strconv.Quote("genesyscloud_routing_wrapupcode::" + uniquePostfix + "$"),
 			},
+			trueValue,
+			trueValue,
 			[]string{
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_queue." + queueResources[1].ResourceName),
@@ -1126,7 +1134,6 @@ func TestAccResourceTfExportSplitFilesAsHCL(t *testing.T) {
 				strconv.Quote("genesyscloud_routing_wrapupcode." + wrapupCodeResources[0].ResourceName),
 				strconv.Quote("genesyscloud_routing_wrapupcode." + wrapupCodeResources[1].ResourceName),
 			},
-			trueValue,
 		)
 
 	resource.Test(t, resource.TestCase{
@@ -1140,11 +1147,6 @@ func TestAccResourceTfExportSplitFilesAsHCL(t *testing.T) {
 					validateFileCreated(expectedFilesPath[1]),
 					validateFileCreated(expectedFilesPath[2]),
 					validateFileCreated(expectedFilesPath[3]),
-					// testQueueExportEqual(exportTestDir+"/"+defaultTfJSONFile, "genesyscloud_routing_queue", resourceExporter.SanitizeResourceName(queueResources[0].Name), queueResources[0]),
-					// testWrapupcodeExportEqual(exportTestDir+"/"+defaultTfJSONFile, "genesyscloud_routing_wrapupcode", resourceExporter.SanitizeResourceName(wrapupCodeResources[0].Name), wrapupCodeResources[0]),
-					// testWrapupcodeExportEqual(exportTestDir+"/"+defaultTfJSONFile, "genesyscloud_routing_wrapupcode", resourceExporter.SanitizeResourceName(wrapupCodeResources[1].Name), wrapupCodeResources[1]),
-					// testWrapupcodeExportEqual(exportTestDir+"/"+defaultTfJSONFile, "genesyscloud_routing_wrapupcode", resourceExporter.SanitizeResourceName(wrapupCodeResources[2].Name), wrapupCodeResources[2]),
-					// testQueueExportExcludesRegEx(exportTestDir+"/"+defaultTfJSONFile, "genesyscloud_routing_queue", "-(dev|test)$"),
 				),
 			},
 		},
@@ -1561,17 +1563,19 @@ func generateTfExportByIncludeFilterResources(
 	directory string,
 	includeState string,
 	items []string,
-	dependencies []string,
+	exportAsHCL string,
 	splitByResource string,
+	dependencies []string,
 ) string {
 	return fmt.Sprintf(`resource "genesyscloud_tf_export" "%s" {
 		directory = "%s"
 		include_state_file = %s
 		include_filter_resources = [%s]
-		depends_on = [%s]
+		export_as_hcl = %s
 		split_files_by_resource = %s
+		depends_on = [%s]
 	}
-	`, resourceID, directory, includeState, strings.Join(items, ","), strings.Join(dependencies, ","), splitByResource)
+	`, resourceID, directory, includeState, strings.Join(items, ","), exportAsHCL, splitByResource, strings.Join(dependencies, ","))
 }
 
 func generateTfExportByExcludeFilterResources(
@@ -1579,18 +1583,20 @@ func generateTfExportByExcludeFilterResources(
 	directory string,
 	includeState string,
 	items []string,
-	dependencies []string,
+	exportAsHCL string,
 	splitByResource string,
+	dependencies []string,
 ) string {
 	return fmt.Sprintf(`resource "genesyscloud_tf_export" "%s" {
 		directory = "%s"
 		include_state_file = %s
 		exclude_filter_resources = [%s]
 		log_permission_errors=true
-		depends_on=[%s]
+		export_as_hcl = %s
 		split_files_by_resource = %s
+		depends_on=[%s]
 	}
-	`, resourceID, directory, includeState, strings.Join(items, ","), strings.Join(dependencies, ","), splitByResource)
+	`, resourceID, directory, includeState, strings.Join(items, ","), exportAsHCL, splitByResource, strings.Join(dependencies, ","))
 }
 
 func getExportedFileContents(filename string, result *string) resource.TestCheckFunc {
@@ -1740,11 +1746,13 @@ func buildWrapupcodeResources(wrapupcodeExports []WrapupcodeExport) string {
 
 // Returns random string. Helpful for regex export testing as unique prefix or postfix
 func randString(length int) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+
 	letters := []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 
 	s := make([]rune, length)
 	for i := range s {
-		s[i] = letters[rand.Intn(len(letters))]
+		s[i] = letters[r.Intn(len(letters))]
 	}
 
 	return string(s)

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -1353,7 +1353,7 @@ func testQueueExportMatchesRegEx(filePath, resourceType, regEx string) resource.
 			return err
 		}
 
-		for k, _ := range resources {
+		for k := range resources {
 			regEx := regexp.MustCompile(regEx)
 
 			if !regEx.MatchString(k) {
@@ -1414,7 +1414,7 @@ func testQueueExportExcludesRegEx(filePath, resourceType, regEx string) resource
 			return err
 		}
 
-		for k, _ := range resources {
+		for k := range resources {
 			regEx := regexp.MustCompile(regEx)
 
 			if regEx.MatchString(k) {


### PR DESCRIPTION
Added `split_files_by_resource` property for resource `genesys_cloud_tf_export`.
Default is `false` and does the current behavior of exporting a giant file. 

If set to `true`, files will be split by resource type eg. genesyscloud_routing_queue.tf(HCL export) / genesyscloud_routing_queue.tf.json (JSON export)
Terraform provider will also be in its own file: provider.tf / provider.tf.json
If there are unresolved attribute, variables will also be declared in separate file: variables.tf / variables.tf.json

Test cases added.

Change on state: Instead of checking for the default export file in the resource read, it will check the entire directory for any files. destroy will also mean deleting every file(and subdirs) inside the export directory.