### PR TITLE
no-jira: Commenting out goreleaser temporarily to run jenkins build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing
-    - go mod tidy
+    #- go mod tidy
 builds:
 - env:
     # goreleaser does not work with CGO, it could also complicate


### PR DESCRIPTION
The error produced by the jenkins release job:

```
• setting defaults
• running before hooks
  • running                                        hook=go mod tidy
⨯ release failed after 0s                  error=hook failed: shell: 'go mod tidy': exit status 1: go: errors parsing go.mod:
/var/build/workspace/build-platform-cxascode/go.mod:5: unknown directive: toolchain
```

If this doesn't fix the jenkins build, we'll have to revert a recent dependabot PR that introduced this "toolchain" line