### PR TITLE
Cleanup/Use sdk instead of direct calls to deal in routing_utilization

### DIFF
--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -1088,7 +1088,7 @@ func readUserRoutingUtilization(d *schema.ResourceData, sdkConfig *platformclien
 				originalLabelUtilizations := originalSettings["label_utilizations"].([]interface{})
 
 				// Only add to the state the configured labels, in the configured order, but not any extras, to help terraform with matching new and old state.
-				filteredLabelUtilizations := routingUtilization.FilterAndFlattenLabelUtilizations(agentUtilization.LabelUtilizations, originalLabelUtilizations)
+				filteredLabelUtilizations := routingUtilization.FilterAndFlattenLabelUtilizationsInternal(agentUtilization.LabelUtilizations, originalLabelUtilizations)
 
 				allSettings["label_utilizations"] = filteredLabelUtilizations
 			} else {

--- a/genesyscloud/routing_utilization/genesyscloud_routing_utilization_proxy.go
+++ b/genesyscloud/routing_utilization/genesyscloud_routing_utilization_proxy.go
@@ -2,19 +2,15 @@ package routing_utilization
 
 import (
 	"context"
-	"fmt"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
 )
 
 var internalProxy *routingUtilizationProxy
 
-type getRoutingUtilizationFunc func(ctx context.Context, p *routingUtilizationProxy) (*platformclientv2.APIResponse, error)
+type getRoutingUtilizationFunc func(ctx context.Context, p *routingUtilizationProxy) (*platformclientv2.Utilizationresponse, *platformclientv2.APIResponse, error)
 type updateRoutingUtilizationFunc func(ctx context.Context, p *routingUtilizationProxy, request *platformclientv2.Utilizationrequest) (*platformclientv2.Utilizationresponse, *platformclientv2.APIResponse, error)
 type deleteRoutingUtilizationFunc func(ctx context.Context, p *routingUtilizationProxy) (*platformclientv2.APIResponse, error)
-
-type updateDirectlyFunc func(ctx context.Context, p *routingUtilizationProxy, d *schema.ResourceData, utilizationRequest []interface{}) (*platformclientv2.APIResponse, error)
 
 type routingUtilizationProxy struct {
 	clientConfig                 *platformclientv2.Configuration
@@ -22,8 +18,6 @@ type routingUtilizationProxy struct {
 	getRoutingUtilizationAttr    getRoutingUtilizationFunc
 	updateRoutingUtilizationAttr updateRoutingUtilizationFunc
 	deleteRoutingUtilizationAttr deleteRoutingUtilizationFunc
-
-	updateDirectlyAttr updateDirectlyFunc
 }
 
 func newRoutingUtilizationProxy(clientConfig *platformclientv2.Configuration) *routingUtilizationProxy {
@@ -34,8 +28,6 @@ func newRoutingUtilizationProxy(clientConfig *platformclientv2.Configuration) *r
 		getRoutingUtilizationAttr:    getRoutingUtilizationFn,
 		updateRoutingUtilizationAttr: updateRoutingUtilizationFn,
 		deleteRoutingUtilizationAttr: deleteRoutingUtilizationFn,
-
-		updateDirectlyAttr: updateDirectlyFn,
 	}
 }
 
@@ -46,31 +38,20 @@ func getRoutingUtilizationProxy(clientConfig *platformclientv2.Configuration) *r
 	return internalProxy
 }
 
