### PR TITLE
Fixes DEVTOOLING-674

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -1231,19 +1231,17 @@ func (g *GenesysCloudResourceExporter) sanitizeConfigMap(
 		}
 
 		if exporter.IsAttributeE164(currAttr) {
-			if phoneNumber, ok := configMap[key].(string); !ok || phoneNumber == "" {
+			if _, ok := configMap[key].(string); !ok {
 				continue
 			}
 			configMap[key] = sanitizeE164Number(configMap[key].(string))
-			continue
 		}
 
 		if exporter.IsAttributeRrule(currAttr) {
-			if rrule, ok := configMap[key].(string); !ok || rrule == "" {
+			if _, ok := configMap[key].(string); !ok {
 				continue
 			}
 			configMap[key] = sanitizeRrule(configMap[key].(string))
-			continue
 		}
 
 		switch val.(type) {


### PR DESCRIPTION
Fixes DEVTOOLING-674 by allowing the sanitizeMap function to continue processing as sanitizeE164Number and sanitizeRrule functions could return empty strings. If they do, we want to filter them out (further down the sanitizeMap function) unless they are explicitly marked to be kept by the AllowForZeroValues config to be retained as blank / zero values.

Presumably, when these functions were originally written, they were likely copied from the above if statements that explicitly continue (for good reason). 