### PR TITLE
Renaming funcs and vars in _init_test.go files

### DIFF
--- a/genesyscloud/architect_grammar/genesyscloud_architect_grammar_init_test.go
+++ b/genesyscloud/architect_grammar/genesyscloud_architect_grammar_init_test.go
@@ -32,7 +32,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_architect_grammar"] = DataSourceArchitectGrammar()
 }
 
-// initTestresources initializes all test_data resources and data sources.
+// initTestResources initializes all test_data resources and data sources.
 func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)

--- a/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_init_test.go
+++ b/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_init_test.go
@@ -29,7 +29,7 @@ func (r *registerTestInstance) registerTestResources() {
 	providerResources["genesyscloud_architect_grammar"] = architectGrammar.ResourceArchitectGrammar()
 }
 
-// initTestresources initializes all test_data resources and data sources.
+// initTestResources initializes all test_data resources and data sources.
 func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)

--- a/genesyscloud/authorization_product/authorization_product_resource_init_test.go
+++ b/genesyscloud/authorization_product/authorization_product_resource_init_test.go
@@ -9,12 +9,12 @@ import (
 var providerDataSources map[string]*schema.Resource
 var providerResources map[string]*schema.Resource
 
-func initTestresources() {
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
-	reg_instance.registerTestDataSources()
+	regInstance := &registerTestInstance{}
+	regInstance.registerTestDataSources()
 }
 
 type registerTestInstance struct {
@@ -26,7 +26,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for outbound ruleset
 	m.Run()

--- a/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_init_test.go
+++ b/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_init_test.go
@@ -42,23 +42,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for external_contacts package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the external_contacts package
+	// Run the test suite for the external_contacts package
 	m.Run()
 }

--- a/genesyscloud/flow_milestone/genesyscloud_flow_milestone_init_test.go
+++ b/genesyscloud/flow_milestone/genesyscloud_flow_milestone_init_test.go
@@ -41,7 +41,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources[resourceName] = DataSourceFlowMilestone()
 }
 
-// initTestresources initializes all test resources and data sources.
+// initTestResources initializes all test resources and data sources.
 func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)

--- a/genesyscloud/integration/genesyscloud_integration_init_test.go
+++ b/genesyscloud/integration/genesyscloud_integration_init_test.go
@@ -46,23 +46,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_integration"] = DataSourceIntegration()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/integration_action/genesyscloud_integration_action_init_test.go
+++ b/genesyscloud/integration_action/genesyscloud_integration_action_init_test.go
@@ -45,23 +45,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_integration"] = integration.DataSourceIntegration()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/integration_credential/genesyscloud_integration_credential_init_test.go
+++ b/genesyscloud/integration_credential/genesyscloud_integration_credential_init_test.go
@@ -41,23 +41,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_integration_credential"] = DataSourceIntegrationCredential()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration_credential package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration_credential package
+	// Run the test suite for the integration_credential package
 	m.Run()
 }

--- a/genesyscloud/integration_custom_auth_action/genesyscloud_integration_custom_auth_action_init_test.go
+++ b/genesyscloud/integration_custom_auth_action/genesyscloud_integration_custom_auth_action_init_test.go
@@ -46,22 +46,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources[resourceName] = DataSourceIntegrationCustomAuthAction()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/outbound/resource_genesyscloud_outbound_init_test.go
+++ b/genesyscloud/outbound/resource_genesyscloud_outbound_init_test.go
@@ -75,21 +75,20 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 }
 