-func (p *routingUtilizationProxy) getRoutingUtilization(ctx context.Context) (*platformclientv2.APIResponse, error) {
+func (p *routingUtilizationProxy) getRoutingUtilization(ctx context.Context) (*platformclientv2.Utilizationresponse, *platformclientv2.APIResponse, error) {
 	return p.getRoutingUtilizationAttr(ctx, p)
 }
+
 func (p *routingUtilizationProxy) updateRoutingUtilization(ctx context.Context, request *platformclientv2.Utilizationrequest) (*platformclientv2.Utilizationresponse, *platformclientv2.APIResponse, error) {
 	return p.updateRoutingUtilizationAttr(ctx, p, request)
 }
+
 func (p *routingUtilizationProxy) deleteRoutingUtilization(ctx context.Context) (*platformclientv2.APIResponse, error) {
 	return p.deleteRoutingUtilizationAttr(ctx, p)
 }
 
-func (p *routingUtilizationProxy) updateDirectly(ctx context.Context, d *schema.ResourceData, utilizationRequest []interface{}) (*platformclientv2.APIResponse, error) {
-	return p.updateDirectlyAttr(ctx, p, d, utilizationRequest)
-}
-
-// Calling the Utilization API directly while the label feature is not available.
-// Once it is, this code can go back to using platformclientv2's RoutingApi to make the call.
-func getRoutingUtilizationFn(ctx context.Context, p *routingUtilizationProxy) (*platformclientv2.APIResponse, error) {
-	apiClient := &p.routingApi.Configuration.APIClient
-	path := fmt.Sprintf("%s/api/v2/routing/utilization", p.routingApi.Configuration.BasePath)
-	headerParams := buildHeaderParams(p.routingApi)
-	resp, err := apiClient.CallAPI(path, "GET", nil, headerParams, nil, nil, "", nil)
-	if err != nil {
-		return resp, fmt.Errorf("failed to get routing utilization %s ", err)
-	}
-	return resp, nil
+func getRoutingUtilizationFn(ctx context.Context, p *routingUtilizationProxy) (*platformclientv2.Utilizationresponse, *platformclientv2.APIResponse, error) {
+	return p.routingApi.GetRoutingUtilization()
 }
 
 func updateRoutingUtilizationFn(ctx context.Context, p *routingUtilizationProxy, utilizationRequest *platformclientv2.Utilizationrequest) (*platformclientv2.Utilizationresponse, *platformclientv2.APIResponse, error) {
@@ -79,22 +60,4 @@ func updateRoutingUtilizationFn(ctx context.Context, p *routingUtilizationProxy,
 
 func deleteRoutingUtilizationFn(ctx context.Context, p *routingUtilizationProxy) (*platformclientv2.APIResponse, error) {
 	return p.routingApi.DeleteRoutingUtilization()
-}
-
-// If the resource has label(s), calls the Utilization API directly.
-// This code can go back to using platformclientv2's RoutingApi to make the call once label utilization is available in platformclientv2's RoutingApi
-func updateDirectlyFn(ctx context.Context, p *routingUtilizationProxy, d *schema.ResourceData, utilizationRequest []interface{}) (*platformclientv2.APIResponse, error) {
-	apiClient := &p.routingApi.Configuration.APIClient
-
-	path := fmt.Sprintf("%s/api/v2/routing/utilization", p.routingApi.Configuration.BasePath)
-	headerParams := buildHeaderParams(p.routingApi)
-	requestPayload := make(map[string]interface{})
-	requestPayload["utilization"] = buildSdkMediaUtilizations(d)
-	requestPayload["labelUtilizations"] = BuildLabelUtilizationsRequest(utilizationRequest)
-
-	resp, err := apiClient.CallAPI(path, "PUT", requestPayload, headerParams, nil, nil, "", nil)
-	if err != nil {
-		return resp, fmt.Errorf("error updating directly %s", err)
-	}
-	return resp, nil
 }


### PR DESCRIPTION
Back when utilization labels were added to cx as code, some attributes weren't public in public-api, so they weren't in the sdk. To make the calls works, we switched to direct calls to public-api, instead of using sdk.

Now the feature is released, we can go back to using the sdk, simplifying the provider.

I'll call it out in the PR, there's a small amount of duplication here, because I'm only cleaning up routing_utilization and not touching user, in the interest of keeping the PR small.

I'll clean up user immediately after this PR, getting rid of said duplication.