### PR TITLE
Specifying version 2 in the goreleaser file to fix build

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,7 @@
 # Visit https://goreleaser.com for documentation on how to customize this
 # behavior.
+version: 2
+
 before:
   hooks:
     # this is just an example and not a requirement for provider building/publishing


### PR DESCRIPTION
During our release process, we download the latest version of goreleaser. On the last release attempt it downloaded v2.0.1 (probably for the first time ever) and now the build is failing because the goreleaser config file does not specify version 2

The error 

```
Downloading GoReleaser v2.0.1...
  • starting release...
  • only configurations files on  version: 2  are supported, yours is  version: 0 , please update your configuration
```