### PR TITLE
Bug/DEVTOOLING-607: Fixed export for teams resource not finishing

### DIFF
--- a/genesyscloud/team/genesyscloud_team_proxy.go
+++ b/genesyscloud/team/genesyscloud_team_proxy.go
@@ -129,6 +129,7 @@ func createTeamFn(ctx context.Context, p *teamProxy, team *platformclientv2.Team
 func getAllTeamFn(ctx context.Context, p *teamProxy, name string) (*[]platformclientv2.Team, *platformclientv2.APIResponse, error) {
 	var (
 		after    string
+		err      error
 		allTeams []platformclientv2.Team
 		response *platformclientv2.APIResponse
 	)
@@ -152,7 +153,7 @@ func getAllTeamFn(ctx context.Context, p *teamProxy, name string) (*[]platformcl
 			break
 		}
 
-		after, err := util.GetQueryParamValueFromUri(*teams.NextUri, "after")
+		after, err = util.GetQueryParamValueFromUri(*teams.NextUri, "after")
 		if err != nil {
 			return nil, resp, fmt.Errorf("unable to parse after cursor from teams next uri: %v", err)
 		}


### PR DESCRIPTION
https://inindca.atlassian.net/browse/DEVTOOLING-607 - Export did not finish and was stuck on the getAll call on the teams resource. This was due to the re-initialization of the after variable in the proxy call, causing the API to only ever return the first page of data and causing the export to hang.