-func initTestresources() {
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 func TestMain(m *testing.M) {
 
 	// Run setup function before starting the test suite for Outbound Package
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for outbound
 	m.Run()

--- a/genesyscloud/outbound_attempt_limit/outbound_attempt_limit_resource_init_test.go
+++ b/genesyscloud/outbound_attempt_limit/outbound_attempt_limit_resource_init_test.go
@@ -9,14 +9,14 @@ import (
 var providerDataSources map[string]*schema.Resource
 var providerResources map[string]*schema.Resource
 
-func initTestresources() {
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestResources()
-	reg_instance.registerTestDataSources()
+	regInstance.registerTestResources()
+	regInstance.registerTestDataSources()
 }
 
 type registerTestInstance struct {
@@ -32,7 +32,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for outbound ruleset
 	m.Run()

--- a/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
+++ b/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
@@ -50,7 +50,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_auth_division_home"] = gcloud.DataSourceAuthDivisionHome()
 }
 
-// initTestresources initializes all test resources and data sources.
+// initTestResources initializes all test resources and data sources.
 func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)

--- a/genesyscloud/outbound_contact_list/outbound_contact_list_resource_init_test.go
+++ b/genesyscloud/outbound_contact_list/outbound_contact_list_resource_init_test.go
@@ -11,14 +11,14 @@ import (
 var providerDataSources map[string]*schema.Resource
 var providerResources map[string]*schema.Resource
 
-func initTestresources() {
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestResources()
-	reg_instance.registerTestDataSources()
+	regInstance.registerTestResources()
+	regInstance.registerTestDataSources()
 }
 
 type registerTestInstance struct {
@@ -38,7 +38,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for outbound ruleset
 	m.Run()

--- a/genesyscloud/outbound_ruleset/genesyscloud_outbound_ruleset_init_test.go
+++ b/genesyscloud/outbound_ruleset/genesyscloud_outbound_ruleset_init_test.go
@@ -38,21 +38,21 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerResources["genesyscloud_outbound_contact_list"] = obContactList.ResourceOutboundContactList()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestResources()
-	reg_instance.registerTestDataSources()
+	regInstance.registerTestResources()
+	regInstance.registerTestDataSources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for the outbound_ruleset package
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for the outbound_ruleset package
 	m.Run()

--- a/genesyscloud/outbound_wrapupcode_mappings/genesyscloud_wrapupcode_mappings_init_test.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/genesyscloud_wrapupcode_mappings_init_test.go
@@ -28,14 +28,13 @@ func (r *registerTestInstance) registerTestResources() {
 
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestResources()
 }
 
 // initTestDataSources is used to initialize data sources used in the test code.  There are no data sources associated with genesyscloud_wrapupcode_mappings resources.
@@ -45,7 +44,7 @@ func initTestDataSources() {
 
 // TestMain is a "setup" function called by the testing framework when run the
 func TestMain(m *testing.M) {
-	initTestresources()
+	initTestResources()
 	initTestDataSources()
 
 	m.Run()

--- a/genesyscloud/process_automation_trigger/process_automation_trigger_resource_init_test.go
+++ b/genesyscloud/process_automation_trigger/process_automation_trigger_resource_init_test.go
@@ -10,14 +10,14 @@ import (
 var providerDataSources map[string]*schema.Resource
 var providerResources map[string]*schema.Resource
 
-func initTestresources() {
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestResources()
-	reg_instance.registerTestDataSources()
+	regInstance.registerTestResources()
+	regInstance.registerTestDataSources()
 }
 
 type registerTestInstance struct {
@@ -35,7 +35,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for Process Automation Trigger
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite
 	m.Run()

--- a/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_init_test.go
+++ b/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_init_test.go
@@ -60,8 +60,8 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources[resourceName] = DataSourceRecordingMediaRetentionPolicy()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	if sdkConfig, err = gcloud.AuthorizeSdk(); err != nil {
 		log.Fatal(err)
 	}
@@ -69,18 +69,17 @@ func initTestresources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_init_test.go
+++ b/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_init_test.go
@@ -31,8 +31,8 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources[resourceName] = DataSourceRoutingSmsAddress()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
@@ -45,7 +45,7 @@ func initTestresources() {
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for routing_sms_addresses package
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for the routing_sms_addresses package
 	m.Run()

--- a/genesyscloud/station/genesyscloud_station_init_test.go
+++ b/genesyscloud/station/genesyscloud_station_init_test.go
@@ -47,23 +47,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_organizations_me"] = gcloud.DataSourceOrganizationsMe()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_init_test.go
+++ b/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_init_test.go
@@ -45,21 +45,21 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_auth_division_home"] = gcloud.DataSourceAuthDivisionHome()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestResources()
-	reg_instance.registerTestDataSources()
+	regInstance.registerTestResources()
+	regInstance.registerTestDataSources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for the task_management_workbin package
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for the task_management_workbin package
 	m.Run()

--- a/genesyscloud/team/genesyscloud_team_init_test.go
+++ b/genesyscloud/team/genesyscloud_team_init_test.go
@@ -40,7 +40,7 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_team"] = DataSourceTeam()
 }
 
-// initTestresources initializes all test resources and data sources.
+// initTestResources initializes all test resources and data sources.
 func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)

--- a/genesyscloud/telephony/genesyscloud_telephony_init_test.go
+++ b/genesyscloud/telephony/genesyscloud_telephony_init_test.go
@@ -47,21 +47,19 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 }
 
-func initTestresources() {
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 func TestMain(m *testing.M) {
-
 	// Run setup function before starting the test suite for Outbound Package
-	initTestresources()
+	initTestResources()
 
 	// Run the test suite for outbound
 	m.Run()

--- a/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
@@ -51,23 +51,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_organizations_me"] = gcloud.DataSourceOrganizationsMe()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_init_test.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_init_test.go
@@ -47,23 +47,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_organizations_me"] = gcloud.DataSourceOrganizationsMe()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite for the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/webdeployments_configuration/genesyscloud_webdeployments_configuration_init_test.go
+++ b/genesyscloud/webdeployments_configuration/genesyscloud_webdeployments_configuration_init_test.go
@@ -35,23 +35,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }

--- a/genesyscloud/webdeployments_deployment/genesyscloud_webdeployments_deployment_init_test.go
+++ b/genesyscloud/webdeployments_deployment/genesyscloud_webdeployments_deployment_init_test.go
@@ -36,23 +36,22 @@ func (r *registerTestInstance) registerTestDataSources() {
 	providerResources["genesyscloud_webdeployments_configuration"] = webDeployConfig.DataSourceWebDeploymentsConfiguration()
 }
 
-// initTestresources initializes all test resources and data sources.
-func initTestresources() {
+// initTestResources initializes all test resources and data sources.
+func initTestResources() {
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 
-	reg_instance := &registerTestInstance{}
+	regInstance := &registerTestInstance{}
 
-	reg_instance.registerTestDataSources()
-	reg_instance.registerTestResources()
-
+	regInstance.registerTestDataSources()
+	regInstance.registerTestResources()
 }
 
 // TestMain is a "setup" function called by the testing framework when run the test
 func TestMain(m *testing.M) {
 	// Run setup function before starting the test suite for integration package
-	initTestresources()
+	initTestResources()
 
-	// Run the test suite for suite the integration package
+	// Run the test suite for the integration package
 	m.Run()
 }


### PR DESCRIPTION
Going from `reg_instance` -> `regInstance` , and `initTestresources` -> `initTestResources`