### PR TITLE
no jira: Satisfying go vet

### DIFF
--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -32,19 +32,19 @@ type UserExport struct {
 	Email        string `json:"email"`
 	Name         string `json:"name"`
 	State        string `json:"state"`
-	ResourceName string `-`
+	ResourceName string ``
 }
 
 type QueueExport struct {
 	AcwTimeoutMs int    `json:"acw_timeout_ms"`
 	Description  string `json:"description"`
 	Name         string `json:"name"`
-	ResourceName string `-`
+	ResourceName string ``
 }
 
 type WrapupcodeExport struct {
 	Name         string `json:"name"`
-	ResourceName string `-`
+	ResourceName string ``
 }
 
 // TestAccResourceTfExport does a basic test check to make sure the export file is created.


### PR DESCRIPTION
The output of `go vet ./genesyscloud/...` prior to these changes:

```log
# terraform-provider-genesyscloud/genesyscloud/tfexporter
genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go:35:2: struct field tag `-` not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go:42:2: struct field tag `-` not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go:47:2: struct field tag `-` not compatible with reflect.StructTag.Get: bad syntax for struct tag pair
```