### PR TITLE
bug/devtooling 362 - Evaluation forms incorrectly assigning published attribute

### DIFF
--- a/docs/resources/outbound_messagingcampaign.md
+++ b/docs/resources/outbound_messagingcampaign.md
@@ -75,13 +75,13 @@ resource "genesyscloud_outbound_messagingcampaign" "example_outbound_messagingca
 
 Required:
 
-- `message_column` (String) The Contact List column specifying the message to send to the contact.
 - `phone_column` (String) The Contact List column specifying the phone number to send a message to.
 - `sender_sms_phone_number` (String) A phone number provisioned for SMS communications in E.164 format. E.g. +13175555555 or +34234234234
 
 Optional:
 
-- `content_template_id` (String) The content template used to formulate the message to send to the contact.
+- `content_template_id` (String) The content template used to formulate the message to send to the contact. Either message_column or content_template_id is required.
+- `message_column` (String) The Contact List column specifying the message to send to the contact. Either message_column or content_template_id is required.
 
 
 <a id="nestedblock--contact_sorts"></a>

--- a/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
@@ -166,7 +166,7 @@ func getAllEvaluationForms(_ context.Context, clientConfig *platformclientv2.Con
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		evaluationForms, resp, getErr := qualityAPI.GetQualityFormsEvaluations(pageSize, pageNum, "", "", "", "publishHistory", "", "")
+		evaluationForms, resp, getErr := qualityAPI.GetQualityFormsEvaluations(pageSize, pageNum, "", "", "", "", "", "")
 		if getErr != nil {
 			return nil, util.BuildAPIDiagnosticError("genesyscloud_quality_forms_evaluation", fmt.Sprintf("Failed to get page of evaluation forms error: %s", getErr), resp)
 		}


### PR DESCRIPTION
This PR Fixes the exporting of the 'published' attribute by using the `GetQualityFormsEvaluationsBulkContexts` api call, which returns a list of published versions of an evaluation form. This can be used to determine if published should be set to true / false 