### PR TITLE
bug/devtooling 560 - Nil error in telephony_providers_edges_phone

### DIFF
--- a/genesyscloud/station/data_source_genesyscloud_station_test.go
+++ b/genesyscloud/station/data_source_genesyscloud_station_test.go
@@ -64,7 +64,7 @@ func TestAccDataSourceStation(t *testing.T) {
 		PhoneBaseSettingsId: "genesyscloud_telephony_providers_edges_phonebasesettings." + phoneBaseSettingsRes + ".id",
 		LineAddresses:       nil, // no line addresses
 		WebRtcUserId:        "genesyscloud_user." + userRes1 + ".id",
-		Depends_on:          "", // no depends on
+		DependsOn:           "", // no depends on
 	},
 	)
 

--- a/genesyscloud/telephony_providers_edges_phone/data_source_genesyscloud_telephony_providers_edges_phone_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/data_source_genesyscloud_telephony_providers_edges_phone_test.go
@@ -80,7 +80,7 @@ func TestAccDataSourcePhone(t *testing.T) {
 						true,
 						"mac",
 						[]string{strconv.Quote("audio/opus")},
-					), generatePhoneProperties("BTR143543"),
+					), generatePhoneProperties(uuid.NewString()),
 				) + generatePhoneDataSource(
 					phoneDataRes,
 					name1,

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -42,10 +42,11 @@ func createPhone(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	if err != nil {
 		return diag.Errorf("failed to create phone %v: %v", *phoneConfig.Name, err)
 	}
+
 	log.Printf("Creating phone %s", *phoneConfig.Name)
+
 	diagErr := util.RetryWhen(util.IsStatus404, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
 		phone, resp, err := pp.createPhone(ctx, phoneConfig)
-		log.Printf("Completed call to create phone name %s with status code %d, correlation id %s and err %s", *phoneConfig.Name, resp.StatusCode, resp.CorrelationID, err)
 		if err != nil {
 			return resp, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to create phone %s error: %s", *phoneConfig.Name, err), resp)
 		}

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -86,31 +86,31 @@ func readPhone(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 		}
 
 		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourcePhone())
-		d.Set("name", *currentPhone.Name)
-		d.Set("state", *currentPhone.State)
-		d.Set("site_id", *currentPhone.Site.Id)
-		d.Set("phone_base_settings_id", *currentPhone.PhoneBaseSettings.Id)
-		d.Set("line_base_settings_id", *currentPhone.LineBaseSettings.Id)
+		_ = d.Set("name", *currentPhone.Name)
+		_ = d.Set("state", *currentPhone.State)
+		_ = d.Set("site_id", *currentPhone.Site.Id)
+		_ = d.Set("phone_base_settings_id", *currentPhone.PhoneBaseSettings.Id)
+		_ = d.Set("line_base_settings_id", *currentPhone.LineBaseSettings.Id)
 
 		if currentPhone.PhoneMetaBase != nil {
-			d.Set("phone_meta_base_id", *currentPhone.PhoneMetaBase.Id)
+			_ = d.Set("phone_meta_base_id", *currentPhone.PhoneMetaBase.Id)
 		}
 
 		if currentPhone.WebRtcUser != nil {
-			d.Set("web_rtc_user_id", *currentPhone.WebRtcUser.Id)
+			_ = d.Set("web_rtc_user_id", *currentPhone.WebRtcUser.Id)
 		}
 
 		if currentPhone.Lines != nil {
-			d.Set("line_addresses", flattenPhoneLines(currentPhone.Lines))
+			_ = d.Set("line_addresses", flattenPhoneLines(currentPhone.Lines))
 		}
 
-		d.Set("properties", nil)
+		_ = d.Set("properties", nil)
 		if currentPhone.Properties != nil {
 			properties, err := util.FlattenTelephonyProperties(currentPhone.Properties)
 			if err != nil {
 				return retry.NonRetryableError(fmt.Errorf("%v", err))
 			}
-			d.Set("properties", properties)
+			_ = d.Set("properties", properties)
 		}
 
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "capabilities", currentPhone.Capabilities, flattenPhoneCapabilities)

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
@@ -102,7 +102,7 @@ func TestAccResourcePhoneBasic(t *testing.T) {
 			"mac",
 			[]string{strconv.Quote("audio/opus")},
 		),
-		generatePhoneProperties("AHWEWLFJ"),
+		generatePhoneProperties(uuid.NewString()),
 	)
 
 	// Update phone with new user and name
@@ -133,7 +133,7 @@ func TestAccResourcePhoneBasic(t *testing.T) {
 			"mac",
 			[]string{strconv.Quote("audio/opus")},
 		),
-		generatePhoneProperties("AHFDOIW12"),
+		generatePhoneProperties(uuid.NewString()),
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -269,7 +269,7 @@ func TestAccResourcePhoneStandalone(t *testing.T) {
 		lineAddresses,
 		"", // no web rtc user
 		"", // no Depends On
-	}, capabilities, generatePhoneProperties("AFEQ123D"))
+	}, capabilities, generatePhoneProperties(uuid.NewString()))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
@@ -29,7 +29,7 @@ type PhoneConfig struct {
 	PhoneBaseSettingsId string
 	LineAddresses       []string
 	WebRtcUserId        string
-	Depends_on          string
+	DependsOn           string
 }
 
 func getPhoneFromResourceData(ctx context.Context, pp *phoneProxy, d *schema.ResourceData) (*platformclientv2.Phone, error) {
@@ -72,12 +72,12 @@ func getPhoneFromResourceData(ctx context.Context, pp *phoneProxy, d *schema.Res
 		if phoneConfig.Properties == nil {
 			phoneConfig.Properties = &map[string]interface{}{}
 		}
-		phone_standalone := map[string]interface{}{
+		phoneStandalone := map[string]interface{}{
 			"value": &map[string]interface{}{
 				"instance": true,
 			},
 		}
-		(*phoneConfig.Properties)["phone_standalone"] = phone_standalone
+		(*phoneConfig.Properties)["phone_standalone"] = phoneStandalone
 	}
 
 	webRtcUserId := d.Get("web_rtc_user_id")
@@ -341,7 +341,7 @@ func GeneratePhoneResourceWithCustomAttrs(config *PhoneConfig, otherAttrs ...str
 		config.SiteId,
 		config.PhoneBaseSettingsId,
 		strings.Join(lineStrs, ","),
-		config.Depends_on,
+		config.DependsOn,
 		webRtcUser,
 		strings.Join(otherAttrs, "\n"),
 	)


### PR DESCRIPTION
A log.Printf line was causing a nil pointer error. This line was executed before an API call was handled for error checks. 
This PR removes the line that throws the error and makes a few small changes with a linter 