### PR TITLE
Adding small check to edges_phone build function

### DIFF
--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
@@ -214,11 +214,14 @@ func buildSdkLines(ctx context.Context, pp *phoneProxy, d *schema.ResourceData, 
 			LineBaseSettings: lineBaseSettings,
 		}
 
-		lineId, err := getLineIdByPhoneId(ctx, pp, d.Id())
-		if err != nil {
-			log.Printf("Failed to retrieve ID for phone %s: %v", d.Id(), err)
-		} else {
-			line.Id = &lineId
+		// If this function is invoked on a phone create, the ID won't exist yet
+		if d.Id() != "" {
+			lineId, err := getLineIdByPhoneId(ctx, pp, d.Id())
+			if err != nil {
+				log.Printf("Failed to retrieve ID for phone %s: %v", d.Id(), err)
+			} else {
+				line.Id = &lineId
+			}
 		}
 
 		lines = append(lines, line)


### PR DESCRIPTION
The changes made in PR #696 highlighted the fact that a nested function for building an object was being called that tried to look up a phone by ID. This function should only have been invoked on update because then `d.Id()` would have a value. Since these new log comments tried to access the value in phone.Name and phone.Id , they revealed (through a nil pointer error) that nothing was actually being returned from the API call 