### PR TITLE
Fix DEVTOOLING-472

### DIFF
--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -209,11 +209,6 @@ func ResourceUser() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
-		Timeouts: &schema.ResourceTimeout{
-			Create: schema.DefaultTimeout(5 * time.Second),
-			Update: schema.DefaultTimeout(5 * time.Second),
-			Read:   schema.DefaultTimeout(5 * time.Second),
-		},
 		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			"email": {


### PR DESCRIPTION
Remove really low timeout configuration for genesyscloud_user resource. It causes context deadline exceeded errors.
Introduced here: https://github.com/MyPureCloud/terraform-provider-genesyscloud/pull/809/files#diff-7ed088e59ad27d5e4856608e5c008a2bf9fe469e5e54fb3ca534f2623c32d0f6R209