### PR TITLE
Bug/devtooling 597 - Routing email route test failing 

### DIFF
--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
@@ -32,7 +32,7 @@ func getAllRoutingEmailRoutes(ctx context.Context, clientConfig *platformclientv
 
 	inboundRoutesMap, respCode, err := proxy.getAllRoutingEmailRoute(ctx, "", "")
 	if err != nil {
-		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get routing email route"), respCode)
+		return nil, util.BuildAPIDiagnosticError(resourceName, "Failed to get routing email route", respCode)
 	}
 
 	for domainId, inboundRoutes := range *inboundRoutesMap {
@@ -57,7 +57,7 @@ func createRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta i
 	replyEmail, err := validateSdkReplyEmailAddress(d)
 	// Checking the self_reference_route flag and routeId rules
 	if err != nil {
-		return util.BuildDiagnosticError(resourceName, fmt.Sprintf("Error occurred while validating the reply email address when creating the record"), err)
+		return util.BuildDiagnosticError(resourceName, "Error occurred while validating the reply email address when creating the record", err)
 	}
 
 	replyDomainID, replyRouteID, _ := extractReplyEmailAddressValue(d)
@@ -135,9 +135,9 @@ func readRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta int
 		resourcedata.SetNillableReference(d, "spam_flow_id", route.SpamFlow)
 
 		if route.Skills != nil {
-			d.Set("skill_ids", util.SdkDomainEntityRefArrToSet(*route.Skills))
+			_ = d.Set("skill_ids", util.SdkDomainEntityRefArrToSet(*route.Skills))
 		} else {
-			d.Set("skill_ids", nil)
+			_ = d.Set("skill_ids", nil)
 		}
 
 		if route.ReplyEmailAddress != nil {
@@ -152,9 +152,9 @@ func readRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta int
 				flattenedEmails["route_id"] = nil
 			}
 
-			d.Set("reply_email_address", []interface{}{flattenedEmails})
+			_ = d.Set("reply_email_address", []interface{}{flattenedEmails})
 		} else {
-			d.Set("reply_email_address", nil)
+			_ = d.Set("reply_email_address", nil)
 		}
 
 		log.Printf("Read routing email route %s %v", d.Id(), route.Name)
@@ -173,7 +173,7 @@ func updateRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta i
 	//Checking the self_reference_route flag and routeId rules
 	replyEmail, err := validateSdkReplyEmailAddress(d)
 	if err != nil {
-		return util.BuildDiagnosticError(resourceName, fmt.Sprintf("Error occurred while validating the reply email address while trying to update the record"), err)
+		return util.BuildDiagnosticError(resourceName, "Error occurred while validating the reply email address while trying to update the record", err)
 	}
 
 	replyDomainID, replyRouteID, _ := extractReplyEmailAddressValue(d)

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -20,10 +20,6 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v129/platformclientv2"
 )
 
-var (
-	sdkConfig *platformclientv2.Configuration
-)
-
 func TestAccResourceRoutingEmailRoute(t *testing.T) {
 
 	var (
@@ -50,6 +46,8 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 		emailFlowResource1 = "test_flow1"
 		emailFlowFilePath1 = "../../examples/resources/genesyscloud_flow/inboundcall_flow_example.yaml"
 	)
+
+	CleanupRoutingEmailDomains()
 
 	// Test error configs
 	resource.Test(t, resource.TestCase{
@@ -461,7 +459,11 @@ func testVerifyRoutingEmailRouteDestroyed(state *terraform.State) error {
 }
 
 func CleanupRoutingEmailDomains() {
-	routingAPI := platformclientv2.NewRoutingApiWithConfig(sdkConfig)
+	config, err := provider.AuthorizeSdk()
+	if err != nil {
+		return
+	}
+	routingAPI := platformclientv2.NewRoutingApiWithConfig(config)
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
@@ -153,9 +153,9 @@ func importRoutingEmailRoute(_ context.Context, d *schema.ResourceData, _ interf
 	// Import must specify domain ID and route ID
 	idParts := strings.Split(d.Id(), "/")
 	if len(idParts) < 2 {
-		return nil, fmt.Errorf("Invalid email route import ID %s", d.Id())
+		return nil, fmt.Errorf("invalid email route import ID %s", d.Id())
 	}
-	d.Set("domain_id", idParts[0])
+	_ = d.Set("domain_id", idParts[0])
 	d.SetId(idParts[1])
 	return []*schema.ResourceData{d}, nil
 }


### PR DESCRIPTION
This PR calls the cleanup function in routing email routes to prevent maximum resources exceeded error, and also makes linter changes