### PR TITLE
No jira: fix export unit test

### DIFF
--- a/genesyscloud/telephony/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -403,8 +403,8 @@ func ValidateInboundSiteSettings(inboundSiteString string, trunkBaseMetaId strin
 func TrunkBaseSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllTrunkBaseSettings),
-		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
-			"inbound_site_id": {RefType: "genesyscloud_telephony_providers_edges_site"},
+		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
+			//"inbound_site_id": {RefType: "genesyscloud_telephony_providers_edges_site"}, TODO: decide how/if this will be included after DEVTOOLING-676 is resolved
 		},
 		JsonEncodeAttributes: []string{"properties"},
 	}


### PR DESCRIPTION
PR #1109 caused the unit test `TestForExportCycles` to fail because of a potential cyclic relationship between exported resources. This PR is just commenting out that RefAttr and fixing the unit tests before the release next Tuesday. 

DEVTOOLING-676 has been created to properly investigate the issue in the next sprint.