### PR TITLE
Fixes DEVTOOLING-497 self-referential reply_email_address.route_id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,7 +28,7 @@ website/node_modules
 terraform-provider-genesyscloud
 .env
 .vscode
-
+**/true
 website/vendor
 vendor/
 

--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -48,18 +48,18 @@ resource "genesyscloud_routing_email_route" "support-route" {
 ### Required
 
 - `domain_id` (String) ID of the routing domain such as: 'example.com'. Changing the domain_id attribute will cause the email_route object to be dropped and recreated with a new ID.
-- `from_email` (String) The sender email to use for outgoing replies.
 - `from_name` (String) The sender name to use for outgoing replies.
 - `pattern` (String) The search pattern that the mailbox name should match.
 
 ### Optional
 
-- `auto_bcc` (Block Set) The recipients that should be automatically blind copied on outbound emails associated with this route. (see [below for nested schema](#nestedblock--auto_bcc))
+- `auto_bcc` (Block Set) The recipients that should be automatically blind copied on outbound emails associated with this route. This should not be set if reply_email_address is specified. (see [below for nested schema](#nestedblock--auto_bcc))
 - `flow_id` (String) The flow to use for processing the email. This should not be set if a queue_id is specified.
+- `from_email` (String) The sender email to use for outgoing replies. This should not be set if reply_email_address is specified.
 - `language_id` (String) The language to use for routing.
 - `priority` (Number) The priority to use for routing.
 - `queue_id` (String) The queue to route the emails to. This should not be set if a flow_id is specified.
-- `reply_email_address` (Block List, Max: 1) The route to use for email replies. (see [below for nested schema](#nestedblock--reply_email_address))
+- `reply_email_address` (Block List, Max: 1) The route to use for email replies. This should not be set if from_email or auto_bcc are specified. (see [below for nested schema](#nestedblock--reply_email_address))
 - `skill_ids` (Set of String) The skills to use for routing.
 - `spam_flow_id` (String) The flow to use for processing inbound emails that have been marked as spam.
 
@@ -89,6 +89,6 @@ Required:
 Optional:
 
 - `route_id` (String) ID of the route.
-- `self_reference_route` (Boolean) Use this route as the reply email address. If true you will use the route id for this resource as the reply and you 
+- `self_reference_route` (Boolean) Use this route as the reply email address. If true you will use the route id for this resource as the reply and you
 							              can not set a route. If you set this value to false (or leave the attribute off)you must set a route id. Defaults to `false`.
 

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -2,15 +2,17 @@ package resource_exporter
 
 import (
 	"context"
-	"github.com/hashicorp/go-cty/cty"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"regexp"
 	"strings"
 	"sync"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/go-cty/cty"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 )
 
 var resourceExporters map[string]*ResourceExporter
@@ -51,7 +53,7 @@ type ResourceInfo struct {
 
 // Allows the definition of a custom resolver for an exporter.
 type RefAttrCustomResolver struct {
-	ResolverFunc func(map[string]interface{}, map[string]*ResourceExporter) error
+	ResolverFunc func(map[string]interface{}, map[string]*ResourceExporter, string) error
 }
 
 // Allows the definition of a custom resolver for an exporter.

--- a/genesyscloud/resource_exporter/resource_exporter_custom_test.go
+++ b/genesyscloud/resource_exporter/resource_exporter_custom_test.go
@@ -32,9 +32,9 @@ This is a unit test because it is just testing this single function without any 
 func TestAccExporterCustomMemberGroup(t *testing.T) {
 	teamID := uuid.NewString()
 	testResults := []*customMemberGroupTest{
-		&customMemberGroupTest{MemberGroupID: uuid.NewString(), MemberGroupType: "SKILLGROUP", GroupName: "test_skill_group_name", ExporterResourceType: "genesyscloud_routing_skill_group", ExpectedResult: "${genesyscloud_routing_skill_group.test_skill_group_name.id}"},
-		&customMemberGroupTest{MemberGroupID: uuid.NewString(), MemberGroupType: "GROUP", GroupName: "test_group_name", ExporterResourceType: "genesyscloud_group", ExpectedResult: "${genesyscloud_group.test_group_name.id}"},
-		&customMemberGroupTest{MemberGroupID: teamID, MemberGroupType: "TEAM", GroupName: "test_team_name", ExporterResourceType: "genesyscloud_team_NA", ExpectedResult: teamID},
+		{MemberGroupID: uuid.NewString(), MemberGroupType: "SKILLGROUP", GroupName: "test_skill_group_name", ExporterResourceType: "genesyscloud_routing_skill_group", ExpectedResult: "${genesyscloud_routing_skill_group.test_skill_group_name.id}"},
+		{MemberGroupID: uuid.NewString(), MemberGroupType: "GROUP", GroupName: "test_group_name", ExporterResourceType: "genesyscloud_group", ExpectedResult: "${genesyscloud_group.test_group_name.id}"},
+		{MemberGroupID: teamID, MemberGroupType: "TEAM", GroupName: "test_team_name", ExporterResourceType: "genesyscloud_team_NA", ExpectedResult: teamID},
 	}
 
 	for _, testResult := range testResults {
@@ -60,7 +60,7 @@ func TestAccExporterCustomMemberGroup(t *testing.T) {
 		}
 
 		//Invoke the resolver
-		err := MemberGroupsResolver(configMap, exporters)
+		err := MemberGroupsResolver(configMap, exporters, testResult.ExporterResourceType)
 
 		if err != nil && testResult.MemberGroupType != "TEAM" {
 			t.Errorf("Received an unexpected error while calling MemberGroupResolver:  %v", err)
@@ -68,7 +68,7 @@ func TestAccExporterCustomMemberGroup(t *testing.T) {
 
 		//The member_group_id should now be replaced by the expected out put with th
 		if configMap["member_group_id"].(string) != testResult.ExpectedResult {
-			t.Errorf("The member_group_id set in the config map was %v,but  wanted %v", configMap["member_group_id"], testResult.ExpectedResult)
+			t.Errorf("The member_group_id set in the config map was %v, but wanted %v", configMap["member_group_id"], testResult.ExpectedResult)
 		}
 	}
 
@@ -85,7 +85,7 @@ func TestRuleSetPropertyGroup(t *testing.T) {
 	jsonString := string(jsonData)
 
 	testResults := []*propertyGroupTest{
-		&propertyGroupTest{Skills: jsonString, SkillName: "test_skill_name", ExporterResourceType: "genesyscloud_routing_skill", ExpectedResult: "[\"${genesyscloud_routing_skill.test_skill_name.id}\"]"},
+		{Skills: jsonString, SkillName: "test_skill_name", ExporterResourceType: "genesyscloud_routing_skill", ExpectedResult: "[\"${genesyscloud_routing_skill.test_skill_name.id}\"]"},
 	}
 
 	for _, testResult := range testResults {
@@ -110,7 +110,7 @@ func TestRuleSetPropertyGroup(t *testing.T) {
 		}
 
 		//Invoke the resolver
-		err := RuleSetSkillPropertyResolver(configMap, exporters)
+		err := RuleSetSkillPropertyResolver(configMap, exporters, testResult.ExporterResourceType)
 
 		if err != nil {
 			t.Errorf("Received an unexpected error while calling RuleSetSkillPropertyResolver:  %v", err)

--- a/genesyscloud/routing_email_route/genesyscloud_routing_email_route_init_test.go
+++ b/genesyscloud/routing_email_route/genesyscloud_routing_email_route_init_test.go
@@ -1,10 +1,12 @@
 package routing_email_route
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"sync"
 	"terraform-provider-genesyscloud/genesyscloud"
+	"terraform-provider-genesyscloud/genesyscloud/architect_flow"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 /*
@@ -30,6 +32,7 @@ func (r *registerTestInstance) registerTestResources() {
 	providerResources["genesyscloud_routing_queue"] = genesyscloud.ResourceRoutingQueue()
 	providerResources["genesyscloud_routing_language"] = genesyscloud.ResourceRoutingLanguage()
 	providerResources["genesyscloud_routing_skill"] = genesyscloud.ResourceRoutingSkill()
+	providerResources["genesyscloud_flow"] = architect_flow.ResourceArchitectFlow()
 }
 
 // initTestResources initializes all test resources and data sources.

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -3,8 +3,10 @@ package routing_email_route
 import (
 	"fmt"
 	"log"
+	"regexp"
 	"strings"
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
+	"terraform-provider-genesyscloud/genesyscloud/architect_flow"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
@@ -19,30 +21,135 @@ import (
 
 func TestAccResourceRoutingEmailRoute(t *testing.T) {
 	var (
-		domainRes     = "routing-domain1"
-		domainId      = fmt.Sprintf("terraform.%s.com", strings.Replace(uuid.NewString(), "-", "", -1))
-		queueResource = "email-queue"
-		queueName     = "Terraform Email Queue-" + uuid.NewString()
-		langResource  = "email-lang"
-		langName      = "tflang" + uuid.NewString()
-		skillResource = "test-skill1"
-		skillName     = "Terraform Skill" + uuid.NewString()
-		routeRes      = "email-route1"
-		routeRes2     = "email-route2"
-		routePattern1 = "terraform1"
-		routePattern2 = "terraform2"
-		routePattern3 = "terraform3"
-		fromEmail1    = "terraform1@test.com"
-		fromEmail2    = "terraform2@test.com"
-		fromName1     = "John Terraform"
-		fromName2     = "Jane Terraform"
-		priority1     = "1"
-		bccEmail1     = "test1@" + domainId
-		bccEmail2     = "test2@" + domainId
+		domainRes          = "routing-domain1"
+		domainId           = fmt.Sprintf("terraform.%s.com", strings.Replace(uuid.NewString(), "-", "", -1))
+		queueResource      = "email-queue"
+		queueName          = "Terraform Email Queue-" + uuid.NewString()
+		langResource       = "email-lang"
+		langName           = "tflang" + uuid.NewString()
+		skillResource      = "test-skill1"
+		skillName          = "Terraform Skill" + uuid.NewString()
+		routeRes           = "email-route1"
+		routeRes2          = "email-route2"
+		routePattern1      = "terraform1"
+		routePattern2      = "terraform2"
+		routePattern3      = "terraform3"
+		fromEmail1         = "terraform1@test.com"
+		fromEmail2         = "terraform2@test.com"
+		fromName1          = "John Terraform"
+		fromName2          = "Jane Terraform"
+		priority1          = "1"
+		bccEmail1          = "test1@" + domainId
+		bccEmail2          = "test2@" + domainId
+		emailFlowResource1 = "test_flow1"
+		emailFlowFilePath1 = "../../examples/resources/genesyscloud_flow/inboundcall_flow_example.yaml"
 	)
 
 	CleanupRoutingEmailDomains()
 
+	// Test error configs
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, nil),
+		Steps: []resource.TestStep{
+			{
+				// Confirm mutual exclusivity of reply_email_address and from_email
+				Config: gcloud.GenerateRoutingEmailDomainResource(
+					domainRes,
+					domainId,
+					util.FalseValue,
+					util.NullValue,
+				) + generateRoutingEmailRouteResource(
+					routeRes+"expectFail",
+					"genesyscloud_routing_email_domain."+domainRes+".id",
+					routePattern1,
+					fromName1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail1),
+					generateRoutingReplyEmail(
+						false,
+						"genesyscloud_routing_email_domain."+domainRes+".id",
+						"genesyscloud_routing_email_route."+routeRes2+".id",
+					),
+				) + generateRoutingEmailRouteResource( // Second route to use as the reply_email_address
+					routeRes2,
+					"genesyscloud_routing_email_domain."+domainRes+".id",
+					routePattern3,
+					fromName1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail1),
+					generateRoutingAutoBcc(fromName2, bccEmail2),
+				),
+				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
+			},
+			{
+				// Confirm mutual exclusivity of reply_email_address and auto_bcc
+				Config: gcloud.GenerateRoutingEmailDomainResource(
+					domainRes,
+					domainId,
+					util.FalseValue,
+					util.NullValue,
+				) + generateRoutingEmailRouteResource(
+					routeRes+"expectFail",
+					"genesyscloud_routing_email_domain."+domainRes+".id",
+					routePattern1,
+					fromName1,
+					generateRoutingAutoBcc(fromName1, bccEmail1),
+					generateRoutingReplyEmail(
+						false,
+						"genesyscloud_routing_email_domain."+domainRes+".id",
+						"genesyscloud_routing_email_route."+routeRes2+".id",
+					),
+				) + generateRoutingEmailRouteResource( // Second route to use as the reply_email_address
+					routeRes2,
+					"genesyscloud_routing_email_domain."+domainRes+".id",
+					routePattern3,
+					fromName1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail1),
+					generateRoutingAutoBcc(fromName2, bccEmail2),
+				),
+				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
+			},
+			{
+				// Confirm mutual exclusivity of flow_id and queue_id
+				Config: gcloud.GenerateRoutingEmailDomainResource(
+					domainRes,
+					domainId,
+					util.FalseValue,
+					util.NullValue,
+				) + gcloud.GenerateRoutingQueueResourceBasic(
+					queueResource,
+					queueName,
+				) + gcloud.GenerateRoutingLanguageResource(
+					langResource,
+					langName,
+				) + gcloud.GenerateRoutingSkillResource(
+					skillResource,
+					skillName,
+				) + architect_flow.GenerateFlowResource(
+					emailFlowResource1,
+					emailFlowFilePath1,
+					"",
+					false,
+				) + generateRoutingEmailRouteResource(
+					routeRes+"expectFail",
+					"genesyscloud_routing_email_domain."+domainRes+".id",
+					routePattern1,
+					fromName1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail1),
+					generateRoutingEmailQueueSettings(
+						"genesyscloud_routing_queue."+queueResource+".id",
+						priority1,
+						"genesyscloud_routing_language."+langResource+".id",
+						"genesyscloud_routing_skill."+skillResource+".id",
+					),
+					fmt.Sprintf("flow_id = genesyscloud_flow.%s.id", emailFlowResource1),
+				),
+				ExpectError: regexp.MustCompile("Conflicting configuration arguments"),
+			},
+		},
+		CheckDestroy: testVerifyRoutingEmailRouteDestroyed,
+	})
+
+	// Standard acceptance tests
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, nil),
@@ -59,7 +166,7 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					"genesyscloud_routing_email_domain."+domainRes+".id",
 					routePattern1,
 					fromName1,
-					fromEmail1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail1),
 					generateRoutingAutoBcc(fromName1, bccEmail1),
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -92,8 +199,6 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					"genesyscloud_routing_email_domain."+domainRes+".id",
 					routePattern2,
 					fromName2,
-					fromEmail2,
-					generateRoutingAutoBcc(fromName2, bccEmail2),
 					generateRoutingReplyEmail(
 						false,
 						"genesyscloud_routing_email_domain."+domainRes+".id",
@@ -110,20 +215,24 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					"genesyscloud_routing_email_domain."+domainRes+".id",
 					routePattern3,
 					fromName1,
-					fromEmail1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail1),
+					generateRoutingAutoBcc(fromName2, bccEmail2),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "pattern", routePattern2),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_name", fromName2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_email", fromEmail2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "auto_bcc.0.name", fromName2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "auto_bcc.0.email", bccEmail2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_email", ""),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "queue_id", "genesyscloud_routing_queue."+queueResource, "id"),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "language_id", "genesyscloud_routing_language."+langResource, "id"),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "skill_ids.0", "genesyscloud_routing_skill."+skillResource, "id"),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "priority", priority1),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.domain_id", domainId),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.route_id", "genesyscloud_routing_email_route."+routeRes2, "id"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "pattern", routePattern3),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "from_name", fromName1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "from_email", fromEmail1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "auto_bcc.0.name", fromName2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "auto_bcc.0.email", bccEmail2),
 				),
 			},
 			{
@@ -147,8 +256,6 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					"genesyscloud_routing_email_domain."+domainRes+".id",
 					routePattern2,
 					fromName2,
-					fromEmail2,
-					generateRoutingAutoBcc(fromName2, bccEmail2),
 					generateRoutingReplyEmail(
 						true,
 						"genesyscloud_routing_email_domain."+domainRes+".id",
@@ -165,14 +272,13 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					"genesyscloud_routing_email_domain."+domainRes+".id",
 					routePattern3,
 					fromName1,
-					fromEmail1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail2),
+					generateRoutingAutoBcc(fromName2, bccEmail2),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "pattern", routePattern2),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_name", fromName2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_email", fromEmail2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "auto_bcc.0.name", fromName2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "auto_bcc.0.email", bccEmail2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_email", ""),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "queue_id", "genesyscloud_routing_queue."+queueResource, "id"),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "language_id", "genesyscloud_routing_language."+langResource, "id"),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "skill_ids.0", "genesyscloud_routing_skill."+skillResource, "id"),
@@ -180,6 +286,11 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.domain_id", domainId),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.route_id", ""),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.self_reference_route", "true"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "auto_bcc.0.name", fromName2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "auto_bcc.0.email", bccEmail2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "pattern", routePattern3),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "from_name", fromName1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "from_email", fromEmail2),
 				),
 			},
 			{
@@ -203,8 +314,6 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					"genesyscloud_routing_email_domain."+domainRes+".id",
 					routePattern2,
 					fromName2,
-					fromEmail2,
-					generateRoutingAutoBcc(fromName2, bccEmail2),
 					generateRoutingReplyEmail(
 						false,
 						"genesyscloud_routing_email_domain."+domainRes+".id",
@@ -221,14 +330,13 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					"genesyscloud_routing_email_domain."+domainRes+".id",
 					routePattern3,
 					fromName1,
-					fromEmail1,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail1),
+					generateRoutingAutoBcc(fromName2, bccEmail2),
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "pattern", routePattern2),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_name", fromName2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_email", fromEmail2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "auto_bcc.0.name", fromName2),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "auto_bcc.0.email", bccEmail2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "from_email", ""),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "queue_id", "genesyscloud_routing_queue."+queueResource, "id"),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "language_id", "genesyscloud_routing_language."+langResource, "id"),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "skill_ids.0", "genesyscloud_routing_skill."+skillResource, "id"),
@@ -236,6 +344,11 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.domain_id", domainId),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.domain_id", domainId),
 					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeRes, "reply_email_address.0.route_id", "genesyscloud_routing_email_route."+routeRes2, "id"),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "auto_bcc.0.name", fromName2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "auto_bcc.0.email", bccEmail2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "pattern", routePattern3),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "from_name", fromName1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeRes2, "from_email", fromEmail1),
 				),
 			},
 			{
@@ -255,16 +368,14 @@ func generateRoutingEmailRouteResource(
 	domainID string,
 	pattern string,
 	fromName string,
-	fromEmail string,
 	otherAttrs ...string) string {
 	return fmt.Sprintf(`resource "genesyscloud_routing_email_route" "%s" {
             domain_id = %s
             pattern = "%s"
             from_name = "%s"
-            from_email = "%s"
             %s
         }
-        `, resourceID, domainID, pattern, fromName, fromEmail, strings.Join(otherAttrs, "\n"))
+        `, resourceID, domainID, pattern, fromName, strings.Join(otherAttrs, "\n"))
 }
 
 func generateRoutingEmailQueueSettings(


### PR DESCRIPTION
Fixes DEVTOOLING-497 self-referential reply_email_address.route_id gets exported in the genesyscloud_routing_email_route resource. 

Also adds:
 - Mutual exclusivity to reply_email_address block and the from_email and auto_bcc fields as per the API and UI behaviors.
 - Mutual exclusivity to flow_id and queue_id fields as per the API and UI behaviors
 - Tests for verifying configuration errors when these fields are used together
 - Logic for determining when to add reply_email_address during create/update
 - Syntax tweaks/fixes to various lines of code along the way as per VS Code editor recommendations