### PR TITLE
DEVTOOLING-46 Fix TestAccResourceRoutingSettingsContactCenter test case failing

### DIFF
--- a/genesyscloud/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/resource_genesyscloud_routing_settings.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
@@ -166,6 +167,8 @@ func updateRoutingSettings(ctx context.Context, d *schema.ResourceData, meta int
 	if err != nil {
 		return diag.Errorf("Failed to update routing settings: %s", err)
 	}
+
+	time.Sleep(5 * time.Second)
 
 	log.Printf("Updated Routing Settings")
 	return readRoutingSettings(ctx, d, meta)


### PR DESCRIPTION
Looks like the consistency checker isn't able to check the nested field `contactcenter.remove_skills_from_blind_transfer` as it's reading the previous value too quickly right after the update is made. 

Adding a sleep (5s) makes the test pass in the Github matrix test.
![image](https://github.com/MyPureCloud/terraform-provider-genesyscloud/assets/22146579/067a5261-8c05-441d-acf6-3127141aacc9)
