### PR TITLE
No jira: using uuid instead of rand for email route tests

### DIFF
--- a/genesyscloud/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_email_route_test.go
@@ -2,13 +2,9 @@ package genesyscloud
 
 import (
 	"fmt"
-	"math/rand"
-	"strconv"
+	"github.com/google/uuid"
 	"strings"
 	"testing"
-	"time"
-
-	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -16,10 +12,9 @@ import (
 )
 
 func TestAccResourceRoutingEmailRoute(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
 	var (
 		domainRes     = "routing-domain1"
-		domainId      = "terraform" + strconv.Itoa(rand.Intn(1000)) + ".com"
+		domainId      = fmt.Sprintf("terraform.%s.com", strings.Replace(uuid.NewString(), "-", "", -1))
 		queueResource = "email-queue"
 		queueName     = "Terraform Email Queue-" + uuid.NewString()
 		langResource  = "email-lang"
@@ -39,10 +34,7 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 		bccEmail1     = "test1@" + domainId
 		bccEmail2     = "test2@" + domainId
 	)
-	_, err := AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
+
 	CleanupRoutingEmailDomains()
 
 	resource.Test(t, resource.TestCase{


### PR DESCRIPTION
This is to fix the test `TestAccResourceRoutingEmailRoute` in the workflow. It was failing with a 400, saying that the email domain already exists. I think going with the uuid package as usual should prevent this. Also the AuthorizeSdk function call was unnecessarily, it turns out 