### PR TITLE
no jira: Using after cursor in workbins getAll function

### DIFF
--- a/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
+++ b/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
@@ -105,12 +105,13 @@ func createTaskManagementWorkbinFn(ctx context.Context, p *taskManagementWorkbin
 func getAllTaskManagementWorkbinFn(ctx context.Context, p *taskManagementWorkbinProxy) (*[]platformclientv2.Workbin, error) {
 	var allWorkbins []platformclientv2.Workbin
 	pageSize := 200
+	after := ""
 
 	for {
 		queryReq := &platformclientv2.Workbinqueryrequest{
 			PageSize: &pageSize,
+			After:    &after,
 		}
-
 		workbins, _, err := p.taskManagementApi.PostTaskmanagementWorkbinsQuery(*queryReq)
 		if err != nil {
 			return nil, fmt.Errorf("failed to get workbin: %v", err)
@@ -121,6 +122,7 @@ func getAllTaskManagementWorkbinFn(ctx context.Context, p *taskManagementWorkbin
 		if workbins.After == nil || *workbins.After == "" {
 			break
 		}
+		after = *workbins.After
 	}
 
 	return &allWorkbins, nil


### PR DESCRIPTION
I noticed that the getAll function wasn't using the after cursor in its requests. By setting `pageSize` to 2 and creating 4 workbins, I was able to confirm that it did get stuck in an infinite loop. 