### PR TITLE
Adding schedule groups back to genesyscloud test provider

### DIFF
--- a/genesyscloud/resource_genesyscloud_init_test.go
+++ b/genesyscloud/resource_genesyscloud_init_test.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"sync"
 	"terraform-provider-genesyscloud/genesyscloud/architect_flow"
+	archScheduleGroup "terraform-provider-genesyscloud/genesyscloud/architect_schedulegroups"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"testing"
 
@@ -67,6 +68,7 @@ func (r *registerTestInstance) registerTestResources() {
 	providerResources["genesyscloud_routing_wrapupcode"] = ResourceRoutingWrapupCode()
 	providerResources["genesyscloud_user"] = ResourceUser()
 	providerResources["genesyscloud_widget_deployment"] = ResourceWidgetDeployment()
+	providerResources["genesyscloud_architect_schedulegroups"] = archScheduleGroup.ResourceArchitectSchedulegroups()
 }
 
 func (r *registerTestInstance) registerTestDataSources() {


### PR DESCRIPTION
Schedule groups are used in the journey action map tests, so this resource needed to be added back to the provider for the genesyscloud package tests. This didn't cause any cyclic issues thanks to the big refactoring done recently @carnellj-genesys 🙌