### PR TITLE
DEVTOOLING-38: Updating flow description instead of name in tests

### DIFF
--- a/examples/resources/genesyscloud_flow/inboundcall_flow_example.yaml
+++ b/examples/resources/genesyscloud_flow/inboundcall_flow_example.yaml
@@ -1,5 +1,6 @@
 inboundCall:
-  name: Terraform Flow Test-89f2194b-b1f6-40f4-86a6-c000812d8c60
+  name: Terraform Flow Test-ccbc124e-745c-4f8b-9f85-890e5d73ddf5
+  description: test description 1
   defaultLanguage: en-us
   startUpRef: ./menus/menu[mainMenu]
   initialGreeting:

--- a/examples/resources/genesyscloud_flow/inboundcall_flow_example2.yaml
+++ b/examples/resources/genesyscloud_flow/inboundcall_flow_example2.yaml
@@ -1,24 +1,17 @@
-inboundEmail:
-    name: Terraform Flow Test-02cc685f-604b-4384-b50f-9e6059c2307e
-    division: New Home
-    startUpRef: "/inboundEmail/states/state[Initial State_10]"
-    defaultLanguage: en-us
-    supportedLanguages:
-        en-us:
-            defaultLanguageSkill:
-                noValue: true
-    settingsInboundEmailHandling:
-        emailHandling:
-            disconnect:
-                none: true
-    settingsErrorHandling:
-        errorHandling:
-            disconnect:
-                none: true
-    states:
-        - state:
-            name: Initial State
-            refId: Initial State_10
-            actions:
-                - disconnect:
-                    name: Disconnect
+inboundCall:
+  name: Terraform Flow Test-ccbc124e-745c-4f8b-9f85-890e5d73ddf5
+  description: test description 2
+  defaultLanguage: en-us
+  startUpRef: ./menus/menu[mainMenu]
+  initialGreeting:
+    tts: Archy says hi!!!!!
+  menus:
+    - menu:
+        name: Main Menu
+        audio:
+          tts: You are at the Main Menu, press 9 to disconnect.
+        refId: mainMenu
+        choices:
+          - menuDisconnect:
+              name: Disconnect
+              dtmf: digit_9

--- a/examples/resources/genesyscloud_flow/inboundcall_flow_example3.yaml
+++ b/examples/resources/genesyscloud_flow/inboundcall_flow_example3.yaml
@@ -1,16 +1,25 @@
-inboundCall:
-  name: Terraform Flow Test-02483b03-a36a-4d46-a0bb-4180aacdedca
-  defaultLanguage: en-us
-  startUpRef: ./menus/menu[mainMenu]
-  initialGreeting:
-    tts: Archy says hi!!!!!
-  menus:
-    - menu:
-        name: Main Menu
-        audio:
-          tts: You are at the Main Menu, press 9 to disconnect.
-        refId: mainMenu
-        choices:
-          - menuDisconnect:
-              name: Disconnect
-              dtmf: digit_9
+inboundEmail:
+    name: Terraform Flow Test-ccbc124e-745c-4f8b-9f85-890e5d73ddf5
+    division: New Home
+    description: test description 1
+    startUpRef: "/inboundEmail/states/state[Initial State_10]"
+    defaultLanguage: en-us
+    supportedLanguages:
+        en-us:
+            defaultLanguageSkill:
+                noValue: true
+    settingsInboundEmailHandling:
+        emailHandling:
+            disconnect:
+                none: true
+    settingsErrorHandling:
+        errorHandling:
+            disconnect:
+                none: true
+    states:
+        - state:
+            name: Initial State
+            refId: Initial State_10
+            actions:
+                - disconnect:
+                    name: Disconnect

--- a/examples/resources/genesyscloud_flow/inboundcall_flow_example_substitutions.yaml
+++ b/examples/resources/genesyscloud_flow/inboundcall_flow_example_substitutions.yaml
@@ -1,5 +1,6 @@
 inboundCall:
   name: "{{flow_name}}"
+  description: "{{description}}"
   defaultLanguage: "{{default_language}}"
   startUpRef: ./menus/menu[mainMenu]
   initialGreeting:


### PR DESCRIPTION
When you invoke the archy import service, it looks up the flow by name and type. If it exists, it updates the current flow. If not, it creates a new flow. That means if a cx as code user tries to change the name on an update, a new flow with a new guid is created and the previous is not cleaned up. We already noted this in the docs.

The reason why there are so many flows not getting cleaned up is because we were updating the name and type in a few tests and verifying the value after. I changed it so that we update the flow description instead. 