### PR TITLE
No jira: Go 1.22

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
         id: go
 
       - name: Setup Terraform CLI

--- a/.github/workflows/test-workflow.yml
+++ b/.github/workflows/test-workflow.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.22'
         id: go
 
       - name: Setup Terraform CLI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version: '1.22'
       id: go
 
     - name: Check out code into the Go module directory

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module terraform-provider-genesyscloud
 
-go 1.21
-
-toolchain go1.21.4
+go 1.22
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
We had an issue with the release in which goreleaser said it did not recognise `toolchain` in the go.mod file. I suspect this is because goreleaser runs on a version of go older than 1.21; when toolchain was introduced. I tried to configure goreleaser to use a specific go version but as far as I'm aware, that's not possible.

I tried going back to 1.20, but there was some dependency in the project that was forcing the Go version to update to 1.21 and add the toolchain line, and I couldn't figure out which dependency it was or how to stop the automatic go version upgrade (it would happen anytime any `go` command was run e.g. `go mod tidy`). 

In the end, updating the go version the other way, up to 1.22, fixed the problem and the toolchain line isn't automatically being added anymore. Hopefully this will allow goreleaser to run in the jenkins build. 