### PR TITLE
no-jira: Fixing routing email domain cleanup function 

### DIFF
--- a/genesyscloud/data_source_genesyscloud_routing_email_domain_test.go
+++ b/genesyscloud/data_source_genesyscloud_routing_email_domain_test.go
@@ -62,8 +62,9 @@ func CleanupRoutingEmailDomains() {
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageNum, pageSize, false, "")
+		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "")
 		if getErr != nil {
+			log.Printf("failed to get page %v of routing email domains: %v", pageNum, getErr)
 			return
 		}
 

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_test.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_test.go
@@ -2361,8 +2361,9 @@ func CleanupRoutingEmailDomains() {
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageNum, pageSize, false, "")
+		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "")
 		if getErr != nil {
+			log.Printf("failed to get page %v of routing email domains: %v", pageNum, getErr)
 			return
 		}
 

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -469,14 +469,16 @@ func testVerifyRoutingEmailRouteDestroyed(state *terraform.State) error {
 func CleanupRoutingEmailDomains() {
 	sdkConfig, err := provider.AuthorizeSdk()
 	if err != nil {
-		log.Fatal(err)
+		log.Printf("failed to authorize sdk inside function CleanupRoutingEmailDomains: %v", err)
+		return
 	}
 	routingAPI := platformclientv2.NewRoutingApiWithConfig(sdkConfig)
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageNum, pageSize, false, "")
+		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "")
 		if getErr != nil {
+			log.Printf("failed to get page %v of routing email domains: %v", pageNum, getErr)
 			return
 		}
 


### PR DESCRIPTION
For now, I'm not going to worry about why this method is duplicated three times. I just noticed that pageNum and pageSize were in the wrong order, and thats why domains were not getting cleaned up. I also added a bit more logging