### PR TITLE
DEVTOOLING-309: Fixing Architect IVR chunking logic 

### DIFF
--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy.go
@@ -258,6 +258,13 @@ func (a *architectIvrProxy) uploadArchitectIvrWithChunkingLogic(ctx context.Cont
 	if len(dnisChunks) > 1 {
 		respIvr, resp, err = a.uploadIvrDnisChunks(ctx, dnisChunks, id)
 		if err != nil {
+			// if the chunking logic failed on create - delete the IVR that was created above
+			// Otherwise the CreateContext func will fail and terraform will assume the IVR was never created
+			if post {
+				if _, deleteErr := a.deleteArchitectIvr(ctx, id); deleteErr != nil {
+					log.Printf("failed to delete ivr '%s' after dnis chunking logic failed: %v", id, deleteErr)
+				}
+			}
 			return respIvr, resp, err
 		}
 	}

--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
@@ -50,6 +50,7 @@ func TestUnitUploadIvrDnisChunksSuccess(t *testing.T) {
 	}
 
 	t.Log("Testing Put Ivr function")
+
 	ivr, _, err = architectIvrProxy.updateArchitectIvr(nil, ivrId, *ivr)
 	if err != nil {
 		t.Errorf("Expected error to be nil, got '%v'", err)
@@ -96,7 +97,6 @@ func TestUnitUploadIvrDnisChunksError(t *testing.T) {
 
 	architectProxy := newArchitectIvrProxy(nil)
 	architectProxy.maxDnisPerRequest = maxDnisPerRequest
-	architectProxy.validatePhoneNumberAttr = createMockValidatePhoneNumberFunc(nil)
 
 	// will be called on create after a chunk update fails because the ivr will need to be manually taken down, in that case
 	architectProxy.deleteArchitectIvrAttr = createMockDeleteIvrFunc(nil)
@@ -124,6 +124,9 @@ func TestUnitUploadIvrDnisChunksError(t *testing.T) {
 
 	t.Log("Testing error handling on proxy.PostArchitectIvr")
 	for _, test := range testCases {
+		if test.mockError == mockGetError {
+			continue
+		}
 		architectProxy.getArchitectIvrAttr = test.mockGetFunction
 		architectProxy.createArchitectIvrBasicAttr = test.mockPostFunction
 		architectProxy.updateArchitectIvrBasicAttr = test.mockPutFunction
@@ -293,7 +296,6 @@ func TestUnitGetIvrDnisAndChunks(t *testing.T) {
 
 		if !testCase.post {
 			architectIvrProxy.getArchitectIvrAttr = createMockGetIvrFunc(ivrId, *testCase.dnisReturnedFromGet, nil)
-			architectIvrProxy.validatePhoneNumberAttr = createMockValidatePhoneNumberFunc(nil)
 		}
 
 		initialUploadDnis, chunks, err := architectIvrProxy.getIvrDnisAndChunks(context.TODO(), ivrId, testCase.post, testCase.ivrFromSchema)
@@ -310,125 +312,6 @@ func TestUnitGetIvrDnisAndChunks(t *testing.T) {
 		for i := range chunks {
 			if !utillists.AreEquivalent(chunks[i], testCase.expectedChunks[i]) {
 				t.Errorf("expected chunk item to be %v, got %v", chunks[i], testCase.expectedChunks[i])
-			}
-		}
-	}
-}
-
-func TestUnitValidateDidNumbers(t *testing.T) {
-	ctx := context.TODO()
-	proxy := newArchitectIvrProxy(nil)
-	numbers := []string{"123", "456", "789"}
-	testError := fmt.Errorf("test error")
-
-	proxy.validatePhoneNumberAttr = createMockValidatePhoneNumberFunc(testError)
-	//proxy.getTelephonyDidPoolsDidsAttr = createMockGetTelephonyDidPoolsDidsFunc(nil, fmt.Errorf("test error"))
-
-	if err := proxy.validateDidNumbers(ctx, numbers); err == nil {
-		t.Errorf("expected to received error '%v', got nil", testError)
-	}
-
-	proxy.validatePhoneNumberAttr = createMockValidatePhoneNumberFunc(nil)
-	if err := proxy.validateDidNumbers(ctx, numbers); err != nil {
-		t.Errorf("expected error to be nil, got: %v", err)
-	}
-}
-
-func TestUnitValidatePhoneNumber(t *testing.T) {
-	var (
-		ctx        = context.TODO()
-		proxy      = newArchitectIvrProxy(nil)
-		trueValue  = true
-		falseValue = false
-	)
-
-	type validatePhoneNumberTestCase struct {
-		didsReturnedFromGet *[]platformclientv2.Didnumber
-		errReturnedFromGet  error
-		number              string
-		errorText           string // some text that should be present in the returned error message
-	}
-
-	testCases := []validatePhoneNumberTestCase{
-		// Number is found and is unassigned - should return nil
-		{
-			didsReturnedFromGet: &[]platformclientv2.Didnumber{
-				{
-					Number:   stringPointer("123"),
-					Assigned: &falseValue,
-				},
-			},
-			errReturnedFromGet: nil,
-			number:             "123",
-			errorText:          "",
-		},
-		// verify error is returned when the getDids func fails
-		{
-			didsReturnedFromGet: nil,
-			errReturnedFromGet:  fmt.Errorf("test error"),
-			errorText:           "test error",
-			number:              "123",
-		},
-		// verify we get the right error when no dids are returned
-		{
-			didsReturnedFromGet: nil,
-			errReturnedFromGet:  nil,
-			errorText:           "could not find any numbers that match did",
-			number:              "123",
-		},
-		{
-			didsReturnedFromGet: &[]platformclientv2.Didnumber{},
-			errReturnedFromGet:  nil,
-			errorText:           "could not find any numbers that match did",
-			number:              "123",
-		},
-		// verify we get the right error when number is already assigned
-		{
-			didsReturnedFromGet: &[]platformclientv2.Didnumber{
-				{
-					Number:    stringPointer("123"),
-					Assigned:  &trueValue,
-					OwnerType: stringPointer("IVR"),
-				},
-			},
-			errReturnedFromGet: nil,
-			number:             "123",
-			errorText:          "phone number 123 is already assigned",
-		},
-		// verify we get the right error when dids are returned but none of them match the number exactly
-		{
-			didsReturnedFromGet: &[]platformclientv2.Didnumber{
-				{
-					Number:   stringPointer("111"),
-					Assigned: &falseValue,
-				},
-				{
-					Number:   stringPointer("222"),
-					Assigned: &falseValue,
-				},
-				{
-					Number:   stringPointer("333"),
-					Assigned: &falseValue,
-				},
-			},
-			errReturnedFromGet: nil,
-			number:             "123",
-			errorText:          "could not find did 123",
-		},
-	}
-
-	for _, testCase := range testCases {
-		proxy.getTelephonyDidPoolsDidsAttr = createMockGetTelephonyDidPoolsDidsFunc(testCase.didsReturnedFromGet, testCase.errReturnedFromGet)
-		err := proxy.validatePhoneNumber(ctx, testCase.number)
-		if testCase.errorText == "" && err != nil {
-			t.Errorf("expected nil error, received: %v", err)
-		}
-		if testCase.errorText != "" && err == nil {
-			t.Errorf("expected error containing text '%s', received nil", testCase.errorText)
-		}
-		if testCase.errorText != "" {
-			if !strings.Contains(fmt.Sprintf("%v", err), testCase.errorText) {
-				t.Errorf("expected error to contain '%v', got '%v'", testCase.errorText, err)
 			}
 		}
 	}
@@ -471,20 +354,4 @@ func createMockDeleteIvrFunc(errToReturn error) deleteArchitectIvrFunc {
 	return func(context.Context, *architectIvrProxy, string) (*platformclientv2.APIResponse, error) {
 		return nil, errToReturn
 	}
-}
-
-func createMockGetTelephonyDidPoolsDidsFunc(didsToReturn *[]platformclientv2.Didnumber, errToReturn error) getTelephonyDidPoolsDidsFunc {
-	return func(ctx context.Context, a *architectIvrProxy, number, varType string) (*[]platformclientv2.Didnumber, error) {
-		return didsToReturn, errToReturn
-	}
-}
-
-func createMockValidatePhoneNumberFunc(errToReturn error) validatePhoneNumberFunc {
-	return func(ctx context.Context, a *architectIvrProxy, number string) error {
-		return errToReturn
-	}
-}
-
-func stringPointer(s string) *string {
-	return &s
 }

--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
@@ -281,7 +281,7 @@ func TestUnitGetIvrDnisAndChunks(t *testing.T) {
 			architectIvrProxy.getArchitectIvrAttr = createMockGetIvrFunc(ivrId, *testCase.dnisReturnedFromGet, nil)
 		}
 
-		initialUploadDnis, chunks := architectIvrProxy.getIvrDnisAndChunks(context.TODO(), ivrId, testCase.post, testCase.ivrFromSchema)
+		initialUploadDnis, chunks, _ := architectIvrProxy.getIvrDnisAndChunks(context.TODO(), ivrId, testCase.post, testCase.ivrFromSchema)
 
 		if !utillists.AreEquivalent(*initialUploadDnis, *testCase.expectedInitialUploadDnis) {
 			t.Errorf("expected initial dnis slice to be %v, got %v", *testCase.expectedInitialUploadDnis, *initialUploadDnis)

--- a/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
@@ -39,6 +39,8 @@ type deleteTelephonyDidPool func(context.Context, *telephonyDidPoolProxy, string
 type getTelephonyDidPoolIdByStartAndEndNumber func(ctx context.Context, t *telephonyDidPoolProxy, start, end string) (id string, retryable bool, err error)
 type getAllTelephonyDidPools func(context.Context, *telephonyDidPoolProxy) (*[]platformclientv2.Didpool, error)
 
+type getTelephonyDidPoolsDids func(ctx context.Context, proxy *telephonyDidPoolProxy, number string, varType string) (*[]platformclientv2.Didnumber, error)
+
 // telephonyDidPoolProxy contains all methods that call genesys cloud APIs.
 type telephonyDidPoolProxy struct {
 	clientConfig                                 *platformclientv2.Configuration

--- a/genesyscloud/util/lists/util_lists.go
+++ b/genesyscloud/util/lists/util_lists.go
@@ -35,7 +35,7 @@ func SubStringInSlice(a string, list []string) bool {
 	return false
 }
 
-// difference returns the elements in a that aren't in b
+// SliceDifference returns the elements in a that aren't in b
 func SliceDifference(a, b []string) []string {
 	var diff []string
 	if len(a) == 0 {
@@ -160,4 +160,14 @@ func NilToEmptyList[T interface{}](list *[]T) *[]T {
 		return &emptyArray
 	}
 	return list
+}
+
+// Remove an item from a string list based on the value
+func Remove[T comparable](s []T, r T) []T {
+	for i, v := range s {
+		if v == r {
+			return append(s[:i], s[i+1:]...)
+		}
+	}
+	return s
 }

--- a/genesyscloud/util/lists/util_lists_test.go
+++ b/genesyscloud/util/lists/util_lists_test.go
@@ -10,6 +10,12 @@ type AreEquivalentTestCase struct {
 	equivalent bool
 }
 
+type RemoveTestCase struct {
+	originalSlice  []string
+	resultingSlice []string
+	itemToRemove   string
+}
+
 func TestAreEquivalent(t *testing.T) {
 	testCases := []AreEquivalentTestCase{
 		{
@@ -66,6 +72,33 @@ func TestAreEquivalent(t *testing.T) {
 			if v != arrayBCopy[k] {
 				t.Errorf("arrayB has changed after going through the function. Should be %v, got %v", arrayBCopy, tc.arrayB)
 			}
+		}
+	}
+}
+
+func TestRemove(t *testing.T) {
+	testCases := []RemoveTestCase{
+		{
+			originalSlice:  []string{"a", "b", "c"},
+			itemToRemove:   "b",
+			resultingSlice: []string{"a", "c"},
+		},
+		{
+			originalSlice:  []string{"a", "b", "c"},
+			itemToRemove:   "a",
+			resultingSlice: []string{"b", "c"},
+		},
+		{
+			originalSlice:  []string{"a", "b", "c"},
+			itemToRemove:   "c",
+			resultingSlice: []string{"a", "b"},
+		},
+	}
+
+	for _, testCase := range testCases {
+		res := Remove(testCase.originalSlice, testCase.itemToRemove)
+		if !AreEquivalent(res, testCase.resultingSlice) {
+			t.Errorf("expected %v, got %v", testCase.resultingSlice, res)
 		}
 	}
 }


### PR DESCRIPTION
This PR addresses 3 issues that existed with the IVR dnis chunking logic:

1. **Speed** - Previously, on update, we were clearing the dnis array on the first PUT, then uploading each chunk again on subsequent requests. So 600 numbers exist in the dnis array, the user adds 20, and we're doing 13 requests (because we're uploading 50 new dnis numbers at a time.) We only need to do one requests in this scenario because the API can handle all 600 dnis that are already associated with the IVR. It's only new numbers that need to be chunked.
    * *Solution* - Slice the difference of the dnis array to establish which numbers are new. Set ivr.Dnis to the numbers that already are associated with the ivr (removing the new ones) + the first chunk, and then add on any new chunks incrementally in subsequent PUT requests.
2. **IVR not being deleted on a failed CREATE** - If there are more than `maxDnisPerRequest` (currently set to 50) in the dnis array on an IVR creation, and the chunking logic fails, then a dangling IVR would be left out there. This is because the IVR is created, but a subsequent update failed. As far as terraform is aware it failed on create so there is no need to call the delete function.
    * *Solution* - Manually call the delete IVR function if a chunk upload fails on IVR creation, before returning the error message.
3. **Inaccurate tf plans outputs** - If we're adding 150 new numbers, the tf plan will state that. However, if the third chunk upload fails, that means we have uploaded 100 numbers successfully before failure. Now when the user runs `terraform apply` again, they will see "50 to add". 
    * *Solution* - Save a copy of the IVR before attempting the update with chunking logic, and if the process fails, reset the IVR to it's original state before returning the error message. This way the user will see "150 to add" again, as expected.