### PR TITLE
Feat/Adding label support to routing_utilization

### DIFF
--- a/docs/resources/routing_utilization.md
+++ b/docs/resources/routing_utilization.md
@@ -18,7 +18,7 @@ The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Cl
 ## Example Usage
 
 ```terraform
-resource "genesyscloud_routing_utilization" "org-utililzation" {
+resource "genesyscloud_routing_utilization" "org-utilization" {
   call {
     maximum_capacity = 1
     include_non_acd  = true
@@ -43,6 +43,15 @@ resource "genesyscloud_routing_utilization" "org-utililzation" {
     include_non_acd           = false
     interruptible_media_types = ["call", "chat"]
   }
+  label_utilizations {
+    label_id         = genesyscloud_routing_utilization_label.red_label.id
+    maximum_capacity = 4
+  }
+  label_utilizations {
+    label_id               = genesyscloud_routing_utilization_label.blue_label.id
+    maximum_capacity       = 3
+    interrupting_label_ids = [genesyscloud_routing_utilization_label.red_label.id]
+  }
 }
 ```
 
@@ -55,6 +64,7 @@ resource "genesyscloud_routing_utilization" "org-utililzation" {
 - `callback` (Block List, Max: 1) Callback media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--callback))
 - `chat` (Block List, Max: 1) Chat media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--chat))
 - `email` (Block List, Max: 1) Email media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--email))
+- `label_utilizations` (Block List) Label utilization settings. If not set, default label settings will be applied. This is in PREVIEW and should not be used unless the feature is available to your organization. (see [below for nested schema](#nestedblock--label_utilizations))
 - `message` (Block List, Max: 1) Message media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--message))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 
@@ -112,6 +122,19 @@ Optional:
 
 - `include_non_acd` (Boolean) Block this media type when on a non-ACD conversation. Defaults to `false`.
 - `interruptible_media_types` (Set of String) Set of other media types that can interrupt this media type (call | callback | chat | email | message).
+
+
+<a id="nestedblock--label_utilizations"></a>
+### Nested Schema for `label_utilizations`
+
+Required:
+
+- `label_id` (String) Id of the label being configured.
+- `maximum_capacity` (Number) Maximum capacity of conversations with this label. Value must be between 0 and 25.
+
+Optional:
+
+- `interrupting_label_ids` (Set of String) Set of other labels that can interrupt this label.
 
 
 <a id="nestedblock--message"></a>

