### PR TITLE
adding ServiceLevel queue metric to the CGR config

### DIFF
--- a/genesyscloud/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/resource_genesyscloud_routing_queue.go
@@ -353,7 +353,7 @@ func ResourceRoutingQueue() *schema.Resource {
 							ValidateFunc: validation.StringInSlice([]string{"GreaterThan", "LessThan", "GreaterThanOrEqualTo", "LessThanOrEqualTo"}, false),
 						},
 						"metric": {
-							Description:  "The queue metric being evaluated. Valid values: EstimatedWaitTime.",
+							Description:  "The queue metric being evaluated. Valid values: EstimatedWaitTime, ServiceLevel",
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "EstimatedWaitTime",

--- a/genesyscloud/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/resource_genesyscloud_routing_queue.go
@@ -357,7 +357,7 @@ func ResourceRoutingQueue() *schema.Resource {
 							Type:         schema.TypeString,
 							Optional:     true,
 							Default:      "EstimatedWaitTime",
-							ValidateFunc: validation.StringInSlice([]string{"EstimatedWaitTime"}, false),
+							ValidateFunc: validation.StringInSlice([]string{"EstimatedWaitTime", "ServiceLevel"}, false),
 						},
 						"condition_value": {
 							Description:  "The limit value, beyond which a rule evaluates as true.",


### PR DESCRIPTION
adding ServiceLevel queue metric to the CGR config

  conditional_group_routing_rules {
    operator        = "LessThan"
    wait_seconds    = 10
    condition_value = 80
    groups {
      member_group_id   = "xxxxxxx"
      member_group_type = "SKILLGROUP"
    }
    metric = "ServiceLevel"
  }