### PR TITLE
DEVENGAGE-2166 Ensure all exported resource names only begin with a letter or underscore

### DIFF
--- a/genesyscloud/resource_exporter/resource_exporter_test.go
+++ b/genesyscloud/resource_exporter/resource_exporter_test.go
@@ -1,0 +1,106 @@
+package resource_exporter
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+type TestAssertion struct {
+	input  string
+	output string
+	name   string
+}
+
+func TestSanitizeResourceName(t *testing.T) {
+
+	simpleString := "foobar"
+	intString := "1234"
+	underscore := "_"
+	dash := "-"
+	unsafeUnicode := "Ⱥ®ÊƩ"
+	unsafeAscii := "#%@&"
+
+	randNumSuffix := "_[0-9]+$"
+
+	assertions := [14]TestAssertion{
+		{
+			name:   "First character",
+			input:  string(simpleString[0]),
+			output: string(simpleString[0]),
+		},
+		{
+			name:   "Safe String",
+			input:  simpleString,
+			output: simpleString,
+		},
+		{
+			name:   "Single Integer",
+			input:  string(intString[0]),
+			output: underscore + string(intString[0]),
+		},
+		{
+			name:   "Single Underscore",
+			input:  underscore,
+			output: underscore,
+		},
+		{
+			name:   "Single Dash",
+			input:  dash,
+			output: underscore + dash,
+		},
+		{
+			name:   "Single Unsafe Ascii Character",
+			input:  string(unsafeAscii[0]),
+			output: underscore + randNumSuffix,
+		},
+		{
+			name:   "Single Unsafe Unicode Character",
+			input:  string(unsafeUnicode[0]),
+			output: underscore + randNumSuffix,
+		},
+		{
+			name:   "String beginning with Integer",
+			input:  intString + simpleString,
+			output: underscore + intString + simpleString,
+		},
+		{
+			name:   "String beginning with Underscore",
+			input:  underscore + simpleString,
+			output: underscore + simpleString,
+		},
+		{
+			name:   "String beginning with Dash",
+			input:  dash + simpleString,
+			output: underscore + dash + simpleString,
+		},
+		{
+			name:   "String beginning with multiple dashes",
+			input:  dash + dash + dash + dash + simpleString + dash + dash + dash + dash,
+			output: underscore + dash + dash + dash + dash + simpleString + dash + dash + dash + dash,
+		},
+		{
+			name:   "String beginning with Unsafe Ascii Character",
+			input:  unsafeAscii + simpleString,
+			output: strings.Repeat(underscore, len(unsafeAscii)) + simpleString + randNumSuffix,
+		},
+		{
+			name:   "String beginning with Unicode",
+			input:  unsafeUnicode + simpleString,
+			output: strings.Repeat(underscore, len(unsafeAscii)) + simpleString + randNumSuffix,
+		},
+		{
+			name:   "String with everything",
+			input:  simpleString + unsafeAscii + underscore + intString + dash + unsafeUnicode + simpleString,
+			output: simpleString + strings.Repeat(underscore, len(unsafeAscii)) + underscore + intString + dash + strings.Repeat(underscore, len([]rune(unsafeUnicode))) + simpleString,
+		},
+	}
+
+	for _, assertion := range assertions {
+		output := SanitizeResourceName(assertion.input)
+		assertionOutputRegex := regexp.MustCompile(assertion.output)
+		if !assertionOutputRegex.MatchString(output) {
+			t.Errorf("%s did not sanitize correctly!\nExpected Output: %v\nActual Output: %v", assertion.name, assertion.output, output)
+		}
+	}
+}


### PR DESCRIPTION

Fixes DEVENGAGE-2166
- Ensure all exported resource names only begin with a letter or underscore.
- Replaces unsafe starting characters with a single underscore. 
- Adds tests for SanitizeResourceName function.