### PR TITLE
Fix naming of one of the mappings

### DIFF
--- a/genesyscloud/dependent_consumers/dependent_consumers.go
+++ b/genesyscloud/dependent_consumers/dependent_consumers.go
@@ -12,7 +12,7 @@ func SetDependentObjectMaps() map[string]string {
 		dependentConsumerMap["BOTFLOW"] = "genesyscloud_flow"
 		dependentConsumerMap["COMPOSERSCRIPT"] = "genesyscloud_script"
 		dependentConsumerMap["COMMONMODULEFLOW"] = "genesyscloud_flow"
-		dependentConsumerMap["CONTACTLIST"] = "genesyscloud_outbound_contactlist"
+		dependentConsumerMap["CONTACTLIST"] = "genesyscloud_outbound_contact_list"
 		dependentConsumerMap["DATAACTION"] = "genesyscloud_integration_action"
 		dependentConsumerMap["DATATABLE"] = "genesyscloud_architect_datatable"
 		dependentConsumerMap["EMAILROUTE"] = "genesyscloud_routing_email_route"


### PR DESCRIPTION
I came across this in my testing. One of the flows referenced a contact list that could not be found when I tried to reapply it in a different org. 

I did a self audit of the rest of the mapping structure and everything else looks good to my human eye.