### PR TITLE
DEVENGAGE-2191 Fix site outbound routes bug(s)

### DIFF
--- a/docs/resources/telephony_providers_edges_site.md
+++ b/docs/resources/telephony_providers_edges_site.md
@@ -95,7 +95,7 @@ resource "genesyscloud_telephony_providers_edges_site" "site" {
 - `media_regions` (List of String) The ordered list of AWS regions through which media can stream. A full list of available media regions can be found at the GET /api/v2/telephony/mediaregions endpoint
 - `media_regions_use_latency_based` (Boolean) Latency based on media region Defaults to `false`.
 - `number_plans` (Block List) Number plans for the site. The order of the plans in the resource file determines the priority of the plans. Specifying number plans will not result in the default plans being overwritten. (see [below for nested schema](#nestedblock--number_plans))
-- `outbound_routes` (Block List) Outbound Routes for the site. The default outbound route will not be delete if routes are specified (see [below for nested schema](#nestedblock--outbound_routes))
+- `outbound_routes` (Set of Object) Outbound Routes for the site. The default outbound route will be deleted if routes are specified (see [below for nested schema](#nestedatt--outbound_routes))
 - `primary_sites` (List of String) Used for primary phone edge assignment on physical edges only.  List of primary sites the phones can be assigned to. If no primary_sites are defined, the site id for this site will be used as the primary site id.
 - `secondary_sites` (List of String) Used for secondary phone edge assignment on physical edges only.  List of secondary sites the phones can be assigned to.  If no primary_sites or secondary_sites are defined then the current site will defined as primary and secondary.
 
@@ -149,18 +149,15 @@ Optional:
 
 
 
-<a id="nestedblock--outbound_routes"></a>
+<a id="nestedatt--outbound_routes"></a>
 ### Nested Schema for `outbound_routes`
-
-Required:
-
-- `classification_types` (List of String) Used to classify this outbound route.
-- `name` (String) The name of the entity.
 
 Optional:
 
-- `description` (String) The resource's description.
-- `distribution` (String) Valid values: SEQUENTIAL, RANDOM. Defaults to `SEQUENTIAL`.
-- `enabled` (Boolean) Enable or disable the outbound route Defaults to `false`.
-- `external_trunk_base_ids` (List of String) Trunk base settings of trunkType "EXTERNAL". This base must also be set on an edge logical interface for correct routing. The order of the IDs determines the distribution if "distribution" is set to "SEQUENTIAL"
+- `classification_types` (List of String)
+- `description` (String)
+- `distribution` (String)
+- `enabled` (Boolean)
+- `external_trunk_base_ids` (List of String)
+- `name` (String)
 

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_site.go
@@ -906,7 +906,7 @@ func updateSiteOutboundRoutes(d *schema.ResourceData, edgesAPI *platformclientv2
 }
 
 func isDefaultPlan(name string) bool {
-	defaultPlans := []string{"Emergency", "Extension", "National", "International", "Network", "Suicide Prevent"}
+	defaultPlans := []string{"Emergency", "Extension", "National", "International", "Network", "Suicide Prevention"}
 	for _, defaultPlan := range defaultPlans {
 		if name == defaultPlan {
 			return true

--- a/genesyscloud/resource_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/resource_genesyscloud_telephony_providers_edges_site_test.go
@@ -468,6 +468,48 @@ func TestAccResourceSiteOutboundRoutes(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.1.enabled", falseValue),
 				),
 			},
+			// Switch around the order of outbound routes which shouldn't have any effect
+			{
+				Config: GenerateSiteResourceWithCustomAttrs(
+					siteRes,
+					name,
+					description,
+					"genesyscloud_location."+locationRes+".id",
+					mediaModel,
+					false,
+					"[\"us-west-2\"]",
+					strconv.Quote("+19205551212"),
+					strconv.Quote("Wilco plumbing"),
+					generateSiteOutboundRoutesWithCustomAttrs(
+						"outboundRoute name 2",
+						"outboundRoute description",
+						"\"National\"",
+						"genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings2.id",
+						"SEQUENTIAL",
+						false),
+					generateSiteOutboundRoutesWithCustomAttrs(
+						"outboundRoute name 1",
+						"outboundRoute description",
+						"\"International\"",
+						"genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1.id",
+						"RANDOM",
+						false)) + trunkBaseSettings1 + trunkBaseSettings2 + location,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.0.name", "outboundRoute name 1"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.0.description", "outboundRoute description"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.0.classification_types.0", "International"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.0.distribution", "RANDOM"),
+					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.0.external_trunk_base_ids.0", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1", "id"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.0.enabled", falseValue),
+
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.1.name", "outboundRoute name 2"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.1.description", "outboundRoute description"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.1.classification_types.0", "National"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.1.distribution", "SEQUENTIAL"),
+					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.1.external_trunk_base_ids.0", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings2", "id"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site."+siteRes, "outbound_routes.1.enabled", falseValue),
+				),
+			},
 			// Remove a route and update the description, classification types, trunk base ids, distribution and enabled value of another route
 			{
 				Config: GenerateSiteResourceWithCustomAttrs(


### PR DESCRIPTION
### Problem(s)

- Getting attribute mismatches when Site with multiple outbound routes are updated. Including just switching around the order of the routes in the list.
- Default Number Plans are not exported (even if they are modified)
- Same attribute mismatch errors on Number Plans when updating number plans on 'update' resource.


### Fixes

- Changed `outbound_routes` type from `schema.TypeList` to `schema.TypeSet`. 
- Also set `outbound_routes` to `schema.SchemaConfigModeAttr` so all outbound routes can be cleared with `outbound_routes = []` 
- Export all number plans including default. Number Plans does not track versions so there's no way to identify which should be exported or can be safely ignored. Reimporting the numebr plans with same names as default causes no problems and overrides as expected.
- Fix 'default number plans' array because one is previously `Suicide Prevent` when it should be `Suicide Prevention`.
- Fix documentation that says 'Default Outbound Route' is not deleted when outbound routes are specified. The code actually updates the routes to exactly match the one in the configuration including removing the Default one in place of a defined route.
- Refactor some utility functions