### PR TITLE
Updating to latest go version 1.21

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.18'
+          go-version: '1.21'
         id: go
 
       - name: Setup Terraform CLI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: '1.21'
       id: go
 
     - name: Check out code into the Go module directory
@@ -52,7 +52,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
-        go-version: '1.18'
+        go-version: '1.21'
       id: go
 
     - name: Setup Terraform CLI

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module terraform-provider-genesyscloud
 
-go 1.18
+go 1.21
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
A dependabot PR failed because the package update introduced [a function](https://pkg.go.dev/errors#Join) that required go 1.20, which seems like a good sign it's time to upgrade