--- a/examples/resources/genesyscloud_routing_utilization/resource.tf
+++ b/examples/resources/genesyscloud_routing_utilization/resource.tf
@@ -1,4 +1,4 @@
-resource "genesyscloud_routing_utilization" "org-utililzation" {
+resource "genesyscloud_routing_utilization" "org-utilization" {
   call {
     maximum_capacity = 1
     include_non_acd  = true
@@ -22,5 +22,14 @@ resource "genesyscloud_routing_utilization" "org-utililzation" {
     maximum_capacity          = 4
     include_non_acd           = false
     interruptible_media_types = ["call", "chat"]
+  }
+  label_utilizations {
+    label_id                  = genesyscloud_routing_utilization_label.red_label.id
+    maximum_capacity          = 4
+  }
+  label_utilizations {
+    label_id                  = genesyscloud_routing_utilization_label.blue_label.id
+    maximum_capacity          = 3
+    interrupting_label_ids    = [genesyscloud_routing_utilization_label.red_label.id]
   }
 }

--- a/genesyscloud/data_source_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/data_source_genesyscloud_routing_utilization_label_test.go
@@ -28,6 +28,7 @@ func TestAccDataSourceRoutingUtilizationLabel(t *testing.T) {
 				Config: GenerateRoutingUtilizationLabelResource(
 					resourceName,
 					labelName,
+					"",
 				) + generateRoutingUtilizationLabelDataSource(dataSourceName, labelName, "genesyscloud_routing_utilization_label."+resourceName),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.genesyscloud_routing_utilization_label."+dataSourceName, "id", "genesyscloud_routing_utilization_label."+resourceName, "id"),

--- a/genesyscloud/resource_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_utilization_label_test.go
@@ -31,6 +31,7 @@ func TestAccResourceRoutingUtilizationLabelBasic(t *testing.T) {
 				Config: GenerateRoutingUtilizationLabelResource(
 					resourceName,
 					labelName,
+					"",
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_utilization_label."+resourceName, "name", labelName),
@@ -41,6 +42,7 @@ func TestAccResourceRoutingUtilizationLabelBasic(t *testing.T) {
 				Config: GenerateRoutingUtilizationLabelResource(
 					resourceName,
 					updatedLabelName,
+					"",
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_utilization_label."+resourceName, "name", updatedLabelName),
@@ -57,11 +59,18 @@ func TestAccResourceRoutingUtilizationLabelBasic(t *testing.T) {
 	})
 }
 
-func GenerateRoutingUtilizationLabelResource(resourceID string, name string) string {
+func GenerateRoutingUtilizationLabelResource(resourceID string, name string, dependsOnResource string) string {
+	dependsOn := ""
+
+	if dependsOnResource != "" {
+		dependsOn = fmt.Sprintf("depends_on=[genesyscloud_routing_utilization_label.%s]", dependsOnResource)
+	}
+
 	return fmt.Sprintf(`resource "genesyscloud_routing_utilization_label" "%s" {
 		name = "%s"
+		%s
 	}
-	`, resourceID, name)
+	`, resourceID, name, dependsOn)
 }
 
 func validateTestLabelDestroyed(state *terraform.State) error {

--- a/genesyscloud/resource_genesyscloud_routing_utilization_test.go
+++ b/genesyscloud/resource_genesyscloud_routing_utilization_test.go
@@ -6,10 +6,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestAccResourceRoutingUtilization(t *testing.T) {
+func TestAccResourceBasicRoutingUtilization(t *testing.T) {
 	t.Parallel()
 	var (
 		maxCapacity1  = "3"
@@ -86,6 +88,154 @@ func TestAccResourceRoutingUtilization(t *testing.T) {
 	})
 }
 
+func TestAccResourceRoutingUtilizationWithLabels(t *testing.T) {
+	var (
+		maxCapacity1  = "3"
+		maxCapacity2  = "4"
+		utilTypeCall  = "call"
+		utilTypeEmail = "email"
+
+		redLabelResource   = "label_red"
+		blueLabelResource  = "label_blue"
+		greenLabelResource = "label_green"
+		redLabelName       = "Terraform Red " + uuid.NewString()
+		blueLabelName      = "Terraform Blue " + uuid.NewString()
+		greenLabelName     = "Terraform Green" + uuid.NewString()
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			TestAccPreCheck(t)
+			if err := checkIfLabelsAreEnabled(); err != nil {
+				t.Skipf("%v", err) // be sure to skip the test and not fail it
+			}
+		},
+		ProviderFactories: GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Create
+				Config: GenerateRoutingUtilizationLabelResource(redLabelResource, redLabelName, "") +
+					GenerateRoutingUtilizationLabelResource(blueLabelResource, blueLabelName, redLabelResource) +
+					GenerateRoutingUtilizationLabelResource(greenLabelResource, greenLabelName, blueLabelResource) +
+					generateRoutingUtilizationResource(
+						generateRoutingUtilMediaType("call", maxCapacity1, FalseValue),
+						generateRoutingUtilMediaType("callback", maxCapacity1, FalseValue),
+						generateRoutingUtilMediaType("chat", maxCapacity1, FalseValue),
+						generateRoutingUtilMediaType("email", maxCapacity1, FalseValue),
+						generateRoutingUtilMediaType("message", maxCapacity1, FalseValue),
+						generateLabelUtilization(redLabelResource, maxCapacity1),
+						generateLabelUtilization(blueLabelResource, maxCapacity1, redLabelResource),
+					),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "call.0.maximum_capacity", maxCapacity1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "call.0.include_non_acd", FalseValue),
+					resource.TestCheckNoResourceAttr("genesyscloud_routing_utilization.routing-util", "call.0.interruptible_media_types"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "callback.0.maximum_capacity", maxCapacity1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "callback.0.include_non_acd", FalseValue),
+					resource.TestCheckNoResourceAttr("genesyscloud_routing_utilization.routing-util", "callback.0.interruptible_media_types"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "chat.0.maximum_capacity", maxCapacity1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "chat.0.include_non_acd", FalseValue),
+					resource.TestCheckNoResourceAttr("genesyscloud_routing_utilization.routing-util", "chat.0.interruptible_media_types"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "email.0.maximum_capacity", maxCapacity1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "email.0.include_non_acd", FalseValue),
+					resource.TestCheckNoResourceAttr("genesyscloud_routing_utilization.routing-util", "email.0.interruptible_media_types"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "message.0.maximum_capacity", maxCapacity1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "message.0.include_non_acd", FalseValue),
+					resource.TestCheckNoResourceAttr("genesyscloud_routing_utilization.routing-util", "message.0.interruptible_media_types"),
+					resource.TestCheckResourceAttrSet("genesyscloud_routing_utilization.routing-util", "label_utilizations.0.label_id"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "label_utilizations.0.maximum_capacity", maxCapacity1),
+					resource.TestCheckResourceAttrSet("genesyscloud_routing_utilization.routing-util", "label_utilizations.1.label_id"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "label_utilizations.1.maximum_capacity", maxCapacity1),
+				),
+			},
+			{
+				// Update with a new max capacities and interruptible media types
+				Config: GenerateRoutingUtilizationLabelResource(redLabelResource, redLabelName, "") +
+					GenerateRoutingUtilizationLabelResource(blueLabelResource, blueLabelName, redLabelResource) +
+					GenerateRoutingUtilizationLabelResource(greenLabelResource, greenLabelName, blueLabelResource) +
+					generateRoutingUtilizationResource(
+						generateRoutingUtilMediaType("call", maxCapacity2, TrueValue, strconv.Quote(utilTypeEmail)),
+						generateRoutingUtilMediaType("callback", maxCapacity2, TrueValue, strconv.Quote(utilTypeCall)),
+						generateRoutingUtilMediaType("chat", maxCapacity2, TrueValue, strconv.Quote(utilTypeCall)),
+						generateRoutingUtilMediaType("email", maxCapacity2, TrueValue, strconv.Quote(utilTypeCall)),
+						generateRoutingUtilMediaType("message", maxCapacity2, TrueValue, strconv.Quote(utilTypeCall)),
+						generateLabelUtilization(redLabelResource, maxCapacity2),
+						generateLabelUtilization(blueLabelResource, maxCapacity2, redLabelResource),
+					),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "call.0.maximum_capacity", maxCapacity2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "call.0.include_non_acd", TrueValue),
+					ValidateStringInArray("genesyscloud_routing_utilization.routing-util", "call.0.interruptible_media_types", utilTypeEmail),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "callback.0.maximum_capacity", maxCapacity2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "callback.0.include_non_acd", TrueValue),
+					ValidateStringInArray("genesyscloud_routing_utilization.routing-util", "callback.0.interruptible_media_types", utilTypeCall),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "chat.0.maximum_capacity", maxCapacity2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "chat.0.include_non_acd", TrueValue),
+					ValidateStringInArray("genesyscloud_routing_utilization.routing-util", "chat.0.interruptible_media_types", utilTypeCall),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "email.0.maximum_capacity", maxCapacity2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "email.0.include_non_acd", TrueValue),
+					ValidateStringInArray("genesyscloud_routing_utilization.routing-util", "email.0.interruptible_media_types", utilTypeCall),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "message.0.maximum_capacity", maxCapacity2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "message.0.include_non_acd", TrueValue),
+					ValidateStringInArray("genesyscloud_routing_utilization.routing-util", "message.0.interruptible_media_types", utilTypeCall),
+					resource.TestCheckResourceAttrSet("genesyscloud_routing_utilization.routing-util", "label_utilizations.0.label_id"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "label_utilizations.0.maximum_capacity", maxCapacity2),
+					resource.TestCheckResourceAttrSet("genesyscloud_routing_utilization.routing-util", "label_utilizations.1.label_id"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "label_utilizations.1.maximum_capacity", maxCapacity2),
+				),
+			},
+			{
+				// Import/Read
+				ResourceName: "genesyscloud_routing_utilization.routing-util",
+				ImportState:  true,
+				ImportStateCheck: func(s []*terraform.InstanceState) error {
+					// When importing, there's no previous state, so no label utilizations are added to the state
+					if len(s) != 1 {
+						return fmt.Errorf("expected 1 state: %#v", s)
+					}
+
+					routingUtilization := s[0]
+					errors := make([]string, 0)
+
+					assertAttributeEquals(routingUtilization, "", "", &errors)
+					assertAttributeEquals(routingUtilization, "call.0.include_non_acd", "true", &errors)
+					assertAttributeEquals(routingUtilization, "call.0.interruptible_media_types.0", "email", &errors)
+					assertAttributeEquals(routingUtilization, "call.0.maximum_capacity", maxCapacity2, &errors)
+					assertAttributeEquals(routingUtilization, "callback.0.include_non_acd", "true", &errors)
+					assertAttributeEquals(routingUtilization, "callback.0.interruptible_media_types.0", "call", &errors)
+					assertAttributeEquals(routingUtilization, "callback.0.maximum_capacity", maxCapacity2, &errors)
+					assertAttributeEquals(routingUtilization, "chat.0.include_non_acd", "true", &errors)
+					assertAttributeEquals(routingUtilization, "chat.0.interruptible_media_types.0", "call", &errors)
+					assertAttributeEquals(routingUtilization, "chat.0.maximum_capacity", maxCapacity2, &errors)
+					assertAttributeEquals(routingUtilization, "email.0.include_non_acd", "true", &errors)
+					assertAttributeEquals(routingUtilization, "email.0.interruptible_media_types.0", "call", &errors)
+					assertAttributeEquals(routingUtilization, "email.0.maximum_capacity", maxCapacity2, &errors)
+					assertAttributeEquals(routingUtilization, "message.0.include_non_acd", "true", &errors)
+					assertAttributeEquals(routingUtilization, "message.0.interruptible_media_types.0", "call", &errors)
+					assertAttributeEquals(routingUtilization, "message.0.maximum_capacity", maxCapacity2, &errors)
+
+					numberOfLabelUtilizations, _ := strconv.Atoi(routingUtilization.Attributes["label_utilizations.#"])
+					if numberOfLabelUtilizations != 0 {
+						errors = append(errors, fmt.Sprintf("expected no label_utilizations, found %s", routingUtilization.Attributes["label_utilizations.#"]))
+					}
+
+					if len(errors) > 0 {
+						return fmt.Errorf(strings.Join(errors[:], "\n"))
+					}
+
+					return nil
+				},
+			},
+		},
+	})
+}
+
+func assertAttributeEquals(state *terraform.InstanceState, attributeName, expectedValue string, errors *[]string) {
+	if state.Attributes[attributeName] != expectedValue {
+		*errors = append(*errors, fmt.Sprintf("expected %s to be %s, actual: %s", attributeName, expectedValue, state.Attributes[attributeName]))
+	}
+}
+
 func generateRoutingUtilMediaType(
 	mediaType string,
 	maxCapacity string,
@@ -99,9 +249,27 @@ func generateRoutingUtilMediaType(
 	`, mediaType, maxCapacity, includeNonAcd, strings.Join(interruptTypes, ","))
 }
 
-func generateRoutingUtilizationResource(mediaTypes ...string) string {
+func generateLabelUtilization(
+	labelResource string,
+	maxCapacity string,
+	interruptingLabelResourceNames ...string) string {
+
+	interruptingLabelResources := make([]string, 0)
+	for _, resourceName := range interruptingLabelResourceNames {
+		interruptingLabelResources = append(interruptingLabelResources, "genesyscloud_routing_utilization_label."+resourceName+".id")
+	}
+
+	return fmt.Sprintf(`label_utilizations {
+		label_id = genesyscloud_routing_utilization_label.%s.id
+		maximum_capacity = %s
+		interrupting_label_ids = [%s]
+	}
+	`, labelResource, maxCapacity, strings.Join(interruptingLabelResources, ","))
+}
+
+func generateRoutingUtilizationResource(attributes ...string) string {
 	return fmt.Sprintf(`resource "genesyscloud_routing_utilization" "routing-util" {
 		%s
 	}
-	`, strings.Join(mediaTypes, "\n"))
+	`, strings.Join(attributes, "\n"))
 }

--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -1043,7 +1043,7 @@ func readUserRoutingUtilization(d *schema.ResourceData, usersAPI *platformclient
 			allSettings := map[string]interface{}{}
 			for sdkType, schemaType := range utilizationMediaTypes {
 				if mediaSettings, ok := (*settings.Utilization)[sdkType]; ok {
-					allSettings[schemaType] = flattenUtilizationSetting(mediaSettings)
+					allSettings[schemaType] = flattenUtilizationMediaSetting(mediaSettings)
 				}
 			}
 			d.Set("routing_utilization", []interface{}{allSettings})
@@ -1349,6 +1349,20 @@ func GenerateUserResource(
 		certifications = [%s]
 	}
 	`, resourceID, email, name, state, title, department, manager, acdAutoAnswer, profileSkills, certifications)
+}
+
+func flattenUtilizationMediaSetting(settings platformclientv2.Mediautilization) []interface{} {
+	settingsMap := make(map[string]interface{})
+	if settings.MaximumCapacity != nil {
+		settingsMap["maximum_capacity"] = *settings.MaximumCapacity
+	}
+	if settings.InterruptableMediaTypes != nil {
+		settingsMap["interruptible_media_types"] = lists.StringListToSet(*settings.InterruptableMediaTypes)
+	}
+	if settings.IncludeNonAcd != nil {
+		settingsMap["include_non_acd"] = *settings.IncludeNonAcd
+	}
+	return []interface{}{settingsMap}
 }
 
 func GenerateUserWithCustomAttrs(resourceID string, email string, name string, attrs ...string) string {


### PR DESCRIPTION
This allows configuring label utilization in the Org utilization (routing_utilization resource).

This is one I had spoken to John Carnell about, since it uses a field that's not public yet, so I had to call the api directly instead of using the existing platform-go-sdk call. It's in my to do list to rework that call once the field is public.

One complicated point in this PR involves how OrgUtilization works in the service that owns it. You can have 10 labels in system, configure only 2 of them, for example, and the response will contain all 10 labels (2 with the custom configuration + 8 with default config).

Translating that to terraform would mean that the configured resource has 2 label_utilizations, but the returned resource has 10...It took me a lot of trouble to get that working here for OrgUtilization, but the same concept will apply to my next PR (for AgentUtilization), and it did not work there at all. It really doesn't like the output not matching the input...

So I just removed the extra labels from the response and everything works. So if you configure 2, the resource will have 2, even if the actual thing in the service has all 10.

I don't know how y'all feel about that, so I'm pointing it out in this description.

I look forward to seeing your feedback. Thanks.