### PR TITLE
Removing reference to smsAddress.Name in log statement

### DIFF
--- a/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
+++ b/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
@@ -113,7 +113,7 @@ func readRoutingSmsAddress(ctx context.Context, d *schema.ResourceData, meta int
 		resourcedata.SetNillableValue(d, "postal_code", sdkSmsAddress.PostalCode)
 		resourcedata.SetNillableValue(d, "country_code", sdkSmsAddress.CountryCode)
 
-		log.Printf("Read Routing Sms Address %s %s", d.Id(), *sdkSmsAddress.Name)
+		log.Printf("Read Routing Sms Address %s", d.Id())
 		return cc.CheckState()
 	})
 }


### PR DESCRIPTION
The first time worked on this ticket, I added a check in the getAllSmsAddresses function to see if `Name` was nil before dereferencing the pointer. I forgot to do the same in a log statement in the read function. In the original ticket description, you can see that the stack trace references the getAll function first 

```log
goroutine 302 [running]:
terraform-provider-genesyscloud/genesyscloud.getAllRoutingSmsAddress({0x1e156d9?, 0x28b...
```

When the bug came back around, it referenced the line containing the log statement in the read function:

```log
goroutine 182 [running]:
terraform-provider-genesyscloud/genesyscloud/routing_sms_addresses.readRoutingSmsAddress.func1()
```