### PR TITLE
bug/DEVTOOLING-557 - Changed Build Function Call to fix type difference

### DIFF
--- a/genesyscloud/resource_genesyscloud_journey_segment.go
+++ b/genesyscloud/resource_genesyscloud_journey_segment.go
@@ -442,8 +442,8 @@ func buildSdkPatchSegment(journeySegment *schema.ResourceData) *platformclientv2
 	description := resourcedata.GetNillableValue[string](journeySegment, "description")
 	color := journeySegment.Get("color").(string)
 	shouldDisplayToAgent := resourcedata.GetNillableBool(journeySegment, "should_display_to_agent")
-	sdkContext := resourcedata.BuildSdkListFirstElement(journeySegment, "context", buildSdkRequestContext, false)
-	journey := resourcedata.BuildSdkListFirstElement(journeySegment, "journey", buildSdkRequestJourney, false)
+	sdkContext := resourcedata.BuildSdkListFirstElement(journeySegment, "context", buildSdkPatchContext, false)
+	journey := resourcedata.BuildSdkListFirstElement(journeySegment, "journey", buildSdkPatchJourney, false)
 	externalSegment := resourcedata.BuildSdkListFirstElement(journeySegment, "external_segment", buildSdkPatchExternalSegment, true)
 	assignmentExpirationDays := resourcedata.GetNillableValue[int](journeySegment, "assignment_expiration_days")
 


### PR DESCRIPTION
This PR changes the build function calls for 2 attributes, which caused the test to fail with the error:
`panic: reflect.Set: value of type *platformclientv2.Requestcontext is not assignable to type *platformclientv2.Patchcontext`