### PR TITLE
bug/DEVTOOLING-436 - Added cleanup function for webdeployments resources

### DIFF
--- a/genesyscloud/webdeployments_configuration/data_source_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/webdeployments_configuration/data_source_genesyscloud_webdeployments_configuration.go
@@ -34,7 +34,7 @@ func dataSourceConfigurationRead(ctx context.Context, d *schema.ResourceData, m 
 					return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Web deployment configuration %s has no published versions and so cannot be used", name), resp))
 				}
 
-				d.Set("version", version)
+				_ = d.Set("version", version)
 
 				return nil
 			}

--- a/genesyscloud/webdeployments_configuration/data_source_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/data_source_genesyscloud_webdeployments_configuration_test.go
@@ -17,7 +17,7 @@ func TestAccDataSourceWebDeploymentsConfiguration(t *testing.T) {
 		resourceNameReference    = fullResourceName + ".name"
 	)
 
-	_ = cleanupWebDeploymentsConfiguration()
+	cleanupWebDeploymentsConfiguration(t, "Test Configuration ")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },

--- a/genesyscloud/webdeployments_configuration/data_source_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/data_source_genesyscloud_webdeployments_configuration_test.go
@@ -16,6 +16,9 @@ func TestAccDataSourceWebDeploymentsConfiguration(t *testing.T) {
 		fullDataSourceName       = "data.genesyscloud_webdeployments_configuration.basic-data"
 		resourceNameReference    = fullResourceName + ".name"
 	)
+
+	_ = cleanupWebDeploymentsConfiguration()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
@@ -78,7 +78,7 @@ func createWebDeploymentConfiguration(ctx context.Context, d *schema.ResourceDat
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("failed to create web deployment configuration %s: %s. %s", name, err, extraErrorInfo), resp))
 		}
 		d.SetId(*configuration.Id)
-		d.Set("status", configuration.Status)
+		_ = d.Set("status", configuration.Status)
 
 		return nil
 	})
@@ -99,8 +99,8 @@ func createWebDeploymentConfiguration(ctx context.Context, d *schema.ResourceDat
 			}
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("error publishing web deployment configuration %s | error: %s", name, err), resp))
 		}
-		d.Set("version", configuration.Version)
-		d.Set("status", configuration.Status)
+		_ = d.Set("version", configuration.Version)
+		_ = d.Set("status", configuration.Status)
 		log.Printf("Created web deployment configuration %s %s", name, *configuration.Id)
 
 		return nil
@@ -132,7 +132,7 @@ func readWebDeploymentConfiguration(ctx context.Context, d *schema.ResourceData,
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("failed to read web deployment configuration %s | error: %s", d.Id(), getErr), resp))
 		}
 
-		d.Set("name", *configuration.Name)
+		_ = d.Set("name", *configuration.Name)
 
 		resourcedata.SetNillableValue(d, "description", configuration.Description)
 		resourcedata.SetNillableValue(d, "languages", configuration.Languages)
@@ -191,8 +191,8 @@ func updateWebDeploymentConfiguration(ctx context.Context, d *schema.ResourceDat
 			}
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("error publishing web deployment configuration %s | error: %s", name, err), resp))
 		}
