### PR TITLE
[no jira] go mod tidy

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -87,7 +87,7 @@ require (
 	github.com/vmihailenco/msgpack v4.0.4+incompatible // indirect
 	golang.org/x/crypto v0.15.0 // indirect
 	golang.org/x/mod v0.13.0 // indirect
-	golang.org/x/net v0.17.0 // indirect
+	golang.org/x/net v0.17.0
 	golang.org/x/sys v0.14.0 // indirect
 	golang.org/x/text v0.14.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect


### PR DESCRIPTION
Jenkins build failed with error message: 
```no-highlight
⨯ release failed after 0s                  error=hook failed: go mod tidy: exit status 1; output: go: go.mod file indicates go 1.21, but maximum version supported by tidy is 1.20
```

`go mod tidy` ran fine locally against main, but it did make this small change. So I want to merge this and try again to see if that makes any difference. If not, we may need to go down to 1.20 