### PR TITLE
DEVTOOLING-424 Fix

### DIFF
--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
@@ -868,5 +868,8 @@ func WebDeploymentConfigurationExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc:   provider.GetAllWithPooledClient(getAllWebDeploymentConfigurations),
 		ExcludedAttributes: []string{"version"},
+		RemoveIfMissing: map[string][]string{
+			"authentication_settings": {"integration_id"},
+		},
 	}
 }


### PR DESCRIPTION
Don't export the `authentication_settings` block in the web config resource if an `integration_id` field is missing