### PR TITLE
Bug/Devtooling-677: Error Migrating routes to independent resource

### DIFF
--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"fmt"
 	"log"
+
+	//"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	"terraform-provider-genesyscloud/genesyscloud/util"
+
+	//"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
@@ -63,10 +67,31 @@ func createSiteOutboundRoutes(ctx context.Context, d *schema.ResourceData, meta 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getSiteOutboundRouteProxy(sdkConfig)
 	siteId := d.Get("site_id").(string)
+	outboundRoutes := buildOutboundRoutes(d.Get("outbound_routes").(*schema.Set))
+	var newRoutes []platformclientv2.Outboundroutebase
+
+	// When creating outbound routes, routes may already exist in the site. This can lead to error `Outbound Route Already Exists`
+	// To prevent this, existing routes for the site are obtained and compared with the routes to be created
+	// ONLY non-existing routes are created for the site
+
+	log.Printf("Retrieving existing outbound routes for side %s before creation", siteId)
+
+	outboundRoutesAPI, resp, err := proxy.getSiteOutboundRoutes(ctx, siteId)
+	if err != nil {
+		return util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get outbound routes for site %s error: %s", d.Id(), err), resp)
+	}
+
+	// If the site already has routes, filter and create routes that don't exist
+	// Otherwise, create every route
+	if outboundRoutesAPI != nil && len(*outboundRoutesAPI) > 0 {
+		newRoutes = checkExistingRoutes(outboundRoutes, outboundRoutesAPI, siteId)
+	} else {
+		newRoutes = append(newRoutes, *outboundRoutes...)
+	}
+
 	log.Printf("creating outbound routes for site %s", siteId)
 
-	outboundRoutes := buildOutboundRoutes(d.Get("outbound_routes").(*schema.Set))
-	for _, outboundRoute := range *outboundRoutes {
+	for _, outboundRoute := range newRoutes {
 		_, resp, err := proxy.createSiteOutboundRoute(ctx, siteId, &outboundRoute)
 		if err != nil {
 			return util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to create outbound route %s for site %s: %s", *outboundRoute.Name, siteId, err), resp)
@@ -127,6 +152,7 @@ func readSiteOutboundRoutes(ctx context.Context, d *schema.ResourceData, meta in
 			_ = d.Set("outbound_routes", nil)
 		}
 
+		log.Printf("Read outbound routes for site %s", d.Id())
 		return cc.CheckState(d)
 	})
 }

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
@@ -5,13 +5,11 @@ import (
 	"fmt"
 	"log"
 
-	//"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	//"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_utils.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_utils.go
@@ -1,6 +1,7 @@
 package telephony_providers_edges_site_outbound_route
 
 import (
+	"log"
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -46,4 +47,15 @@ func nameInOutboundRoutes(name string, outboundRoutes []platformclientv2.Outboun
 	}
 
 	return nil, false
+}
+
+func checkExistingRoutes(definedRoutes, apiRoutes *[]platformclientv2.Outboundroutebase, siteId string) (newRoutes []platformclientv2.Outboundroutebase) {
+	for _, definedRoute := range *definedRoutes {
+		if _, present := nameInOutboundRoutes(*definedRoute.Name, *apiRoutes); present {
+			log.Printf("Route %s associated with site %s already exists. Creating only non-existing routes", *definedRoute.Name, siteId)
+		} else {
+			newRoutes = append(newRoutes, definedRoute)
+		}
+	}
+	return newRoutes
 }


### PR DESCRIPTION
When migrating to independent outbound routes resource, the error 
`OutboundRoute with name 'Default Outbound Route' already exists` can occur
This PR checks the existing routes within a site and only creates any new sites, to prevent the error.
This allows users to migrate existing routes, create new routes, or do both at the same time