### PR TITLE
No jira: fix outbound tests

### DIFF
--- a/genesyscloud/outbound_campaign/data_source_genesyscloud_outbound_campaign_test.go
+++ b/genesyscloud/outbound_campaign/data_source_genesyscloud_outbound_campaign_test.go
@@ -9,11 +9,6 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
-)
-
-var (
-	sdkConfig *platformclientv2.Configuration
 )
 
 func TestAccDataSourceOutboundCampaign(t *testing.T) {
@@ -24,15 +19,9 @@ func TestAccDataSourceOutboundCampaign(t *testing.T) {
 		outboundFlowFilePath = "../../examples/resources/genesyscloud_flow/outboundcall_flow_example.yaml"
 	)
 
-	// necessary to avoid errors during site creation
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
 	emergencyNumber := "+13173124740"
-	err = edgeSite.DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err := edgeSite.DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s, %v", emergencyNumber, err)
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
+++ b/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
@@ -1,6 +1,8 @@
 package outbound_campaign
 
 import (
+	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
+	"log"
 	"sync"
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	"terraform-provider-genesyscloud/genesyscloud/outbound"
@@ -22,6 +24,11 @@ var providerDataSources map[string]*schema.Resource
 
 // providerResources holds a map of all registered resources
 var providerResources map[string]*schema.Resource
+
+var (
+	sdkConfig *platformclientv2.Configuration
+	authErr   error
+)
 
 type registerTestInstance struct {
 	resourceMapMutex   sync.RWMutex
@@ -52,6 +59,10 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 // initTestResources initializes all test resources and data sources.
 func initTestResources() {
+	sdkConfig, authErr = gcloud.AuthorizeSdk()
+	if authErr != nil {
+		log.Fatalf("failed to authorize sdk for package outbound_campaign: %v", authErr)
+	}
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 

--- a/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_proxy.go
+++ b/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_proxy.go
@@ -3,7 +3,11 @@ package outbound_campaign
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"log"
+	gcloud "terraform-provider-genesyscloud/genesyscloud"
+	"time"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
 )
@@ -90,6 +94,36 @@ func (p *outboundCampaignProxy) updateOutboundCampaign(ctx context.Context, id s
 // deleteOutboundCampaign deletes a Genesys Cloud outbound campaign by Id
 func (p *outboundCampaignProxy) deleteOutboundCampaign(ctx context.Context, id string) (response *platformclientv2.APIResponse, err error) {
 	return p.deleteOutboundCampaignAttr(ctx, p, id)
+}
+
+// turnOffCampaign sets a campaign's campaign_status to 'off' before confirming the update using retry logic and get calls
+func (p *outboundCampaignProxy) turnOffCampaign(ctx context.Context, campaignId string) diag.Diagnostics {
+	log.Printf("Reading Outbound Campaign %s", campaignId)
+	outboundCampaign, _, getErr := p.getOutboundCampaignById(ctx, campaignId)
+	if getErr != nil {
+		return diag.Errorf("Failed to read Outbound Campaign %s: %s", campaignId, getErr)
+	}
+	log.Printf("Read Outbound Campaign %s", campaignId)
+
+	log.Printf("Updating campaign '%s' campaign_status to off", *outboundCampaign.Name)
+	if diagErr := updateOutboundCampaignStatus(ctx, campaignId, p, *outboundCampaign, "off"); diagErr != nil {
+		return diagErr
+	}
+	log.Printf("Updated campaign '%s'", *outboundCampaign.Name)
+
+	return gcloud.WithRetries(ctx, 30*time.Second, func() *retry.RetryError {
+		log.Printf("Reading Outbound Campaign %s to ensure campaign_status if 'off'", campaignId)
+		outboundCampaign, _, getErr := p.getOutboundCampaignById(ctx, campaignId)
+		if getErr != nil {
+			return retry.NonRetryableError(fmt.Errorf("failed to read Outbound Campaign %s: %s", campaignId, getErr))
+		}
+		log.Printf("Read Outbound Campaign %s", campaignId)
+		if *outboundCampaign.CampaignStatus != "off" {
+			return retry.RetryableError(fmt.Errorf("campaign %s campaign_status is still %s", campaignId, *outboundCampaign.CampaignStatus))
+		}
+		// Success
+		return nil
+	})
 }
 
 // createOutboundCampaignFn is an implementation function for creating a Genesys Cloud outbound campaign

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
@@ -64,8 +64,8 @@ func getAllAuthOutboundCampaign(ctx context.Context, clientConfig *platformclien
 
 // createOutboundCampaign is used by the outbound_campaign resource to create Genesys cloud outbound campaign
 func createOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	proxy := newOutboundCampaignProxy(sdkConfig)
+	clientConfig := meta.(*gcloud.ProviderMeta).ClientConfig
+	proxy := getOutboundCampaignProxy(clientConfig)
 	campaignStatus := d.Get("campaign_status").(string)
 
 	campaign := getOutboundCampaignFromResourceData(d)
@@ -95,8 +95,8 @@ func createOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta in
 
 // readOutboundCampaign is used by the outbound_campaign resource to read an outbound campaign from genesys cloud
 func readOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	proxy := newOutboundCampaignProxy(sdkConfig)
+	clientConfig := meta.(*gcloud.ProviderMeta).ClientConfig
+	proxy := getOutboundCampaignProxy(clientConfig)
 
 	log.Printf("Reading Outbound Campaign %s", d.Id())
 
@@ -156,8 +156,8 @@ func readOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta inte
 
 // updateOutboundCampaign is used by the outbound_campaign resource to update an outbound campaign in Genesys Cloud
 func updateOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	proxy := newOutboundCampaignProxy(sdkConfig)
+	clientConfig := meta.(*gcloud.ProviderMeta).ClientConfig
+	proxy := getOutboundCampaignProxy(clientConfig)
 	campaignStatus := d.Get("campaign_status").(string)
 
 	campaign := getOutboundCampaignFromResourceData(d)
@@ -180,38 +180,28 @@ func updateOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta in
 
 // deleteOutboundCampaign is used by the outbound_campaign resource to delete an outbound campaign from Genesys cloud
 func deleteOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
-	sdkConfig := meta.(*gcloud.ProviderMeta).ClientConfig
-	proxy := newOutboundCampaignProxy(sdkConfig)
+	clientConfig := meta.(*gcloud.ProviderMeta).ClientConfig
+	proxy := getOutboundCampaignProxy(clientConfig)
 
 	campaignStatus := d.Get("campaign_status").(string)
 
 	// Campaigns have to be turned off before they can be deleted
 	if campaignStatus != "off" {
-		diagErr := gcloud.RetryWhen(gcloud.IsStatus400, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
-			log.Printf("Turning off Outbound Campaign before deletion")
-			outboundCampaign, resp, getErr := proxy.getOutboundCampaignById(ctx, d.Id())
-			if getErr != nil {
-				return resp, diag.Errorf("Failed to read Outbound Campaign %s: %s", d.Id(), getErr)
-			}
-			// Handles updating the campaign based on what is set in ResourceData.campaign_status
-			diagErr := updateOutboundCampaignStatus(ctx, d.Id(), proxy, *outboundCampaign, "off")
-			if diagErr != nil {
-				return resp, diagErr
-			}
-			return resp, nil
-		})
-		if diagErr != nil {
+		log.Printf("Turning off Outbound Campaign before deletion")
+		if diagErr := proxy.turnOffCampaign(ctx, d.Id()); diagErr != nil {
 			return diagErr
 		}
-		// Give the campaign some time to turn off
-		time.Sleep(20 * time.Second)
 	}
+
+	log.Printf("Deleting Outbound Campaign %s", d.Id())
 	_, err := proxy.deleteOutboundCampaign(ctx, d.Id())
 	if err != nil {
 		return diag.Errorf("Failed to delete campaign %s: %s", d.Id(), err)
 	}
+	log.Printf("Deleted Outbound Campaign %s", d.Id())
 
 	return gcloud.WithRetries(ctx, 30*time.Second, func() *retry.RetryError {
+		log.Printf("Reading Outbound Campaign %s to confirm is has been deleted", d.Id())
 		_, resp, err := proxy.getOutboundCampaignById(ctx, d.Id())
 		if err != nil {
 			if gcloud.IsStatus404(resp) {
@@ -221,7 +211,6 @@ func deleteOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta in
 			}
 			return retry.NonRetryableError(fmt.Errorf("Error deleting Outbound Campaign %s: %s", d.Id(), err))
 		}
-
 		return retry.RetryableError(fmt.Errorf("Outbound Campaign %s still exists", d.Id()))
 	})
 }

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
@@ -3,17 +3,16 @@ package outbound_campaign
 import (
 	"context"
 	"fmt"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
 	"log"
 	"strconv"
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	"terraform-provider-genesyscloud/genesyscloud/outbound"
 	obContactList "terraform-provider-genesyscloud/genesyscloud/outbound_contact_list"
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
-
-	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_sequence/data_source_genesyscloud_outbound_sequence_test.go
+++ b/genesyscloud/outbound_sequence/data_source_genesyscloud_outbound_sequence_test.go
@@ -31,15 +31,8 @@ func TestAccDataSourceOutboundSequence(t *testing.T) {
 		emergencyNumber       = "+13128451429"
 	)
 
-	// necessary to avoid errors during site creation
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = edgeSite.DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err := edgeSite.DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s: %v", emergencyNumber, err)
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_init_test.go
+++ b/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_init_test.go
@@ -1,6 +1,8 @@
 package outbound_sequence
 
 import (
+	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
+	"log"
 	"sync"
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	"terraform-provider-genesyscloud/genesyscloud/outbound"
@@ -22,6 +24,11 @@ var providerDataSources map[string]*schema.Resource
 
 // providerResources holds a map of all registered resources
 var providerResources map[string]*schema.Resource
+
+var (
+	sdkConfig *platformclientv2.Configuration
+	authErr   error
+)
 
 type registerTestInstance struct {
 	resourceMapMutex   sync.RWMutex
@@ -54,6 +61,11 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 // initTestResources initializes all test resources and data sources.
 func initTestResources() {
+	sdkConfig, authErr = gcloud.AuthorizeSdk()
+	if authErr != nil {
+		log.Fatalf("failed to authorize sdk for the package outbound_sequence: %v", authErr)
+	}
+
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_test.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_test.go
@@ -16,7 +16,6 @@ import (
 )
 
 func TestAccResourceOutboundSequence(t *testing.T) {
-
 	t.Parallel()
 	var (
 		// Sequence
@@ -35,15 +34,8 @@ func TestAccResourceOutboundSequence(t *testing.T) {
 		emergencyNumber       = "+13172947329"
 	)
 
-	// necessary to avoid errors during site creation
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = edgeSite.DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err := edgeSite.DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s: %v", emergencyNumber, err)
 	}
 
 	resource.Test(t, resource.TestCase{
@@ -146,15 +138,8 @@ func TestAccResourceOutboundSequenceStatus(t *testing.T) {
 		emergencyNumber       = "+13172947330"
 	)
 
-	// necessary to avoid errors during site creation
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = edgeSite.DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err := edgeSite.DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s: %v", emergencyNumber, err)
 	}
 
 	resource.Test(t, resource.TestCase{

--- a/genesyscloud/station/data_source_genesyscloud_station_test.go
+++ b/genesyscloud/station/data_source_genesyscloud_station_test.go
@@ -33,11 +33,6 @@ func TestAccDataSourceStation(t *testing.T) {
 		stationDataRes = "station1234"
 	)
 
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	defaultSiteId, err := edgeSite.GetOrganizationDefaultSiteId()
 	if err != nil {
 		t.Fatal(err)

--- a/genesyscloud/telephony_providers_edges_phone/data_source_genesyscloud_telephony_providers_edges_phone_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/data_source_genesyscloud_telephony_providers_edges_phone_test.go
@@ -32,11 +32,6 @@ func TestAccDataSourcePhone(t *testing.T) {
 		userDepartment = "Development"
 	)
 
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	defaultSiteId, err := edgeSite.GetOrganizationDefaultSiteId()
 	if err != nil {
 		t.Fatal(err)

--- a/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
@@ -1,13 +1,14 @@
 package telephony_providers_edges_phone
 
 import (
+	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
+	"log"
 	"sync"
-	"testing"
-
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	didPool "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_did_pool"
 	phoneBaseSettings "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_phonebasesettings"
 	edgeSite "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
+	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -19,11 +20,16 @@ import (
    Please make sure you register ALL resources and data sources your test cases will use.
 */
 
-// providerDataSources holds a map of all registered sites
-var providerDataSources map[string]*schema.Resource
+var (
+	// providerDataSources holds a map of all registered sites
+	providerDataSources map[string]*schema.Resource
 
-// providerResources holds a map of all registered sites
-var providerResources map[string]*schema.Resource
+	// providerResources holds a map of all registered sites
+	providerResources map[string]*schema.Resource
+
+	sdkConfig *platformclientv2.Configuration
+	authErr   error
+)
 
 type registerTestInstance struct {
 	resourceMapMutex   sync.RWMutex
@@ -54,6 +60,10 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 // initTestResources initializes all test resources and data sources.
 func initTestResources() {
+	sdkConfig, authErr = gcloud.AuthorizeSdk()
+	if authErr != nil {
+		log.Fatalf("failed to authorize sdk for the package telephony_providers_edges_phone: %v", authErr)
+	}
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
@@ -63,11 +63,6 @@ func TestAccResourcePhoneBasic(t *testing.T) {
 		"",               // No certs
 	)
 
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	siteId, err := edgeSite.GetOrganizationDefaultSiteId()
 	if err != nil {
 		t.Fatal(err)
@@ -181,17 +176,13 @@ func TestAccResourcePhoneBasic(t *testing.T) {
 func TestAccResourcePhoneStandalone(t *testing.T) {
 	t.Parallel()
 	number := "+14175538114"
-	platformConfig, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
 	// TODO: Use did pool resource inside config once cyclic dependency issue is resolved between genesyscloud and did_pools package
-	didPoolId, err := createDidPoolForEdgesPhoneTest(platformConfig, number)
+	didPoolId, err := createDidPoolForEdgesPhoneTest(sdkConfig, number)
 	if err != nil {
 		t.Fatal(err)
 	}
 	defer func() {
-		if err := deleteDidPool(platformConfig, didPoolId); err != nil {
+		if err := deleteDidPool(sdkConfig, didPoolId); err != nil {
 			t.Logf("failed to delete did pool '%s': %v", didPoolId, err)
 		}
 	}()
@@ -206,8 +197,8 @@ func TestAccResourcePhoneStandalone(t *testing.T) {
 	locationRes := "test-location"
 
 	emergencyNumber := "+13173114121"
-	if err := edgeSite.DeleteLocationWithNumber(emergencyNumber); err != nil {
-		t.Log(err)
+	if err = edgeSite.DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s: %v", emergencyNumber, err)
 	}
 
 	locationConfig := gcloud.GenerateLocationResource(

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_init_test.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_init_test.go
@@ -1,6 +1,7 @@
 package telephony_providers_edges_site
 
 import (
+	"log"
 	"sync"
 	"testing"
 
@@ -49,6 +50,11 @@ func (r *registerTestInstance) registerTestDataSources() {
 
 // initTestResources initializes all test resources and data sources.
 func initTestResources() {
+	sdkConfig, authErr = gcloud.AuthorizeSdk()
+	if authErr != nil {
+		log.Fatalf("failed to authorize sdk: %v", authErr)
+	}
+
 	providerDataSources = make(map[string]*schema.Resource)
 	providerResources = make(map[string]*schema.Resource)
 

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
@@ -3,6 +3,7 @@ package telephony_providers_edges_site
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
 
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
@@ -18,6 +19,12 @@ resource_genesyscloud_telephony_providers_edges_site_schema.go should hold four 
 4.  The resource exporter configuration for the telephony_providers_edges_site exporter.
 */
 const resourceName = "genesyscloud_telephony_providers_edges_site"
+
+// used in sdk authorization for tests
+var (
+	sdkConfig *platformclientv2.Configuration
+	authErr   error
+)
 
 var (
 	// This is outside the ResourceSite because it is used in a utility function.

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
@@ -9,17 +9,12 @@ import (
 	"time"
 
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
-	telephony "terraform-provider-genesyscloud/genesyscloud/telephony"
+	"terraform-provider-genesyscloud/genesyscloud/telephony"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/mypurecloud/platform-client-sdk-go/v119/platformclientv2"
-)
-
-var (
-	// Used for testing the default site functionality. Track so it can be restored after test
-	originalSiteId string
 )
 
 func TestAccResourceSite(t *testing.T) {
@@ -586,7 +581,7 @@ func TestAccResourceSiteDefaultSite(t *testing.T) {
 		ProviderFactories: gcloud.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{
-				// Store the original default site so it can be restored later
+				// Store the original default site, so it can be restored later
 				PreConfig: func() {
 					originalSiteId, err = GetOrganizationDefaultSiteId()
 					if err != nil {
@@ -660,7 +655,7 @@ func testVerifySitesDestroyed(state *terraform.State) error {
 			continue
 		} else {
 			// Unexpected error
-			return fmt.Errorf("Unexpected error: %s", err)
+			return fmt.Errorf("unexpected error: %s", err)
 		}
 	}
 	// Success. All sites destroyed

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
@@ -45,15 +45,9 @@ func TestAccResourceSite(t *testing.T) {
 		locationRes = "test-location1"
 	)
 
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	emergencyNumber := "+13173124741"
-	err = DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err := DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s: %v", emergencyNumber, err)
 	}
 
 	location := gcloud.GenerateLocationResource(
@@ -181,15 +175,9 @@ func TestAccResourceSiteNumberPlans(t *testing.T) {
 		locationRes = "test-location1"
 	)
 
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	emergencyNumber := "+13173124742"
-	err = DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err := DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s: %v", emergencyNumber, err)
 	}
 
 	location := gcloud.GenerateLocationResource(
@@ -382,15 +370,9 @@ func TestAccResourceSiteOutboundRoutes(t *testing.T) {
 		locationRes = "test-location1"
 	)
 
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	emergencyNumber := "+13173124743"
-	err = DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err := DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s, %v", emergencyNumber, err)
 	}
 
 	location := gcloud.GenerateLocationResource(
@@ -573,20 +555,14 @@ func TestAccResourceSiteDefaultSite(t *testing.T) {
 		locationRes = "test-location1"
 	)
 
-	_, err := gcloud.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	originalSiteId, err = GetOrganizationDefaultSiteId()
+	originalSiteId, err := GetOrganizationDefaultSiteId()
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	emergencyNumber := "+13173124744"
-	err = DeleteLocationWithNumber(emergencyNumber)
-	if err != nil {
-		t.Fatal(err)
+	if err = DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s, %v", emergencyNumber, err)
 	}
 
 	location := gcloud.GenerateLocationResource(

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
@@ -538,10 +538,9 @@ func GenerateSiteResourceWithCustomAttrs(
 	`, siteRes, name, description, locationId, mediaModel, mediaRegionsUseLatencyBased, mediaRegions, callerId, callerName, strings.Join(otherAttrs, "\n"))
 }
 
-// DeleteLocationWithNumber is a test utiliy function to delete site and location with the provided emergency number
-func DeleteLocationWithNumber(emergencyNumber string) error {
-	sdkConfig := platformclientv2.GetDefaultConfiguration()
-	locationsAPI := platformclientv2.NewLocationsApiWithConfig(sdkConfig)
+// DeleteLocationWithNumber is a test utility function to delete site and location with the provided emergency number
+func DeleteLocationWithNumber(emergencyNumber string, config *platformclientv2.Configuration) error {
+	locationsAPI := platformclientv2.NewLocationsApiWithConfig(config)
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
@@ -556,6 +555,9 @@ func DeleteLocationWithNumber(emergencyNumber string) error {
 
 		for _, location := range *locations.Entities {
 			if location.EmergencyNumber != nil {
+				if location.EmergencyNumber.E164 == nil {
+					continue
+				}
 				if strings.Contains(*location.EmergencyNumber.E164, emergencyNumber) {
 					err := deleteSiteWithLocationId(*location.Id)
 					if err != nil {
@@ -575,7 +577,6 @@ func DeleteLocationWithNumber(emergencyNumber string) error {
 // deleteSiteWithLocationId is a test utility function that will
 // delete a site with the provided location id
 func deleteSiteWithLocationId(locationId string) error {
-	sdkConfig := platformclientv2.GetDefaultConfiguration()
 	edgesAPI := platformclientv2.NewTelephonyProvidersEdgeApiWithConfig(sdkConfig)
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
@@ -601,9 +602,8 @@ func deleteSiteWithLocationId(locationId string) error {
 	}
 }
 
-// getOrganizationDefaultSite is a test utiliy function to get the default site ID of the org
+// GetOrganizationDefaultSiteId is a test utiliy function to get the default site ID of the org
 func GetOrganizationDefaultSiteId() (siteId string, err error) {
-	sdkConfig := platformclientv2.GetDefaultConfiguration()
 	organizationApi := platformclientv2.NewOrganizationApiWithConfig(sdkConfig)
 
 	org, _, err := organizationApi.GetOrganizationsMe()


### PR DESCRIPTION
This is to fix outbound test failures like:

```log
 resource_genesyscloud_outbound_sequence_test.go:41: POST https://login.mypurecloud.com/oauth/token giving up after 1 attempt(s): Post "https://login.mypurecloud.com/oauth/token": net/http: cannot rewind body after connection loss
```

I suspect this is occurring when we try to call the function `AuthorizeSdk` inside the acceptance tests. Instead, this function is being called once from TestMain to save the config to a package-level variable on initialisation of the package, as is already done for the genesyscloud package.  