-		d.Set("version", configuration.Version)
-		d.Set("status", configuration.Status)
+		_ = d.Set("version", configuration.Version)
+		_ = d.Set("status", configuration.Status)
 		return nil
 	})
 	if diagErr != nil {

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
@@ -1168,6 +1168,7 @@ func verifyConfigurationDestroyed(state *terraform.State) error {
 func cleanupWebDeploymentsConfiguration(t *testing.T, prefix string) {
 	config, err := provider.AuthorizeSdk()
 	if err != nil {
+		t.Logf("Failed to authorize SDK: %s", err)
 		return
 	}
 	deploymentsAPI := platformclientv2.NewWebDeploymentsApiWithConfig(config)
@@ -1183,7 +1184,6 @@ func cleanupWebDeploymentsConfiguration(t *testing.T, prefix string) {
 			resp, delErr := deploymentsAPI.DeleteWebdeploymentsConfiguration(*configuration.Id)
 			if delErr != nil {
 				t.Logf("Failed to delete configuration %s: %s %v", *configuration.Id, delErr, resp)
-				return
 			}
 			time.Sleep(5 * time.Second)
 		}

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
@@ -121,7 +121,7 @@ func CustomizeConfigurationDiff(ctx context.Context, diff *schema.ResourceDiff, 
 	if len(diff.GetChangedKeysPrefix("")) > 0 {
 		// When any change is made to the configuration we automatically publish a new version, so mark the version as updated
 		// so dependent deployments will update appropriately to reference the newest version
-		diff.SetNewComputed("version")
+		_ = diff.SetNewComputed("version")
 	}
 	return nil
 }

--- a/genesyscloud/webdeployments_deployment/data_source_genesyscloud_webdeployments_deployment_test.go
+++ b/genesyscloud/webdeployments_deployment/data_source_genesyscloud_webdeployments_deployment_test.go
@@ -17,6 +17,9 @@ func TestAccDataSourceWebDeploymentsDeployment(t *testing.T) {
 		fullResourceName      = "genesyscloud_webdeployments_deployment.basic"
 		fullDataSourceName    = "data.genesyscloud_webdeployments_deployment.basic-data"
 	)
+
+	_ = cleanupWebDeploymentsDeployment()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),

--- a/genesyscloud/webdeployments_deployment/data_source_genesyscloud_webdeployments_deployment_test.go
+++ b/genesyscloud/webdeployments_deployment/data_source_genesyscloud_webdeployments_deployment_test.go
@@ -18,7 +18,7 @@ func TestAccDataSourceWebDeploymentsDeployment(t *testing.T) {
 		fullDataSourceName    = "data.genesyscloud_webdeployments_deployment.basic-data"
 	)
 
-	_ = cleanupWebDeploymentsDeployment()
+	cleanupWebDeploymentsDeployment(t, "Test Deployment ")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
@@ -151,12 +151,7 @@ func readWebDeployment(ctx context.Context, d *schema.ResourceData, meta interfa
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Failed to read web deployment %s | error: %s", d.Id(), getErr), resp))
 		}
 
-<<<<<<< HEAD
-		d.Set("name", *deployment.Name)
-=======
-		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWebDeployment())
 		_ = d.Set("name", *deployment.Name)
->>>>>>> 73c4fde3 (Added cleanup function for webdeployments resources)
 
 		if deployment.Description != nil {
 			_ = d.Set("description", *deployment.Description)

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
@@ -151,23 +151,28 @@ func readWebDeployment(ctx context.Context, d *schema.ResourceData, meta interfa
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Failed to read web deployment %s | error: %s", d.Id(), getErr), resp))
 		}
 
+<<<<<<< HEAD
 		d.Set("name", *deployment.Name)
+=======
+		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWebDeployment())
+		_ = d.Set("name", *deployment.Name)
+>>>>>>> 73c4fde3 (Added cleanup function for webdeployments resources)
 
 		if deployment.Description != nil {
-			d.Set("description", *deployment.Description)
+			_ = d.Set("description", *deployment.Description)
 		}
 		if deployment.AllowAllDomains != nil {
-			d.Set("allow_all_domains", *deployment.AllowAllDomains)
+			_ = d.Set("allow_all_domains", *deployment.AllowAllDomains)
 		}
-		d.Set("configuration", flattenConfiguration(deployment.Configuration))
+		_ = d.Set("configuration", flattenConfiguration(deployment.Configuration))
 		if deployment.AllowedDomains != nil && len(*deployment.AllowedDomains) > 0 {
-			d.Set("allowed_domains", *deployment.AllowedDomains)
+			_ = d.Set("allowed_domains", *deployment.AllowedDomains)
 		}
 		if deployment.Flow != nil {
-			d.Set("flow_id", *deployment.Flow.Id)
+			_ = d.Set("flow_id", *deployment.Flow.Id)
 		}
 		if deployment.Status != nil {
-			d.Set("status", *deployment.Status)
+			_ = d.Set("status", *deployment.Status)
 		}
 
 		log.Printf("Read web deployment %s %s", d.Id(), *deployment.Name)

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
@@ -298,6 +298,7 @@ func verifyLanguagesDestroyed(state *terraform.State) error {
 func cleanupWebDeploymentsDeployment(t *testing.T, prefix string) {
 	config, err := provider.AuthorizeSdk()
 	if err != nil {
+		t.Logf("Failed to authorize SDK: %s", err)
 		return
 	}
 	deploymentsAPI := platformclientv2.NewWebDeploymentsApiWithConfig(config)
@@ -313,7 +314,6 @@ func cleanupWebDeploymentsDeployment(t *testing.T, prefix string) {
 			_, err := deploymentsAPI.DeleteWebdeploymentsDeployment(*webDeployment.Id)
 			if err != nil {
 				t.Logf("failed to delete deployment: %v %v %v", *webDeployment.Id, getErr, resp)
-				return
 			}
 			time.Sleep(5 * time.Second)
 		}

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
@@ -3,15 +3,16 @@ package webdeployments_deployment
 import (
 	"encoding/json"
 	"fmt"
-	"regexp"
-	"terraform-provider-genesyscloud/genesyscloud/provider"
-	"terraform-provider-genesyscloud/genesyscloud/util"
-	"testing"
-
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/mypurecloud/platform-client-sdk-go/v129/platformclientv2"
+	"regexp"
+	"strings"
+	"terraform-provider-genesyscloud/genesyscloud/provider"
+	"terraform-provider-genesyscloud/genesyscloud/util"
+	"testing"
+	"time"
 )
 
 func TestAccResourceWebDeploymentsDeployment(t *testing.T) {
@@ -21,6 +22,8 @@ func TestAccResourceWebDeploymentsDeployment(t *testing.T) {
 		deploymentDescription = "Test Deployment description " + util.RandString(32)
 		fullResourceName      = "genesyscloud_webdeployments_deployment.basic"
 	)
+
+	_ = cleanupWebDeploymentsDeployment()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
@@ -55,6 +58,8 @@ func TestAccResourceWebDeploymentsDeployment_AllowedDomains(t *testing.T) {
 		firstDomain      = "genesys-" + util.RandString(8) + ".com"
 		secondDomain     = "genesys-" + util.RandString(8) + ".com"
 	)
+
+	_ = cleanupWebDeploymentsDeployment()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
@@ -97,6 +102,8 @@ func TestAccResourceWebDeploymentsDeployment_Versioning(t *testing.T) {
 		fullDeploymentResourceName = "genesyscloud_webdeployments_deployment.versioning"
 		fullConfigResourceName     = "genesyscloud_webdeployments_configuration.minimal"
 	)
+
+	_ = cleanupWebDeploymentsDeployment()
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
@@ -285,5 +292,30 @@ func verifyLanguagesDestroyed(state *terraform.State) error {
 		}
 	}
 	// Success. All languages destroyed
+	return nil
+}
+
+func cleanupWebDeploymentsDeployment() error {
+	config, err := provider.AuthorizeSdk()
+
+	if err != nil {
+		return err
+	}
+	deploymentsAPI := platformclientv2.NewWebDeploymentsApiWithConfig(config)
+
+	webDeployments, resp, getErr := deploymentsAPI.GetWebdeploymentsDeployments([]string{})
+	if getErr != nil {
+		return util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("failed to get page of deployments: %v", getErr), resp)
+	}
+
+	for _, webDeployment := range *webDeployments.Entities {
+		if webDeployment.Name != nil && strings.HasPrefix(*webDeployment.Name, "Test Deployment ") {
+			_, err := deploymentsAPI.DeleteWebdeploymentsDeployment(*webDeployment.Id)
+			if err != nil {
+				return util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("failed to delete deployment: %v %v", *webDeployment.Id, getErr), resp)
+			}
+			time.Sleep(5 * time.Second)
+		}
+	}
 	return nil
 }


### PR DESCRIPTION
This PR adds a cleanup function to the tests for webdeployments resources to prevent exceeding maximum number of resources.
This PR also includes changes to the resources from the linter