### PR TITLE
DEVTOOLING-282

### DIFF
--- a/genesyscloud/integration/data_source_genesyscloud_integration.go
+++ b/genesyscloud/integration/data_source_genesyscloud_integration.go
@@ -23,7 +23,7 @@ import (
 // dataSourceIntegrationRead retrieves by name the integration id in question
 func dataSourceIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sdkConfig := m.(*gcloud.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	integrationName := d.Get("name").(string)
 

--- a/genesyscloud/integration/genesyscloud_integration_proxy.go
+++ b/genesyscloud/integration/genesyscloud_integration_proxy.go
@@ -72,9 +72,9 @@ func newIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integra
 	}
 }
 
-// getIntegrationsProxy acts as a singleton to for the internalProxy.  It also ensures
+// GetIntegrationsProxy acts as a singleton to for the internalProxy.  It also ensures
 // that we can still proxy our tests by directly setting internalProxy package variable
-func getIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integrationsProxy {
+func GetIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integrationsProxy {
 	if internalProxy == nil {
 		internalProxy = newIntegrationsProxy(clientConfig)
 	}
@@ -92,8 +92,8 @@ func (p *integrationsProxy) createIntegration(ctx context.Context, integrationRe
 	return p.createIntegrationAttr(ctx, p, integrationReq)
 }
 
-// getIntegrationById gets Genesys Cloud Integration by id
-func (p *integrationsProxy) getIntegrationById(ctx context.Context, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+// GetIntegrationById gets Genesys Cloud Integration by id
+func (p *integrationsProxy) GetIntegrationById(ctx context.Context, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	return p.getIntegrationByIdAttr(ctx, p, integrationId)
 }
 

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -40,7 +40,7 @@ utils function in the package.  This will keep the code manageable and easy to w
 
 // getAllIntegrations retrieves all of the integrations via Terraform in the Genesys Cloud and is used for the exporter
 func getAllIntegrations(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
-	ip := getIntegrationsProxy(clientConfig)
+	ip := GetIntegrationsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 
 	integrations, err := ip.getAllIntegrations(ctx)
@@ -62,7 +62,7 @@ func createIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 	integrationType := d.Get("integration_type").(string)
 
 	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	createIntegrationReq := &platformclientv2.Createintegrationrequest{
 		IntegrationType: &platformclientv2.Integrationtype{
@@ -101,12 +101,12 @@ func createIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 // readIntegration is used by the integration resource to read an integration from genesys cloud.
 func readIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	log.Printf("Reading integration %s", d.Id())
 
 	return gcloud.WithRetriesForRead(ctx, d, func() *retry.RetryError {
-		currentIntegration, resp, getErr := ip.getIntegrationById(ctx, d.Id())
+		currentIntegration, resp, getErr := ip.GetIntegrationById(ctx, d.Id())
 		if getErr != nil {
 			if gcloud.IsStatus404(resp) {
 				return retry.RetryableError(fmt.Errorf("failed to read integration %s: %s", d.Id(), getErr))
@@ -137,7 +137,7 @@ func updateIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 	intendedState := d.Get("intended_state").(string)
 
 	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	diagErr, name := updateIntegrationConfigFromResourceData(ctx, d, ip)
 	if diagErr != nil {
@@ -161,7 +161,7 @@ func updateIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 // deleteIntegration is used by the integration resource to delete an integration from Genesys cloud.
 func deleteIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	_, err := ip.deleteIntegration(ctx, d.Id())
 	if err != nil {
@@ -169,7 +169,7 @@ func deleteIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 	}
 
 	return gcloud.WithRetries(ctx, 30*time.Second, func() *retry.RetryError {
-		_, resp, err := ip.getIntegrationById(ctx, d.Id())
+		_, resp, err := ip.GetIntegrationById(ctx, d.Id())
 		if err != nil {
 			if gcloud.IsStatus404(resp) {
 				// Integration deleted

--- a/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
+++ b/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
@@ -65,7 +65,7 @@ func newIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *int
 	}
 }
 
-// getIntegrationsProxy acts as a singleton to for the internalProxy.  It also ensures
+// getIntegrationCredsProxy acts as a singleton to for the internalProxy.  It also ensures
 // that we can still proxy our tests by directly setting internalProxy package variable
 func getIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *integrationCredsProxy {
 	if internalProxy == nil {

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
@@ -59,6 +59,7 @@ func getAllCredentials(ctx context.Context, clientConfig *platformclientv2.Confi
 			_, resp, err := integrationsProxy.GetIntegrationById(ctx, integrationId)
 			if err != nil {
 				if gcloud.IsStatus404(resp) {
+					log.Printf("Integration id %s no longer exist, we are therefore not exporting the associated integration credential id %s", integrationId, *cred.Id)
 					continue
 				} else {
 					log.Printf("Integration id %s exists but we got an unexpected error retrieving it: %v", integrationId, err)


### PR DESCRIPTION
* Exporting two functions of the integration package: GetIntegrationsProxy & GetIntegrationById
* These functions are used within the integration_credential package to make sure we're not exporting an integration credential for an integration that no longer exists in GC (HTTP 404)
* In case there is an error other than 404 while trying to get the interaction, we trace the message but still export the integration credential.