### PR TITLE
No jira: flow data source read

### DIFF
--- a/genesyscloud/architect_flow/data_source_genesyscloud_flow.go
+++ b/genesyscloud/architect_flow/data_source_genesyscloud_flow.go
@@ -21,22 +21,22 @@ func dataSourceFlowRead(ctx context.Context, d *schema.ResourceData, m interface
 
 	// Query flow by name. Retry in case search has not yet indexed the flow.
 	return util.WithRetries(ctx, 5*time.Second, func() *retry.RetryError {
-		for pageNum := 1; ; pageNum++ {
-			flows, _, getErr := p.GetAllFlows(ctx)
-			if getErr != nil {
-				return retry.NonRetryableError(fmt.Errorf("error requesting flow %s: %s", name, getErr))
-			}
+		flows, _, getErr := p.GetAllFlows(ctx)
+		if getErr != nil {
+			return retry.NonRetryableError(fmt.Errorf("error requesting flow %s: %s", name, getErr))
+		}
 
-			if flows == nil || len(*flows) == 0 {
-				return retry.RetryableError(fmt.Errorf("no flows found with name %s", name))
-			}
+		if flows == nil || len(*flows) == 0 {
+			return retry.RetryableError(fmt.Errorf("no flows found with name %s", name))
+		}
 
-			for _, entity := range *flows {
-				if *entity.Name == name {
-					d.SetId(*entity.Id)
-					return nil
-				}
+		for _, entity := range *flows {
+			if *entity.Name == name {
+				d.SetId(*entity.Id)
+				return nil
 			}
 		}
+
+		return retry.RetryableError(fmt.Errorf("no flows found with name %s", name))
 	})
 }


### PR DESCRIPTION
The way this code was written could cause an infinite loop to occur. The for loop was unnecessary since the proxy function handles the pagination logic and returns all the flows. If more than zero flows was returned without error, and none of them matched `d.Get("name")` , then nothing would break the for loop