### PR TITLE
Devtooling 501: Removing support for v1 and v1-http widget deployments

### DIFF
--- a/docs/resources/widget_deployment.md
+++ b/docs/resources/widget_deployment.md
@@ -47,7 +47,6 @@ resource "genesyscloud_widget_deployment" "mywidget" {
 ### Optional
 
 - `allowed_domains` (List of String) The list of domains that are approved to use this Deployment; the list will be added to CORS headers for ease of web use
-- `client_config` (Map of String) The client configuration options that should be made available to the clients of this Deployment. The map key should match the client_type for this deployment. MaxItems: 1
 - `description` (String) Widget Deployment description.
 - `flow_id` (String) The Inbound Chat Flow to run when new chats are initiated under this Deployment
 - `third_party_client_config` (Map of String) The third party client configuration options that should be made available to the clients of this Deployment.

--- a/docs/resources/widget_deployment.md
+++ b/docs/resources/widget_deployment.md
@@ -27,9 +27,8 @@ resource "genesyscloud_widget_deployment" "mywidget" {
   client_type             = "v1"
   authentication_required = true
   disabled                = true
-  client_config {
-    authentication_url = "https://examplewebsite.com"
-    webchat_skin       = "modern-caret-skin"
+  third_party_client_config = {
+    foo = "bar"
   }
   allowed_domains = []
 }

--- a/docs/resources/widget_deployment.md
+++ b/docs/resources/widget_deployment.md
@@ -40,13 +40,14 @@ resource "genesyscloud_widget_deployment" "mywidget" {
 ### Required
 
 - `authentication_required` (Boolean) When true, the customer members starting a chat must be authenticated by supplying their JWT to the create operation.
-- `client_type` (String) The type of display widget for which this Deployment is configured, which controls the administrator settings shown.Valid values: v1, v2, v1-http, third-party.
+- `client_type` (String) The type of display widget for which this Deployment is configured, which controls the administrator settings shown. Valid values: v1, v1-http, v2, third-party
 - `disabled` (Boolean) When true, all create chat operations using this Deployment will be rejected.
 - `name` (String) Name of the Widget Deployment.
 
 ### Optional
 
 - `allowed_domains` (List of String) The list of domains that are approved to use this Deployment; the list will be added to CORS headers for ease of web use
+- `client_config` (Block Set, Max: 1, Deprecated) The V1 and V1-http client configuration options that should be made available to the clients of this Deployment. (see [below for nested schema](#nestedblock--client_config))
 - `description` (String) Widget Deployment description.
 - `flow_id` (String) The Inbound Chat Flow to run when new chats are initiated under this Deployment
 - `third_party_client_config` (Map of String) The third party client configuration options that should be made available to the clients of this Deployment.
@@ -55,4 +56,12 @@ resource "genesyscloud_widget_deployment" "mywidget" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--client_config"></a>
+### Nested Schema for `client_config`
+
+Optional:
+
+- `authentication_url` (String) Url endpoint to perform_authentication
+- `webchat_skin` (String) Skin for the webchat user. (basic, modern-caret-skin)
 

--- a/docs/resources/widget_deployment.md
+++ b/docs/resources/widget_deployment.md
@@ -48,22 +48,13 @@ resource "genesyscloud_widget_deployment" "mywidget" {
 ### Optional
 
 - `allowed_domains` (List of String) The list of domains that are approved to use this Deployment; the list will be added to CORS headers for ease of web use
-- `client_config` (Block Set, Max: 1) The V1 and V1-http client configuration options that should be made available to the clients of this Deployment. (see [below for nested schema](#nestedblock--client_config))
+- `client_config` (Map of String) The client configuration options that should be made available to the clients of this Deployment. The map key should match the client_type for this deployment. MaxItems: 1
 - `description` (String) Widget Deployment description.
 - `flow_id` (String) The Inbound Chat Flow to run when new chats are initiated under this Deployment
+- `third_party_client_config` (Map of String) The third party client configuration options that should be made available to the clients of this Deployment.
+- `v2_client_config` (Map of String) The v2 client configuration options that should be made available to the clients of this Deployment.
 
 ### Read-Only
 
 - `id` (String) The ID of this resource.
-
-<a id="nestedblock--client_config"></a>
-### Nested Schema for `client_config`
-
-Required:
-
-- `webchat_skin` (String) Skin for the webchat user. (basic, modern-caret-skin)
-
-Optional:
-
-- `authentication_url` (String) Url endpoint to perform_authentication
 

--- a/examples/resources/genesyscloud_widget_deployment/resource.tf
+++ b/examples/resources/genesyscloud_widget_deployment/resource.tf
@@ -5,9 +5,8 @@ resource "genesyscloud_widget_deployment" "mywidget" {
   client_type             = "v1"
   authentication_required = true
   disabled                = true
-  client_config {
-    authentication_url = "https://examplewebsite.com"
-    webchat_skin       = "modern-caret-skin"
+  third_party_client_config = {
+    foo = "bar"
   }
   allowed_domains = []
 }

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_schema.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_schema.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 const (
@@ -65,7 +65,7 @@ func ResourceArchitectIvrConfig() *schema.Resource {
 				Type:        schema.TypeSet,
 				Optional:    true,
 				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString, ValidateDiagFunc: gcloud.ValidatePhoneNumber},
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateDiagFunc: validators.ValidatePhoneNumber},
 			},
 			"open_hours_flow_id": {
 				Description: "ID of inbound call flow for open hours.",

--- a/genesyscloud/data_source_genesyscloud_widget_deployment_test.go
+++ b/genesyscloud/data_source_genesyscloud_widget_deployment_test.go
@@ -22,15 +22,11 @@ func TestAccDataSourceWidgetDeployment(t *testing.T) {
 		name:                   widgetDeploymentsName + uuid.NewString(),
 		description:            "This is a test description",
 		flowID:                 uuid.NewString(),
-		clientType:             "v1",
+		clientType:             V2,
 		authenticationRequired: "true",
 		disabled:               "true",
 	}
 
-	_, err := provider.AuthorizeSdk()
-	if err != nil {
-		t.Fatal(err)
-	}
 	deleteWidgetDeploymentWithName(widgetDeploymentsName)
 
 	resource.Test(t, resource.TestCase{

--- a/genesyscloud/data_source_genesyscloud_widget_deployment_test.go
+++ b/genesyscloud/data_source_genesyscloud_widget_deployment_test.go
@@ -34,7 +34,7 @@ func TestAccDataSourceWidgetDeployment(t *testing.T) {
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{
-				Config: generateWidgetDeployV2(widgetDeployV1) + generateWidgetDeploymentDataSource(widgetDeploymentsDataSource, "genesyscloud_widget_deployment."+widgegetDeploymentsResource+".name", "genesyscloud_widget_deployment."+widgegetDeploymentsResource),
+				Config: generateWidgetDeploymentResource(widgetDeployV1) + generateWidgetDeploymentDataSource(widgetDeploymentsDataSource, "genesyscloud_widget_deployment."+widgegetDeploymentsResource+".name", "genesyscloud_widget_deployment."+widgegetDeploymentsResource),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.genesyscloud_widget_deployment."+widgetDeploymentsDataSource, "id", "genesyscloud_widget_deployment."+widgegetDeploymentsResource, "id"),
 				),

--- a/genesyscloud/data_source_genesyscloud_widget_deployment_test.go
+++ b/genesyscloud/data_source_genesyscloud_widget_deployment_test.go
@@ -25,8 +25,6 @@ func TestAccDataSourceWidgetDeployment(t *testing.T) {
 		clientType:             "v1",
 		authenticationRequired: "true",
 		disabled:               "true",
-		webChatSkin:            "basic",
-		authenticationUrl:      "https://localhost",
 	}
 
 	_, err := provider.AuthorizeSdk()
@@ -40,7 +38,7 @@ func TestAccDataSourceWidgetDeployment(t *testing.T) {
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{
-				Config: generateWidgetDeployV1(widgetDeployV1) + generateWidgetDeploymentDataSource(widgetDeploymentsDataSource, "genesyscloud_widget_deployment."+widgegetDeploymentsResource+".name", "genesyscloud_widget_deployment."+widgegetDeploymentsResource),
+				Config: generateWidgetDeployV2(widgetDeployV1) + generateWidgetDeploymentDataSource(widgetDeploymentsDataSource, "genesyscloud_widget_deployment."+widgegetDeploymentsResource+".name", "genesyscloud_widget_deployment."+widgegetDeploymentsResource),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.genesyscloud_widget_deployment."+widgetDeploymentsDataSource, "id", "genesyscloud_widget_deployment."+widgegetDeploymentsResource, "id"),
 				),

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_schema.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_schema.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 /*
@@ -53,7 +53,7 @@ func ResourceExternalContact() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Computed:         true,
-				ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+				ValidateDiagFunc: validators.ValidatePhoneNumber,
 			},
 			"country_code": {
 				Description: "Phone number country code.",
@@ -95,7 +95,7 @@ func ResourceExternalContact() *schema.Resource {
 				Description:      "Contact address country code.",
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateDiagFunc: gcloud.ValidateCountryCode,
+				ValidateDiagFunc: validators.ValidateCountryCode,
 			},
 		},
 	}

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_schema.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_schema.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 const resourceName = "genesyscloud_outbound_callabletimeset"
@@ -23,13 +23,13 @@ var campaignTimeslotResource = &schema.Resource{
 		`start_time`: {
 			Description:      `The start time of the interval as an ISO-8601 string, i.e. HH:mm:ss`,
 			Required:         true,
-			ValidateDiagFunc: gcloud.ValidateTime,
+			ValidateDiagFunc: validators.ValidateTime,
 			Type:             schema.TypeString,
 		},
 		`stop_time`: {
 			Description:      `The end time of the interval as an ISO-8601 string, i.e. HH:mm:ss`,
 			Required:         true,
-			ValidateDiagFunc: gcloud.ValidateTime,
+			ValidateDiagFunc: validators.ValidateTime,
 			Type:             schema.TypeString,
 		},
 		`day`: {

--- a/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_schema.go
+++ b/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_schema.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 const resourceName = "genesyscloud_outbound_dnclist"
@@ -90,7 +90,7 @@ func ResourceOutboundDncList() *schema.Resource {
 							Description:      `Expiration date for DNC phone numbers in yyyy-MM-ddTHH:mmZ format.`,
 							Optional:         true,
 							Type:             schema.TypeString,
-							ValidateDiagFunc: gcloud.ValidateDateTime,
+							ValidateDiagFunc: validators.ValidateDateTime,
 						},
 						`phone_numbers`: {
 							Description: `Phone numbers to add to a DNC list. Only possible if the dncSourceType is rds.  Phone numbers must be in an E.164 number format.`,
@@ -98,7 +98,7 @@ func ResourceOutboundDncList() *schema.Resource {
 							Type:        schema.TypeList,
 							Elem: &schema.Schema{
 								Type:             schema.TypeString,
-								ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+								ValidateDiagFunc: validators.ValidatePhoneNumber,
 							},
 						},
 					},

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_schema.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_schema.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 /*
@@ -67,13 +67,13 @@ var (
 			`earliest_callable_time`: {
 				Description:      "The earliest time to dial a contact. Valid format is HH:mm",
 				Optional:         true,
-				ValidateDiagFunc: gcloud.ValidateTimeHHMM,
+				ValidateDiagFunc: validators.ValidateTimeHHMM,
 				Type:             schema.TypeString,
 			},
 			`latest_callable_time`: {
 				Description:      "The latest time to dial a contact. Valid format is HH:mm.",
 				Optional:         true,
-				ValidateDiagFunc: gcloud.ValidateTimeHHMM,
+				ValidateDiagFunc: validators.ValidateTimeHHMM,
 				Type:             schema.TypeString,
 			},
 		},
@@ -83,13 +83,13 @@ var (
 			`earliest_callable_time`: {
 				Description:      "The earliest time to dial a contact. Valid format is HH:mm.",
 				Optional:         true,
-				ValidateDiagFunc: gcloud.ValidateTimeHHMM,
+				ValidateDiagFunc: validators.ValidateTimeHHMM,
 				Type:             schema.TypeString,
 			},
 			`latest_callable_time`: {
 				Description:      "The latest time to dial a contact. Valid format is HH:mm.",
 				Optional:         true,
-				ValidateDiagFunc: gcloud.ValidateTimeHHMM,
+				ValidateDiagFunc: validators.ValidateTimeHHMM,
 				Type:             schema.TypeString,
 			},
 			`time_zone_id`: {

--- a/genesyscloud/resource_genesyscloud_widget_deployment.go
+++ b/genesyscloud/resource_genesyscloud_widget_deployment.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"net/url"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
+	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -15,9 +15,8 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
-	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
+	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
-	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -25,33 +24,8 @@ import (
 )
 
 const (
-	V1            = "v1"
-	V1HTTP        = "v1-http"
-	V2            = "v2"
-	THIRDPARTY    = "third-party"
-	HTTPSPROTOCOL = "https"
-	WEBSKINBASIC  = "basic"
-	WEBSKINMODERN = "modern-caret-skin"
-)
-
-var (
-	clientConfigSchemaResource = &schema.Resource{
-		Schema: map[string]*schema.Schema{
-			"webchat_skin": {
-				Description:  "Skin for the webchat user. (basic, modern-caret-skin)",
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{WEBSKINBASIC, WEBSKINMODERN}, false),
-			},
-			"authentication_url": {
-				Description:      "Url endpoint to perform_authentication",
-				Type:             schema.TypeString,
-				Required:         false,
-				Optional:         true,
-				ValidateDiagFunc: validateAuthURL,
-			},
-		},
-	}
+	V2         = "v2"
+	THIRDPARTY = "third-party"
 )
 
 func getAllWidgetDeployments(_ context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
@@ -67,78 +41,6 @@ func getAllWidgetDeployments(_ context.Context, clientConfig *platformclientv2.C
 	}
 
 	return resources, nil
-}
-
-func buildSdkAllowedDomains(d *schema.ResourceData) *[]string {
-	allowed_domains := []string{}
-	if domains, ok := d.GetOk("allowed_domains"); ok {
-		allowed_domains = lists.InterfaceListToStrings(domains.([]interface{}))
-	}
-	return &allowed_domains
-}
-
-func parseSdkClientConfigData(d *schema.ResourceData) (webchatSkin *string, authenticationUrl *string) {
-	clientConfigSet := d.Get("client_config").(*schema.Set)
-
-	if clientConfigSet != nil && len(clientConfigSet.List()) > 0 {
-		clientConfig := clientConfigSet.List()[0].(map[string]interface{})
-		fields := make(map[string]string)
-
-		for k, v := range clientConfig {
-			fields[k] = v.(string)
-		}
-
-		webchatSkin := fields["webchat_skin"]
-		authUrl := fields["authentication_url"]
-		return &webchatSkin, &authUrl
-	}
-	return nil, nil
-}
-
-func validateAuthURL(authUrl interface{}, _ cty.Path) diag.Diagnostics {
-	authUrlString := authUrl.(string)
-	u, err := url.Parse(authUrlString)
-	if err != nil {
-		return util.BuildDiagnosticError("genesyscloud_widget_deployment", fmt.Sprintf("Authorization url %s provided is not a valid URL", authUrlString), err)
-	}
-
-	if u.Scheme == "" || u.Host == "" {
-		log.Printf("Scheme: %s", u.Scheme)
-		log.Printf("Host: %s", u.Host)
-		return util.BuildDiagnosticError("genesyscloud_widget_deployment", fmt.Sprintf("Authorization url %s provided is not valid url", authUrlString), fmt.Errorf("authorization url provided is not valid url"))
-	}
-
-	if u.Scheme != HTTPSPROTOCOL {
-		return util.BuildDiagnosticError("genesyscloud_widget_deployment", fmt.Sprintf("Authorization url provided must begin with https"), fmt.Errorf("authorization url provided must begin with https"))
-
-	}
-
-	return nil
-}
-
-func buildSDKClientConfig(clientType string, d *schema.ResourceData) (*platformclientv2.Widgetclientconfig, error) {
-	widgetClientConfig := &platformclientv2.Widgetclientconfig{}
-	clientConfig := d.Get("client_config").(*schema.Set)
-
-	if (clientType == V1 || clientType == V1HTTP) && clientConfig.Len() == 0 {
-		return nil, fmt.Errorf("V1 and v1-http widget configurations must have a client_config defined. ")
-	}
-
-	if clientType == V1 {
-		v1Client := &platformclientv2.Widgetclientconfigv1{}
-
-		v1Client.WebChatSkin, v1Client.AuthenticationUrl = parseSdkClientConfigData(d)
-
-		widgetClientConfig.V1 = v1Client
-	}
-
-	if clientType == V1HTTP {
-		v1HttpClient := &platformclientv2.Widgetclientconfigv1http{}
-		v1HttpClient.WebChatSkin, v1HttpClient.AuthenticationUrl = parseSdkClientConfigData(d)
-		widgetClientConfig.V1Http = v1HttpClient
-	}
-
-	return widgetClientConfig, nil
 }
 
 func WidgetDeploymentExporter() *resourceExporter.ResourceExporter {
@@ -192,54 +94,32 @@ func ResourceWidgetDeployment() *schema.Resource {
 				Description: "The list of domains that are approved to use this Deployment; the list will be added to CORS headers for ease of web use",
 				Type:        schema.TypeList,
 				Elem:        &schema.Schema{Type: schema.TypeString},
-				Required:    false,
 				Optional:    true,
 			},
 			"client_type": {
 				Description:  "The type of display widget for which this Deployment is configured, which controls the administrator settings shown.Valid values: v1, v2, v1-http, third-party.",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{V1, V2, V1HTTP, THIRDPARTY}, false),
+				ValidateFunc: validation.StringInSlice([]string{V2, THIRDPARTY}, false),
 			},
 			"client_config": {
-				Description: " The V1 and V1-http client configuration options that should be made available to the clients of this Deployment.",
-				Type:        schema.TypeSet,
-				MaxItems:    1,
+				Description: "The client configuration options that should be made available to the clients of this Deployment. The map key should match the client_type for this deployment. MaxItems: 1",
+				Type:        schema.TypeMap,
 				Optional:    true,
-				Elem:        clientConfigSchemaResource,
+			},
+			"v2_client_config": {
+				Description: "The v2 client configuration options that should be made available to the clients of this Deployment.",
+				Type:        schema.TypeMap,
+				Optional:    true,
+			},
+			"third_party_client_config": {
+				Description:   "The third party client configuration options that should be made available to the clients of this Deployment.",
+				Type:          schema.TypeMap,
+				Optional:      true,
+				ConflictsWith: []string{"v2_client_config"},
 			},
 		},
 	}
-}
-
-func flattenClientConfig(clientType string, clientConfig platformclientv2.Widgetclientconfig) *schema.Set {
-	clientConfigSet := schema.NewSet(schema.HashResource(clientConfigSchemaResource), []interface{}{})
-
-	clientConfigMap := make(map[string]interface{})
-
-	if clientType == V1 {
-		if clientConfig.V1.WebChatSkin != nil {
-			clientConfigMap["webchat_skin"] = *clientConfig.V1.WebChatSkin
-		}
-
-		if clientConfig.V1.AuthenticationUrl != nil {
-			clientConfigMap["authentication_url"] = *clientConfig.V1.AuthenticationUrl
-		}
-	}
-
-	if clientType == V1HTTP {
-		if clientConfig.V1Http.WebChatSkin != nil {
-			clientConfigMap["webchat_skin"] = *clientConfig.V1Http.WebChatSkin
-		}
-
-		if clientConfig.V1Http.AuthenticationUrl != nil {
-			clientConfigMap["authentication_url"] = *clientConfig.V1Http.AuthenticationUrl
-		}
-	}
-
-	clientConfigSet.Add(clientConfigMap)
-
-	return clientConfigSet
 }
 
 func readWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -259,47 +139,15 @@ func readWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta inte
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError("genesyscloud_widget_deployment", fmt.Sprintf("Failed to read widget deployment %s | error: %s", d.Id(), getErr), resp))
 		}
 
-		d.Set("name", *currentWidget.Name)
-		if currentWidget.Description != nil {
-			d.Set("description", *currentWidget.Description)
-		} else {
-			d.Set("description", nil)
-		}
-
-		if currentWidget.AuthenticationRequired != nil {
-			d.Set("authentication_required", *currentWidget.AuthenticationRequired)
-		} else {
-			d.Set("authentication_required", nil)
-		}
-
-		if currentWidget.Disabled != nil {
-			d.Set("disabled", *currentWidget.Disabled)
-		} else {
-			d.Set("disabled", nil)
-		}
-
-		if currentWidget.Flow != nil {
-			d.Set("flow_id", *currentWidget.Flow.Id)
-		} else {
-			d.Set("flow_id", nil)
-		}
-
-		if currentWidget.AllowedDomains != nil {
-			d.Set("allowed_domains", *currentWidget.AllowedDomains)
-		} else {
-			d.Set("allowed_domains", nil)
-		}
-
-		if currentWidget.ClientType != nil {
-			d.Set("client_type", *currentWidget.ClientType)
-		} else {
-			d.Set("client_type", nil)
-		}
-
+		_ = d.Set("name", *currentWidget.Name)
+		resourcedata.SetNillableValue(d, "description", currentWidget.Description)
+		resourcedata.SetNillableValue(d, "authentication_required", currentWidget.AuthenticationRequired)
+		resourcedata.SetNillableValue(d, "disabled", currentWidget.Disabled)
+		resourcedata.SetNillableValue(d, "allowed_domains", currentWidget.AllowedDomains)
+		resourcedata.SetNillableValue(d, "client_type", currentWidget.ClientType)
+		resourcedata.SetNillableReference(d, "flow_id", currentWidget.Flow)
 		if currentWidget.ClientConfig != nil {
-			d.Set("client_config", flattenClientConfig(*currentWidget.ClientType, *currentWidget.ClientConfig))
-		} else {
-			d.Set("client_config", nil)
+			flattenClientConfig(d, *currentWidget.ClientConfig)
 		}
 
 		return cc.CheckState(d)
@@ -308,30 +156,19 @@ func readWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta inte
 
 func createWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	name := d.Get("name").(string)
-	description := d.Get("description").(string)
-	auth_required := d.Get("authentication_required").(bool)
-	disabled := d.Get("disabled").(bool)
-	flowId := util.BuildSdkDomainEntityRef(d, "flow_id")
-	allowed_domains := buildSdkAllowedDomains(d) //Need to make this an array of strings.
-	client_type := d.Get("client_type").(string)
-	client_config, client_config_err := buildSDKClientConfig(client_type, d)
-
-	if client_config_err != nil {
-		return util.BuildDiagnosticError("genesyscloud_widget_deployment", fmt.Sprintf("Failed to create widget deployment %s", name), client_config_err)
-	}
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	widgetsAPI := platformclientv2.NewWidgetsApiWithConfig(sdkConfig)
 
 	createWidget := platformclientv2.Widgetdeployment{
 		Name:                   &name,
-		Description:            &description,
-		AuthenticationRequired: &auth_required,
-		Disabled:               &disabled,
-		Flow:                   flowId,
-		AllowedDomains:         allowed_domains,
-		ClientType:             &client_type,
-		ClientConfig:           client_config,
+		Description:            platformclientv2.String(d.Get("description").(string)),
+		AuthenticationRequired: platformclientv2.Bool(d.Get("authentication_required").(bool)),
+		Disabled:               platformclientv2.Bool(d.Get("disabled").(bool)),
+		Flow:                   util.BuildSdkDomainEntityRef(d, "flow_id"),
+		AllowedDomains:         buildSdkAllowedDomains(d),
+		ClientType:             platformclientv2.String(d.Get("client_type").(string)),
+		ClientConfig:           buildSDKClientConfig(d),
 	}
 
 	log.Printf("Creating widgets deployment %s", name)
@@ -353,28 +190,6 @@ func createWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta in
 	deletePotentialDuplicateDeployments(widgetsAPI, name, *widget.Id, resourceIDMetaMap, newResourceIDMetaMap)
 
 	return readWidgetDeployment(ctx, d, meta)
-}
-
-// Sometimes the Widget API creates 2 deployments due to a bug. This function will delete any duplicates
-func deletePotentialDuplicateDeployments(widgetAPI *platformclientv2.WidgetsApi, name, id string, existingResourceIDMetaMap, newResourceIDMetaMap resourceExporter.ResourceIDMetaMap) {
-	for _, val := range existingResourceIDMetaMap {
-		for key1, val1 := range newResourceIDMetaMap {
-			if val.Name == val1.Name {
-				delete(newResourceIDMetaMap, key1)
-				break
-			}
-		}
-	}
-
-	for key, val := range newResourceIDMetaMap {
-		if key != id && val.Name == name {
-			log.Printf("Deleting duplicate widget deployment %s", name)
-			_, err := widgetAPI.DeleteWidgetsDeployment(key)
-			if err != nil {
-				log.Printf("failed to delete widget deployment %s: %s", name, err)
-			}
-		}
-	}
 }
 
 func deleteWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -404,30 +219,19 @@ func deleteWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta in
 
 func updateWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	name := d.Get("name").(string)
-	description := d.Get("description").(string)
-	auth_required := d.Get("authentication_required").(bool)
-	disabled := d.Get("disabled").(bool)
-	flowId := util.BuildSdkDomainEntityRef(d, "flow_id")
-	allowed_domains := buildSdkAllowedDomains(d) //Need to make this an array of strings.
-	client_type := d.Get("client_type").(string)
-	client_config, client_config_err := buildSDKClientConfig(client_type, d)
-
-	if client_config_err != nil {
-		return util.BuildDiagnosticError("genesyscloud_widget_deployment", fmt.Sprintf("Failed updating widget deployment %s", name), client_config_err)
-	}
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	widgetsAPI := platformclientv2.NewWidgetsApiWithConfig(sdkConfig)
 
 	updateWidget := platformclientv2.Widgetdeployment{
 		Name:                   &name,
-		Description:            &description,
-		AuthenticationRequired: &auth_required,
-		Disabled:               &disabled,
-		Flow:                   flowId,
-		AllowedDomains:         allowed_domains,
-		ClientType:             &client_type,
-		ClientConfig:           client_config,
+		Description:            platformclientv2.String(d.Get("description").(string)),
+		AuthenticationRequired: platformclientv2.Bool(d.Get("authentication_required").(bool)),
+		Disabled:               platformclientv2.Bool(d.Get("disabled").(bool)),
+		Flow:                   util.BuildSdkDomainEntityRef(d, "flow_id"),
+		AllowedDomains:         buildSdkAllowedDomains(d),
+		ClientType:             platformclientv2.String(d.Get("client_type").(string)),
+		ClientConfig:           buildSDKClientConfig(d),
 	}
 
 	log.Printf("Updating widget deployment %s", name)
@@ -439,4 +243,62 @@ func updateWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta in
 
 	log.Printf("Finished updating widget deployment %s", name)
 	return readWidgetDeployment(ctx, d, meta)
+}
+
+func buildSDKClientConfig(d *schema.ResourceData) *platformclientv2.Widgetclientconfig {
+	v2ClientConfig := d.Get("v2_client_config")
+	if m, ok := v2ClientConfig.(map[string]any); ok && len(m) > 0 {
+		return &platformclientv2.Widgetclientconfig{V2: &v2ClientConfig}
+	}
+	thirdPartyClientConfig := d.Get("third_party_client_config")
+	if m, ok := thirdPartyClientConfig.(map[string]any); ok && len(m) > 0 {
+		return &platformclientv2.Widgetclientconfig{ThirdParty: &thirdPartyClientConfig}
+	}
+	return nil
+}
+
+func buildSdkAllowedDomains(d *schema.ResourceData) *[]string {
+	if domains, ok := d.Get("allowed_domains").([]any); ok {
+		allowedDomains := lists.InterfaceListToStrings(domains)
+		return &allowedDomains
+	}
+	return nil
+}
+
+func flattenClientConfig(d *schema.ResourceData, config platformclientv2.Widgetclientconfig) {
+	if config.ThirdParty != nil {
+		thirdParty := *config.ThirdParty
+		if thirdPartyMap, _ := thirdParty.(map[string]any); len(thirdPartyMap) > 0 {
+			_ = d.Set("third_party_client_config", thirdPartyMap)
+			return
+		}
+	}
+	if config.V2 != nil {
+		v2Config := *config.V2
+		if v2ConfigMap, _ := v2Config.(map[string]any); len(v2ConfigMap) > 0 {
+			_ = d.Set("v2_client_config", v2ConfigMap)
+		}
+	}
+}
+
+// deletePotentialDuplicateDeployments Sometimes the Widget API creates 2 deployments due to a bug. This function will delete any duplicates
+func deletePotentialDuplicateDeployments(widgetAPI *platformclientv2.WidgetsApi, name, id string, existingResourceIDMetaMap, newResourceIDMetaMap resourceExporter.ResourceIDMetaMap) {
+	for _, val := range existingResourceIDMetaMap {
+		for key1, val1 := range newResourceIDMetaMap {
+			if val.Name == val1.Name {
+				delete(newResourceIDMetaMap, key1)
+				break
+			}
+		}
+	}
+
+	for key, val := range newResourceIDMetaMap {
+		if key != id && val.Name == name {
+			log.Printf("Deleting duplicate widget deployment %s", name)
+			_, err := widgetAPI.DeleteWidgetsDeployment(key)
+			if err != nil {
+				log.Printf("failed to delete widget deployment %s: %s", name, err)
+			}
+		}
+	}
 }

--- a/genesyscloud/resource_genesyscloud_widget_deployment.go
+++ b/genesyscloud/resource_genesyscloud_widget_deployment.go
@@ -102,11 +102,6 @@ func ResourceWidgetDeployment() *schema.Resource {
 				Required:     true,
 				ValidateFunc: validation.StringInSlice([]string{V2, THIRDPARTY}, false),
 			},
-			"client_config": {
-				Description: "The client configuration options that should be made available to the clients of this Deployment. The map key should match the client_type for this deployment. MaxItems: 1",
-				Type:        schema.TypeMap,
-				Optional:    true,
-			},
 			"v2_client_config": {
 				Description: "The v2 client configuration options that should be made available to the clients of this Deployment.",
 				Type:        schema.TypeMap,

--- a/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_schema.go
+++ b/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_schema.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 // SetRegistrar registers all the resources, data sources and exporters in the package
@@ -68,7 +68,7 @@ func ResourceRoutingSmsAddress() *schema.Resource {
 				Required:         true,
 				ForceNew:         true,
 				Type:             schema.TypeString,
-				ValidateDiagFunc: gcloud.ValidateCountryCode,
+				ValidateDiagFunc: validators.ValidateCountryCode,
 			},
 			`auto_correct_address`: {
 				Description: `This is used when the address is created. If the value is not set or true, then the system will, if necessary, auto-correct the address you provide. Set this value to false if the system should not auto-correct the address.`,

--- a/genesyscloud/scripts/resource_scripts_schema.go
+++ b/genesyscloud/scripts/resource_scripts_schema.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 /*
@@ -59,7 +59,7 @@ func ResourceScript() *schema.Resource {
 				Description:  "Path to the script file to upload.",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: gcloud.ValidatePath,
+				ValidateFunc: validators.ValidatePath,
 			},
 			"file_content_hash": {
 				Description: "Hash value of the script file content. Used to detect changes.",

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_schema.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_schema.go
@@ -7,7 +7,7 @@ import (
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
 	"terraform-provider-genesyscloud/genesyscloud/util"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 /*
@@ -91,14 +91,14 @@ func ResourceTaskManagementWorkitem() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				Type:             schema.TypeString,
-				ValidateDiagFunc: gcloud.ValidateLocalDateTimes,
+				ValidateDiagFunc: validators.ValidateLocalDateTimes,
 			},
 			`date_expires`: {
 				Description:      `The expiry date of the Workitem. Date time is represented as an ISO-8601 string. For example: yyyy-MM-ddTHH:mm:ss[.mmm]Z`,
 				Optional:         true,
 				Computed:         true,
 				Type:             schema.TypeString,
-				ValidateDiagFunc: gcloud.ValidateLocalDateTimes,
+				ValidateDiagFunc: validators.ValidateLocalDateTimes,
 			},
 			`duration_seconds`: {
 				Description: `The estimated duration in seconds to complete the workitem.`,

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_schema.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_schema.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -77,7 +77,7 @@ func ResourceTaskManagementWorktype() *schema.Resource {
 				Optional:         true,
 				Computed:         true,
 				Type:             schema.TypeString,
-				ValidateDiagFunc: gcloud.ValidateTime,
+				ValidateDiagFunc: validators.ValidateTime,
 			},
 		},
 	}

--- a/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_schema.go
+++ b/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_schema.go
@@ -4,7 +4,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 const resourceName = "genesyscloud_telephony_providers_edges_did"
@@ -24,7 +24,7 @@ func DataSourceDid() *schema.Resource {
 				Description:      "Phone number for the DID.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+				ValidateDiagFunc: validators.ValidatePhoneNumber,
 			},
 		},
 	}

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_schema.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_schema.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 const resourceName = "genesyscloud_telephony_providers_edges_did_pool"
@@ -44,13 +44,13 @@ func ResourceTelephonyDidPool() *schema.Resource {
 				Description:      "Starting phone number of the DID Pool range. Phone number must be in a E.164 number format. Changing the start_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+				ValidateDiagFunc: validators.ValidatePhoneNumber,
 			},
 			"end_phone_number": {
 				Description:      "Ending phone number of the DID Pool range.  Phone number must be in an E.164 number format. Changing the end_phone_number attribute will cause the did_pool object to be dropped and recreated with a new ID.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+				ValidateDiagFunc: validators.ValidatePhoneNumber,
 			},
 			"description": {
 				Description: "DID Pool description.",
@@ -83,13 +83,13 @@ func DataSourceDidPool() *schema.Resource {
 				Description:      "Starting phone number of the DID Pool range. Must be in an E.164 number format.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+				ValidateDiagFunc: validators.ValidatePhoneNumber,
 			},
 			"end_phone_number": {
 				Description:      "Ending phone number of the DID Pool range.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+				ValidateDiagFunc: validators.ValidatePhoneNumber,
 			},
 		},
 	}

--- a/genesyscloud/telephony_providers_edges_extension_pool/genesyscloud_telephony_providers_edges_extension_pool_schema.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/genesyscloud_telephony_providers_edges_extension_pool_schema.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 const (
@@ -29,14 +29,14 @@ func ResourceTelephonyExtensionPool() *schema.Resource {
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: gcloud.ValidateExtensionPool,
+				ValidateDiagFunc: validators.ValidateExtensionPool,
 			},
 			"end_number": {
 				Description:      "Ending phone number of the Extension Pool range. Changing the end_number attribute will cause the extension object to be dropped and recreated with a new ID.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ForceNew:         true,
-				ValidateDiagFunc: gcloud.ValidateExtensionPool,
+				ValidateDiagFunc: validators.ValidateExtensionPool,
 			},
 			"description": {
 				Description: "Extension Pool description.",
@@ -56,13 +56,13 @@ func DataSourceExtensionPool() *schema.Resource {
 				Description:      "Starting number of the Extension Pool range.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidateExtensionPool,
+				ValidateDiagFunc: validators.ValidateExtensionPool,
 			},
 			"end_number": {
 				Description:      "Ending number of the Extension Pool range.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidateExtensionPool,
+				ValidateDiagFunc: validators.ValidateExtensionPool,
 			},
 		},
 	}
@@ -76,7 +76,7 @@ func TelephonyExtensionPoolExporter() *resourceExporter.ResourceExporter {
 }
 
 func SetRegistrar(l registrar.Registrar) {
-	l.RegisterDataSource("genesyscloud_telephony_providers_edges_extension_pool", DataSourceExtensionPool())
-	l.RegisterResource("genesyscloud_telephony_providers_edges_extension_pool", ResourceTelephonyExtensionPool())
-	l.RegisterExporter("genesyscloud_telephony_providers_edges_extension_pool", TelephonyExtensionPoolExporter())
+	l.RegisterDataSource(resourceName, DataSourceExtensionPool())
+	l.RegisterResource(resourceName, ResourceTelephonyExtensionPool())
+	l.RegisterExporter(resourceName, TelephonyExtensionPoolExporter())
 }

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_schema.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_schema.go
@@ -5,7 +5,7 @@ import (
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
 	"terraform-provider-genesyscloud/genesyscloud/util"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -140,7 +140,7 @@ func ResourcePhone() *schema.Resource {
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,
-				Elem:        &schema.Schema{Type: schema.TypeString, ValidateDiagFunc: gcloud.ValidatePhoneNumber},
+				Elem:        &schema.Schema{Type: schema.TypeString, ValidateDiagFunc: validators.ValidatePhoneNumber},
 			},
 			"properties": {
 				Description:      "phone properties",

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 /*
@@ -90,7 +90,7 @@ func ResourceSite() *schema.Resource {
 				Description:      "A reoccurring rule for updating the Edges assigned to the site. The only supported frequencies are daily and weekly. Weekly frequencies require a day list with at least oneday specified. All other configurations are not supported.",
 				Type:             schema.TypeString,
 				Required:         true,
-				ValidateDiagFunc: gcloud.ValidateRrule,
+				ValidateDiagFunc: validators.ValidateRrule,
 			},
 			"start": {
 				Description: "Date time is represented as an ISO-8601 string without a timezone. For example: yyyy-MM-ddTHH:mm:ss.SSS",
@@ -221,7 +221,7 @@ func ResourceSite() *schema.Resource {
 				Description:      "The caller ID value for the site. The callerID must be a valid E.164 formatted phone number",
 				Type:             schema.TypeString,
 				Optional:         true,
-				ValidateDiagFunc: gcloud.ValidatePhoneNumber,
+				ValidateDiagFunc: validators.ValidatePhoneNumber,
 			},
 			"caller_name": {
 				Description: "The caller name for the site",

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 
@@ -48,7 +48,7 @@ func ResourceTfExport() *schema.Resource {
 				Optional:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: gcloud.ValidateSubStringInSlice(resourceExporter.GetAvailableExporterTypes()),
+					ValidateFunc: validators.ValidateSubStringInSlice(resourceExporter.GetAvailableExporterTypes()),
 				},
 				ForceNew:      true,
 				Deprecated:    "Use include_filter_resources attribute instead",
@@ -60,7 +60,7 @@ func ResourceTfExport() *schema.Resource {
 				Optional:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: gcloud.ValidateSubStringInSlice(resourceExporter.GetAvailableExporterTypes()),
+					ValidateFunc: validators.ValidateSubStringInSlice(resourceExporter.GetAvailableExporterTypes()),
 				},
 				ForceNew:      true,
 				ConflictsWith: []string{"resource_types", "exclude_filter_resources"},
@@ -80,7 +80,7 @@ func ResourceTfExport() *schema.Resource {
 				Optional:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
-					ValidateFunc: gcloud.ValidateSubStringInSlice(resourceExporter.GetAvailableExporterTypes()),
+					ValidateFunc: validators.ValidateSubStringInSlice(resourceExporter.GetAvailableExporterTypes()),
 				},
 				ForceNew:      true,
 				ConflictsWith: []string{"resource_types", "include_filter_resources"},

--- a/genesyscloud/util/resourcedata/resourcedata.go
+++ b/genesyscloud/util/resourcedata/resourcedata.go
@@ -147,21 +147,21 @@ func SetNillableValue[T any](d *schema.ResourceData, key string, value *T) {
 	}
 }
 
-// SetNillableValueWithInterfaceArrayWithFunc will read the values in a nested resource using the provided function and set it on the schema
+// SetNillableValueWithInterfaceArrayWithFunc will set the value of {key} to an interface array using func {f} if {value} is not nil
 func SetNillableValueWithInterfaceArrayWithFunc[T any](d *schema.ResourceData, key string, value *T, f func(*T) []interface{}) {
 	if value != nil {
-		d.Set(key, f(value))
+		_ = d.Set(key, f(value))
 	} else {
-		d.Set(key, nil)
+		_ = d.Set(key, nil)
 	}
 }
 
-// SetNillableValueWithInterfaceArrayWithFunc will read the values in a nested resource using the provided function and set it on the schema
+// SetNillableValueWithSchemaSetWithFunc will set the value of {key} to a *schema.Set using func {f} if {value} is not nil
 func SetNillableValueWithSchemaSetWithFunc[T any](d *schema.ResourceData, key string, value *T, f func(*T) *schema.Set) {
 	if value != nil {
-		d.Set(key, f(value))
+		_ = d.Set(key, f(value))
 	} else {
-		d.Set(key, nil)
+		_ = d.Set(key, nil)
 	}
 }
 

--- a/genesyscloud/validators/validators.go
+++ b/genesyscloud/validators/validators.go
@@ -94,7 +94,7 @@ func ValidateRrule(rrule interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Provided rrule %v is not in string format", rrule)
 }
 
-// Validates a phone extension pool
+// ValidateExtensionPool validates a phone extension pool
 func ValidateExtensionPool(number interface{}, _ cty.Path) diag.Diagnostics {
 	if numberStr, ok := number.(string); ok {
 
@@ -109,7 +109,7 @@ func ValidateExtensionPool(number interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Extension provided %v is not a string", number)
 }
 
-// Validates a date string is in the format yyyy-MM-dd
+// ValidateDate validates a date string is in the format yyyy-MM-dd
 func ValidateDate(date interface{}, _ cty.Path) diag.Diagnostics {
 	if dateStr, ok := date.(string); ok {
 		_, err := time.Parse(resourcedata.DateParseFormat, dateStr)
@@ -121,7 +121,7 @@ func ValidateDate(date interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Date %v is not a string", date)
 }
 
-// Validates a date string is in the format 2006-01-02T15:04Z
+// ValidateDateTime validates a date string is in the format 2006-01-02T15:04Z
 func ValidateDateTime(date interface{}, _ cty.Path) diag.Diagnostics {
 	if dateStr, ok := date.(string); ok {
 		_, err := time.Parse("2006-01-02T15:04Z", dateStr)
@@ -133,7 +133,7 @@ func ValidateDateTime(date interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Date %v is not a string", date)
 }
 
-// Validates a country code is in format ISO 3166-1 alpha-2
+// ValidateCountryCode validates a country code is in format ISO 3166-1 alpha-2
 func ValidateCountryCode(code interface{}, _ cty.Path) diag.Diagnostics {
 	countryCode := code.(string)
 	if len(countryCode) == 2 {
@@ -144,7 +144,7 @@ func ValidateCountryCode(code interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Country code %v is not of format ISO 3166-1 alpha-2", code)
 }
 
-// Validates a date string is in format hh:mm:ss
+// ValidateTime validates a date string is in format hh:mm:ss
 func ValidateTime(time interface{}, _ cty.Path) diag.Diagnostics {
 	timeStr := time.(string)
 	if len(timeStr) > 9 {
@@ -157,7 +157,7 @@ func ValidateTime(time interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Time %v is not a valid time", time)
 }
 
-// Validates a date string is in format hh:mm
+// ValidateTimeHHMM validates a date string is in format hh:mm
 func ValidateTimeHHMM(time interface{}, _ cty.Path) diag.Diagnostics {
 	timeStr := time.(string)
 	if timeStr == "" {
@@ -171,7 +171,7 @@ func ValidateTimeHHMM(time interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Time %v is not a valid time, must use format HH:mm", time)
 }
 
-// Validates a date string is in the format 2006-01-02T15:04:05.000000
+// ValidateLocalDateTimes validates a date string is in the format 2006-01-02T15:04:05.000000
 func ValidateLocalDateTimes(date interface{}, _ cty.Path) diag.Diagnostics {
 	if dateStr, ok := date.(string); ok {
 		_, err := time.Parse(resourcedata.TimeParseFormat, dateStr)
@@ -183,7 +183,7 @@ func ValidateLocalDateTimes(date interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Errorf("Date %v is not a string", date)
 }
 
-// Validates a file path or URL
+// ValidatePath validates a file path or URL
 func ValidatePath(i interface{}, k string) (warnings []string, errors []error) {
 	v, ok := i.(string)
 	if !ok {
@@ -207,7 +207,7 @@ func ValidatePath(i interface{}, k string) (warnings []string, errors []error) {
 	return warnings, errors
 }
 
-// Validate a response asset filename matches the criteria outlined in the description
+// ValidateResponseAssetName validate a response asset filename matches the criteria outlined in the description
 func ValidateResponseAssetName(name interface{}, _ cty.Path) diag.Diagnostics {
 	if nameStr, ok := name.(string); ok {
 		matched, err := regexp.MatchString("^[^\\.][^\\`\\\\{\\^\\}\\% \"\\>\\<\\[\\]\\#\\~|]+[^/]$", nameStr)
@@ -250,7 +250,7 @@ func ValidateSubStringInSlice(valid []string) schema.SchemaValidateFunc {
 	}
 }
 
-// Validate if a string matches '#FFFFFF' RGB color representation.
+// ValidateHexColor validates if a string matches '#FFFFFF' RGB color representation.
 func ValidateHexColor(color interface{}, _ cty.Path) diag.Diagnostics {
 	if colorStr, ok := color.(string); ok {
 		matched, err := regexp.MatchString("^#([A-Fa-f0-9]{6})$", colorStr)

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
@@ -4,7 +4,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	gcloud "terraform-provider-genesyscloud/genesyscloud/validators"
+	"terraform-provider-genesyscloud/genesyscloud/validators"
 	wdcUtils "terraform-provider-genesyscloud/genesyscloud/webdeployments_configuration/utils"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -518,13 +518,13 @@ var (
 							Description:      "Background color for hero section, in hexadecimal format, eg #ffffff",
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: gcloud.ValidateHexColor,
+							ValidateDiagFunc: validators.ValidateHexColor,
 						},
 						"text_color": {
 							Description:      "Text color for hero section, in hexadecimal format, eg #ffffff",
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: gcloud.ValidateHexColor,
+							ValidateDiagFunc: validators.ValidateHexColor,
 						},
 						"image_uri": {
 							Description:  "Background image for hero section",
@@ -546,31 +546,31 @@ var (
 							Description:      "Global background color, in hexadecimal format, eg #ffffff",
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: gcloud.ValidateHexColor,
+							ValidateDiagFunc: validators.ValidateHexColor,
 						},
 						"primary_color": {
 							Description:      "Global primary color, in hexadecimal format, eg #ffffff",
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: gcloud.ValidateHexColor,
+							ValidateDiagFunc: validators.ValidateHexColor,
 						},
 						"primary_color_dark": {
 							Description:      "Global dark primary color, in hexadecimal format, eg #ffffff",
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: gcloud.ValidateHexColor,
+							ValidateDiagFunc: validators.ValidateHexColor,
 						},
 						"primary_color_light": {
 							Description:      "Global light primary color, in hexadecimal format, eg #ffffff",
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: gcloud.ValidateHexColor,
+							ValidateDiagFunc: validators.ValidateHexColor,
 						},
 						"text_color": {
 							Description:      "Global text color, in hexadecimal format, eg #ffffff",
 							Type:             schema.TypeString,
 							Required:         true,
-							ValidateDiagFunc: gcloud.ValidateHexColor,
+							ValidateDiagFunc: validators.ValidateHexColor,
 						},
 						"font_family": {
 							Description: "Global font family",


### PR DESCRIPTION
API change is described here - [https://developer.genesys.cloud/forum/t/deprecation-removal-acd-chat-v1-0/25174](https://developer.genesys.cloud/forum/t/deprecation-removal-acd-chat-v1-0/25174)

I also added support for the two other client types - v2 and third-party