### PR TITLE
Cleanup/Remove utilization label availability check / mentions

### DIFF
--- a/docs/resources/routing_utilization.md
+++ b/docs/resources/routing_utilization.md
@@ -64,7 +64,7 @@ resource "genesyscloud_routing_utilization" "org-utilization" {
 - `callback` (Block List, Max: 1) Callback media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--callback))
 - `chat` (Block List, Max: 1) Chat media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--chat))
 - `email` (Block List, Max: 1) Email media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--email))
-- `label_utilizations` (Block List) Label utilization settings. If not set, default label settings will be applied. This is in PREVIEW and should not be used unless the feature is available to your organization. (see [below for nested schema](#nestedblock--label_utilizations))
+- `label_utilizations` (Block List) Label utilization settings. If not set, default label settings will be applied. (see [below for nested schema](#nestedblock--label_utilizations))
 - `message` (Block List, Max: 1) Message media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--message))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/docs/resources/routing_utilization_label.md
+++ b/docs/resources/routing_utilization_label.md
@@ -2,11 +2,11 @@
 page_title: "genesyscloud_routing_utilization_label Resource - terraform-provider-genesyscloud"
 subcategory: ""
 description: |-
-  Genesys Cloud Routing Utilization Label. This resource is not yet widely available. Only use it if the feature is enabled.
+  Genesys Cloud Routing Utilization Label.
 ---
 # genesyscloud_routing_utilization_label (Resource)
 
-Genesys Cloud Routing Utilization Label. This resource is not yet widely available. Only use it if the feature is enabled.
+Genesys Cloud Routing Utilization Label.
 
 ## API Usage
 The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Client has been granted the necessary scopes and permissions to perform these operations:

--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -417,7 +417,7 @@ func ResourceUser() *schema.Resource {
 							Elem:        routingUtilization.UtilizationSettingsResource,
 						},
 						"label_utilizations": {
-							Description: "Label utilization settings. If not set, default label settings will be applied. This is in PREVIEW and should not be used unless the feature is available to your organization.",
+							Description: "Label utilization settings. If not set, default label settings will be applied.",
 							Type:        schema.TypeList,
 							Optional:    true,
 							Computed:    true,

--- a/genesyscloud/resource_genesyscloud_user_test.go
+++ b/genesyscloud/resource_genesyscloud_user_test.go
@@ -864,12 +864,7 @@ func TestAccResourceUserroutingUtilWithLabels(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			util.TestAccPreCheck(t)
-			if err := routingUtilizationLabel.CheckIfLabelsAreEnabled(); err != nil {
-				t.Skipf("%v", err) // be sure to skip the test and not fail it
-			}
-		},
+		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
@@ -2,13 +2,14 @@ package routing_utilization
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
 	"time"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const resourceName = "genesyscloud_routing_utilization"
@@ -149,7 +150,7 @@ func ResourceRoutingUtilization() *schema.Resource {
 				Elem:        UtilizationSettingsResource,
 			},
 			"label_utilizations": {
-				Description: "Label utilization settings. If not set, default label settings will be applied. This is in PREVIEW and should not be used unless the feature is available to your organization.",
+				Description: "Label utilization settings. If not set, default label settings will be applied.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Computed:    true,

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v131/platformclientv2"
 )
 
-func TestAccResourceBasicRoutingUtilization(t *testing.T) {
+func TestAccResourceRoutingUtilizationBasic(t *testing.T) {
 	t.Parallel()
 	var (
 		maxCapacity1  = "3"
@@ -114,12 +114,7 @@ func TestAccResourceRoutingUtilizationWithLabels(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			util.TestAccPreCheck(t)
-			if err := routingUtilizationLabel.CheckIfLabelsAreEnabled(); err != nil {
-				t.Skipf("%v", err) // be sure to skip the test and not fail it
-			}
-		},
+		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, nil),
 		Steps: []resource.TestStep{
 			{
@@ -295,7 +290,7 @@ func CleanupRoutingUtilizationLabel() error {
 		const pageSize = 100
 		labels, _, getErr := routingAPI.GetRoutingUtilizationLabels(pageSize, pageNum, "", "")
 		if getErr != nil {
-			log.Printf("failed to get page %v of routing email domains: %v", pageNum, getErr)
+			log.Printf("failed to get page %v of utilization labels: %v", pageNum, getErr)
 			return getErr
 		}
 
@@ -307,7 +302,7 @@ func CleanupRoutingUtilizationLabel() error {
 			if label.Id != nil && strings.HasPrefix(*label.Name, "Terraform") {
 				_, err := routingAPI.DeleteRoutingUtilizationLabel(*label.Id, true)
 				if err != nil {
-					log.Printf("Failed to delete routing email domain %s: %s", *label.Id, err)
+					log.Printf("Failed to delete utilization label %s: %s", *label.Id, err)
 					continue
 				}
 				time.Sleep(5 * time.Second)

--- a/genesyscloud/routing_utilization_label/data_source_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/routing_utilization_label/data_source_genesyscloud_routing_utilization_label_test.go
@@ -18,12 +18,7 @@ func TestAccDataSourceRoutingUtilizationLabel(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			util.TestAccPreCheck(t)
-			if err := CheckIfLabelsAreEnabled(); err != nil {
-				t.Skipf("%v", err) // be sure to skip the test and not fail it
-			}
-		},
+		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_schema.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_schema.go
@@ -1,11 +1,12 @@
 package routing_utilization_label
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const resourceName = "genesyscloud_routing_utilization_label"
@@ -19,7 +20,7 @@ func SetRegistrar(regInstance registrar.Registrar) {
 
 func ResourceRoutingUtilizationLabel() *schema.Resource {
 	return &schema.Resource{
-		Description: "Genesys Cloud Routing Utilization Label. This resource is not yet widely available. Only use it if the feature is enabled.",
+		Description: "Genesys Cloud Routing Utilization Label.",
 
 		CreateContext: provider.CreateWithPooledClient(createRoutingUtilizationLabel),
 		ReadContext:   provider.ReadWithPooledClient(readRoutingUtilizationLabel),

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
@@ -20,12 +20,7 @@ func TestAccResourceRoutingUtilizationLabelBasic(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			util.TestAccPreCheck(t)
-			if err := CheckIfLabelsAreEnabled(); err != nil {
-				t.Skipf("%v", err) // be sure to skip the test and not fail it
-			}
-		},
+		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_utils.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_utils.go
@@ -2,9 +2,7 @@ package routing_utilization_label
 
 import (
 	"fmt"
-	"github.com/mypurecloud/platform-client-sdk-go/v131/platformclientv2"
 	"strings"
-	"terraform-provider-genesyscloud/genesyscloud/provider"
 )
 
 func GenerateRoutingUtilizationLabelResource(resourceID string, name string, dependsOnResource string) string {
@@ -19,20 +17,6 @@ func GenerateRoutingUtilizationLabelResource(resourceID string, name string, dep
 		%s
 	}
 	`, resourceID, name, dependsOn)
-}
-
-func CheckIfLabelsAreEnabled() error { // remove once the feature is globally enabled
-	sdkConfig, err := provider.AuthorizeSdk()
-	if err != nil {
-		return err
-	}
-
-	api := platformclientv2.NewRoutingApiWithConfig(sdkConfig)
-	_, resp, _ := api.GetRoutingUtilizationLabels(100, 1, "", "")
-	if resp.StatusCode == 501 {
-		return fmt.Errorf("feature is not yet implemented in this org.")
-	}
-	return nil
 }
 
 func GenerateLabelUtilization(


### PR DESCRIPTION
Utilization Labels are now GA, so I'm removing the mentions of it not being available and checks from tests, since they're not needed anymore.