### PR TITLE
increased member_division_ids maxItems to 1000

### DIFF
--- a/genesyscloud/resource_genesyscloud_routing_skill_group.go
+++ b/genesyscloud/resource_genesyscloud_routing_skill_group.go
@@ -141,7 +141,7 @@ func ResourceRoutingSkillGroup() *schema.Resource {
 			"member_division_ids": {
 				Description: "The IDs of member divisions to add or remove for this skill group. An empty array means all divisions will be removed, \"*\" means all divisions will be added.",
 				Type:        schema.TypeList,
-				MaxItems:    50,
+				MaxItems:    1000,
 				Optional:    true,
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},


### PR DESCRIPTION
increased member_division_ids maxItems to 1000
divisions is an adjustable limit and can be increased as it is in my case.