### PR TITLE
DEVENGAGE-2148 Fix export issue with media retention policies with deleteDaysThreshold <= 365

### DIFF
--- a/genesyscloud/resource_genesyscloud_recording_media_retention_policy.go
+++ b/genesyscloud/resource_genesyscloud_recording_media_retention_policy.go
@@ -972,7 +972,7 @@ func getAllMediaRetentionPolicies(_ context.Context, clientConfig *platformclien
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		retentionPolicies, _, getErr := recordingAPI.GetRecordingMediaretentionpolicies(pageSize, pageNum, "", []string{}, "", "", "", true, false, false, 365)
+		retentionPolicies, _, getErr := recordingAPI.GetRecordingMediaretentionpolicies(pageSize, pageNum, "", []string{}, "", "", "", true, false, false, 0)
 
 		if getErr != nil {
 			return nil, diag.Errorf("Failed to get page of media retention policies %v", getErr)


### PR DESCRIPTION
Fix issue by replacing the API call to use deleteDaysThreshold  = 0 instead of 365.