### PR TITLE
Bug/devtooling-606 Export Managed sites as data sources 

### DIFF
--- a/docs/data-sources/telephony_providers_edges_site.md
+++ b/docs/data-sources/telephony_providers_edges_site.md
@@ -25,10 +25,6 @@ data "genesyscloud_telephony_providers_edges_site" "site" {
 
 - `name` (String) Site name.
 
-### Optional
-
-- `managed` (Boolean) Return entities that are managed by Genesys Cloud. Defaults to `false`.
-
 ### Read-Only
 
 - `id` (String) The ID of this resource.

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"sync"
 
+
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -303,4 +304,17 @@ func SetRegisterExporter(resources map[string]*ResourceExporter) {
 	resourceExporterMapMutex.Lock()
 	defer resourceExporterMapMutex.Unlock()
 	resourceExporters = resources
+}
+
+var (
+	ExportAsData []string
+	dsMutex      sync.Mutex
+)
+
+// The GetDataSourceItems function adds resources to the ExportAsData []string
+// The ExportAsData will be checked in the genesyscloud_resource_exporter to determine resources to be exported as data source
+func GetDataSourceItems(name string) {
+	dsMutex.Lock()
+	defer dsMutex.Unlock()
+	ExportAsData = append(ExportAsData, name)
 }

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -307,13 +307,19 @@ func SetRegisterExporter(resources map[string]*ResourceExporter) {
 }
 
 var (
-	ExportAsData []string
-	dsMutex      sync.Mutex
+	ExportAsData          []string
+	dsMutex               sync.Mutex
+	resourceNameSanitizer = NewSanitizerProvider()
 )
 
-// The GetDataSourceItems function adds resources to the ExportAsData []string
+// The GetDataSourceItems function adds resources to the ExportAsData []string and are formatted correctly
 // The ExportAsData will be checked in the genesyscloud_resource_exporter to determine resources to be exported as data source
-func GetDataSourceItems(name string) {
+func GetDataSourceItems(resourceName, itemName string) {
+	exportName := resourceName + "::" + resourceNameSanitizer.S.SanitizeResourceName(itemName)
+	addDataSourceItemstoExport(exportName)
+}
+
+func addDataSourceItemstoExport(name string) {
 	dsMutex.Lock()
 	defer dsMutex.Unlock()
 	ExportAsData = append(ExportAsData, name)

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -312,9 +312,9 @@ var (
 	resourceNameSanitizer = NewSanitizerProvider()
 )
 
-// The GetDataSourceItems function adds resources to the ExportAsData []string and are formatted correctly
+// The AddDataSourceItems function adds resources to the ExportAsData []string and are formatted correctly
 // The ExportAsData will be checked in the genesyscloud_resource_exporter to determine resources to be exported as data source
-func GetDataSourceItems(resourceName, itemName string) {
+func AddDataSourceItems(resourceName, itemName string) {
 	exportName := resourceName + "::" + resourceNameSanitizer.S.SanitizeResourceName(itemName)
 	addDataSourceItemstoExport(exportName)
 }

--- a/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site.go
@@ -3,7 +3,6 @@ package telephony_providers_edges_site
 import (
 	"context"
 	"fmt"
-	"log"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"time"

--- a/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site.go
@@ -3,6 +3,7 @@ package telephony_providers_edges_site
 import (
 	"context"
 	"fmt"
+	"log"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"time"
@@ -18,11 +19,11 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, m interface
 	sp := GetSiteProxy(sdkConfig)
 
 	name := d.Get("name").(string)
-	managed := d.Get("managed").(bool)
 
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {
-		siteId, retryable, resp, err := sp.getSiteIdByName(ctx, name, managed)
+		siteId, retryable, resp, err := sp.getSiteIdByName(ctx, name)
 		if err != nil {
+			log.Println("ERR: ", err)
 			if retryable {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("failed to get site %s", name), resp))
 			}

--- a/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site.go
@@ -23,7 +23,6 @@ func dataSourceSiteRead(ctx context.Context, d *schema.ResourceData, m interface
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {
 		siteId, retryable, resp, err := sp.getSiteIdByName(ctx, name)
 		if err != nil {
-			log.Println("ERR: ", err)
 			if retryable {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("failed to get site %s", name), resp))
 			}

--- a/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site_test.go
@@ -67,8 +67,7 @@ func TestAccDataSourceSite(t *testing.T) {
 					strconv.Quote("Wilco plumbing")) + location + generateSiteDataSource(
 					siteDataRes,
 					name,
-					"genesyscloud_telephony_providers_edges_site."+siteRes,
-					false),
+					"genesyscloud_telephony_providers_edges_site."+siteRes),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttrPair("data.genesyscloud_telephony_providers_edges_site."+siteDataRes, "id", "genesyscloud_telephony_providers_edges_site."+siteRes, "id"),
 				),
@@ -101,7 +100,6 @@ func TestAccDataSourceSiteManaged(t *testing.T) {
 					siteDataRes,
 					name,
 					"",
-					true,
 				),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("data.genesyscloud_telephony_providers_edges_site."+siteDataRes, "id", siteId),
@@ -117,13 +115,12 @@ func generateSiteDataSource(
 	// Must explicitly use depends_on in terraform v0.13 when a data source references a resource
 	// Fixed in v0.14 https://github.com/hashicorp/terraform/pull/26284
 	dependsOnResource string,
-	managed bool) string {
+) string {
 	return fmt.Sprintf(`data "genesyscloud_telephony_providers_edges_site" "%s" {
 		name = "%s"
-		managed = %t
 		depends_on=[%s]
 	}
-	`, resourceID, name, managed, dependsOnResource)
+	`, resourceID, name, dependsOnResource)
 }
 
 func getSiteIdByName(name string) (string, error) {

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
@@ -33,12 +33,13 @@ Each proxy implementation:
 var internalProxy *SiteProxy
 
 // Type definitions for each func on our proxy so we can easily mock them out later
-type getAllSitesFunc func(ctx context.Context, p *SiteProxy, managed bool) (*[]platformclientv2.Site, *platformclientv2.APIResponse, error)
-type createSiteFunc func(ctx context.Context, p *SiteProxy, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
-type deleteSiteFunc func(ctx context.Context, p *SiteProxy, siteId string) (*platformclientv2.APIResponse, error)
-type getSiteByIdFunc func(ctx context.Context, p *SiteProxy, siteId string) (site *platformclientv2.Site, resp *platformclientv2.APIResponse, err error)
-type getSiteIdByNameFunc func(ctx context.Context, p *SiteProxy, siteName string, managed bool) (siteId string, retryable bool, resp *platformclientv2.APIResponse, err error)
-type updateSiteFunc func(ctx context.Context, p *SiteProxy, siteId string, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
+type getAllManagedSitesFunc func(ctx context.Context, p *siteProxy) (*[]platformclientv2.Site, *platformclientv2.APIResponse, error)
+type getAllUnmanagedSitesFunc func(ctx context.Context, p *siteProxy) (*[]platformclientv2.Site, *platformclientv2.APIResponse, error)
+type createSiteFunc func(ctx context.Context, p *siteProxy, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
+type deleteSiteFunc func(ctx context.Context, p *siteProxy, siteId string) (*platformclientv2.APIResponse, error)
+type getSiteByIdFunc func(ctx context.Context, p *siteProxy, siteId string) (site *platformclientv2.Site, resp *platformclientv2.APIResponse, err error)
+type getSiteIdByNameFunc func(ctx context.Context, p *siteProxy, siteName string) (siteId string, retryable bool, resp *platformclientv2.APIResponse, err error)
+type updateSiteFunc func(ctx context.Context, p *siteProxy, siteId string, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
 
 type createSiteOutboundRouteFunc func(ctx context.Context, p *SiteProxy, siteId string, outboundRoute *platformclientv2.Outboundroutebase) (*platformclientv2.Outboundroutebase, *platformclientv2.APIResponse, error)
 type getSiteOutboundRoutesFunc func(ctx context.Context, p *SiteProxy, siteId string) (*[]platformclientv2.Outboundroutebase, *platformclientv2.APIResponse, error)
@@ -321,20 +322,32 @@ func getSiteByIdFn(ctx context.Context, p *SiteProxy, siteId string) (*platformc
 }
 
 // getSiteIdByNameFn is an implementation function for retrieving a Genesys Cloud Site by name
-func getSiteIdByNameFn(ctx context.Context, p *SiteProxy, siteName string, managed bool) (string, bool, *platformclientv2.APIResponse, error) {
-	sites, resp, err := getAllSitesFn(ctx, p, managed)
+func getSiteIdByNameFn(ctx context.Context, p *siteProxy, siteName string) (string, bool, *platformclientv2.APIResponse, error) {
+	managed, resp, err := p.getAllManagedSites(ctx)
 	if err != nil {
 		return "", false, resp, err
 	}
-	if sites == nil || len(*sites) == 0 {
-		return "", true, resp, fmt.Errorf("no sites found with name %s", siteName)
-	}
-	for _, site := range *sites {
-		if (site.Name != nil && *site.Name == siteName) && (site.State != nil && *site.State != "deleted") {
-			return *site.Id, false, resp, nil
+
+	if managed != nil {
+		for _, site := range *managed {
+			if (site.Name != nil && *site.Name == siteName) && (site.State != nil && *site.State != "deleted") {
+				return *site.Id, false, resp, nil
+			}
 		}
 	}
 
+	unmanaged, resp, err := p.getAllUnmanagedSites(ctx)
+	if err != nil {
+		return "", false, resp, err
+	}
+
+	if unmanaged != nil {
+		for _, site := range *unmanaged {
+			if (site.Name != nil && *site.Name == siteName) && (site.State != nil && *site.State != "deleted") {
+				return *site.Id, false, resp, nil
+			}
+		}
+	}
 	return "", true, resp, fmt.Errorf("no sites found with name %s", siteName)
 }
 

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
@@ -6,6 +6,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
+
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
@@ -33,13 +33,12 @@ Each proxy implementation:
 var internalProxy *SiteProxy
 
 // Type definitions for each func on our proxy so we can easily mock them out later
-type getAllManagedSitesFunc func(ctx context.Context, p *siteProxy) (*[]platformclientv2.Site, *platformclientv2.APIResponse, error)
-type getAllUnmanagedSitesFunc func(ctx context.Context, p *siteProxy) (*[]platformclientv2.Site, *platformclientv2.APIResponse, error)
-type createSiteFunc func(ctx context.Context, p *siteProxy, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
-type deleteSiteFunc func(ctx context.Context, p *siteProxy, siteId string) (*platformclientv2.APIResponse, error)
-type getSiteByIdFunc func(ctx context.Context, p *siteProxy, siteId string) (site *platformclientv2.Site, resp *platformclientv2.APIResponse, err error)
-type getSiteIdByNameFunc func(ctx context.Context, p *siteProxy, siteName string) (siteId string, retryable bool, resp *platformclientv2.APIResponse, err error)
-type updateSiteFunc func(ctx context.Context, p *siteProxy, siteId string, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
+type getAllSitesFunc func(ctx context.Context, p *SiteProxy, managed bool) (*[]platformclientv2.Site, *platformclientv2.APIResponse, error)
+type createSiteFunc func(ctx context.Context, p *SiteProxy, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
+type deleteSiteFunc func(ctx context.Context, p *SiteProxy, siteId string) (*platformclientv2.APIResponse, error)
+type getSiteByIdFunc func(ctx context.Context, p *SiteProxy, siteId string) (site *platformclientv2.Site, resp *platformclientv2.APIResponse, err error)
+type getSiteIdByNameFunc func(ctx context.Context, p *SiteProxy, siteName string) (siteId string, retryable bool, resp *platformclientv2.APIResponse, err error)
+type updateSiteFunc func(ctx context.Context, p *SiteProxy, siteId string, site *platformclientv2.Site) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
 
 type createSiteOutboundRouteFunc func(ctx context.Context, p *SiteProxy, siteId string, outboundRoute *platformclientv2.Outboundroutebase) (*platformclientv2.Outboundroutebase, *platformclientv2.APIResponse, error)
 type getSiteOutboundRoutesFunc func(ctx context.Context, p *SiteProxy, siteId string) (*[]platformclientv2.Outboundroutebase, *platformclientv2.APIResponse, error)
@@ -158,8 +157,8 @@ func (p *SiteProxy) getSiteById(ctx context.Context, siteId string) (site *platf
 }
 
 // getSiteIdByNameFunc returns a single Genesys Cloud Site by Name
-func (p *SiteProxy) getSiteIdByName(ctx context.Context, siteName string, managed bool) (siteId string, retryable bool, resp *platformclientv2.APIResponse, err error) {
-	return p.getSiteIdByNameAttr(ctx, p, siteName, managed)
+func (p *SiteProxy) getSiteIdByName(ctx context.Context, siteName string) (siteId string, retryable bool, resp *platformclientv2.APIResponse, err error) {
+	return p.getSiteIdByNameAttr(ctx, p, siteName)
 }
 
 // updateSiteFunc updates a Genesys Cloud Site
@@ -322,8 +321,8 @@ func getSiteByIdFn(ctx context.Context, p *SiteProxy, siteId string) (*platformc
 }
 
 // getSiteIdByNameFn is an implementation function for retrieving a Genesys Cloud Site by name
-func getSiteIdByNameFn(ctx context.Context, p *siteProxy, siteName string) (string, bool, *platformclientv2.APIResponse, error) {
-	managed, resp, err := p.getAllManagedSites(ctx)
+func getSiteIdByNameFn(ctx context.Context, p *SiteProxy, siteName string) (string, bool, *platformclientv2.APIResponse, error) {
+	managed, resp, err := getAllSitesFn(ctx, p, true)
 	if err != nil {
 		return "", false, resp, err
 	}
@@ -336,7 +335,7 @@ func getSiteIdByNameFn(ctx context.Context, p *siteProxy, siteName string) (stri
 		}
 	}
 
-	unmanaged, resp, err := p.getAllUnmanagedSites(ctx)
+	unmanaged, resp, err := getAllSitesFn(ctx, p, false)
 	if err != nil {
 		return "", false, resp, err
 	}

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -48,7 +48,7 @@ func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 		// When exporting managed sites, they must automatically be exported as data source 
 		// Managed sites are added to the ExportAsData []string in resource_exporter
 		if tfexporter_state.IsExporterActive() {
-			resourceExporter.GetDataSourceItems(resourceName, *managedSite.Name)
+			resourceExporter.AddDataSourceItems(resourceName, *managedSite.Name)
 		}
 	}
 	return resources, nil

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"strings"
+	//"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 	"terraform-provider-genesyscloud/genesyscloud/util"
@@ -46,10 +46,9 @@ func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 	for _, managedSite := range *managedSites {
 		resources[*managedSite.Id] = &resourceExporter.ResourceMeta{Name: *managedSite.Name}
 		// When exporting managed sites, they must automatically be exported as data source 
-		// Managed sites are added to the ExportAsData []string in resource_exporter and formatted correctly for export as data source
+		// Managed sites are added to the ExportAsData []string in resource_exporter
 		if tfexporter_state.IsExporterActive() {
-			managedSiteDataSource := resourceName + "::" + strings.ReplaceAll(*managedSite.Name, " ", "_")
-			resourceExporter.GetDataSourceItems(managedSiteDataSource)
+			resourceExporter.GetDataSourceItems(resourceName, *managedSite.Name)
 		}
 	}
 	return resources, nil

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -25,6 +25,8 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
 )
 
+var DataSourceManagedSites []string 
+
 func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	sp := GetSiteProxy(sdkConfig)
@@ -46,10 +48,11 @@ func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 	for _, managedSite := range *managedSites {
 		resources[*managedSite.Id] = &resourceExporter.ResourceMeta{Name: *managedSite.Name}
 		// When exporting managed sites, they must automatically be exported as data
-		// Managed sites are added to tfexporter.ManagedSites and formatted correctly for export as data
+		// Managed sites are added to the DataSourceManagedSites []string and formatted correctly for export as data
+		// The genesyscloud_resource_exporter will read DataSourceManagedSites
 		if tfexporter_state.IsExporterActive() {
 			managedSiteDataSource := resourceName + "::" + strings.ReplaceAll(*managedSite.Name, " ", "_")
-			tfexporter.AddToDataSource(managedSiteDataSource)
+			DataSourceManagedSites = append(DataSourceManagedSites, managedSiteDataSource)
 		}
 	}
 	return resources, nil

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	//"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 	"terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
-	"terraform-provider-genesyscloud/genesyscloud/tfexporter"
 	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -25,8 +25,6 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
 )
 
-var DataSourceManagedSites []string 
-
 func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	sp := GetSiteProxy(sdkConfig)
@@ -47,12 +45,11 @@ func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 	}
 	for _, managedSite := range *managedSites {
 		resources[*managedSite.Id] = &resourceExporter.ResourceMeta{Name: *managedSite.Name}
-		// When exporting managed sites, they must automatically be exported as data
-		// Managed sites are added to the DataSourceManagedSites []string and formatted correctly for export as data
-		// The genesyscloud_resource_exporter will read DataSourceManagedSites
+		// When exporting managed sites, they must automatically be exported as data source 
+		// Managed sites are added to the ExportAsData []string in resource_exporter and formatted correctly for export as data source
 		if tfexporter_state.IsExporterActive() {
 			managedSiteDataSource := resourceName + "::" + strings.ReplaceAll(*managedSite.Name, " ", "_")
-			DataSourceManagedSites = append(DataSourceManagedSites, managedSiteDataSource)
+			resourceExporter.GetDataSourceItems(managedSiteDataSource)
 		}
 	}
 	return resources, nil

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -4,7 +4,10 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
+	"terraform-provider-genesyscloud/genesyscloud/tfexporter"
+	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
@@ -43,8 +46,12 @@ func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 	}
 	for _, managedSite := range *managedSites {
 		resources[*managedSite.Id] = &resourceExporter.ResourceMeta{Name: *managedSite.Name}
+		// When exporting managed sites, they must automatically be exported as data
+		// Managed sites are added to tfexporter.ManagedSites and formatted correctly for export as data
+		if tfexporter_state.IsExporterActive() {
+			tfexporter.ManagedSites = []string{resourceName + "::" + strings.ReplaceAll(*managedSite.Name, " ", "_")}
+		}
 	}
-
 	return resources, nil
 }
 

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -49,7 +49,8 @@ func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 		// When exporting managed sites, they must automatically be exported as data
 		// Managed sites are added to tfexporter.ManagedSites and formatted correctly for export as data
 		if tfexporter_state.IsExporterActive() {
-			tfexporter.ManagedSites = []string{resourceName + "::" + strings.ReplaceAll(*managedSite.Name, " ", "_")}
+			managedSiteDataSource := resourceName + "::" + strings.ReplaceAll(*managedSite.Name, " ", "_")
+			tfexporter.AddToDataSource(managedSiteDataSource)
 		}
 	}
 	return resources, nil

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
@@ -304,12 +304,6 @@ func DataSourceSite() *schema.Resource {
 				Type:        schema.TypeString,
 				Required:    true,
 			},
-			"managed": {
-				Description: "Return entities that are managed by Genesys Cloud.",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-			},
 		},
 	}
 }

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
@@ -2,8 +2,8 @@ package telephony_providers_edges_site
 
 import (
 	"fmt"
-	"log"
 	"os"
+	"log"
 	"strconv"
 	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
@@ -535,6 +535,23 @@ func GenerateSiteResourceWithCustomAttrs(
 	`, siteRes, name, description, locationId, mediaModel, mediaRegionsUseLatencyBased, mediaRegions, callerId, callerName, strings.Join(otherAttrs, "\n"))
 }
 
+func CheckForDefaultSite(siteName string) error {
+	var (
+		sdk, _   = provider.AuthorizeSdk()
+		siteAPI  = platformclientv2.NewTelephonyProvidersEdgeApiWithConfig(sdk)
+		pageSize = 100
+	)
+
+	sites, _, getErr := siteAPI.GetTelephonyProvidersEdgesSites(pageSize, 1, "", "", siteName, "", true, []string{})
+	if getErr != nil {
+		return getErr
+	}
+	if sites == nil {
+		return fmt.Errorf("no default site found with name %s", siteName)
+	}
+	return nil
+}
+
 // DeleteLocationWithNumber is a test utility function to delete site and location with the provided emergency number
 func DeleteLocationWithNumber(emergencyNumber string, config *platformclientv2.Configuration) error {
 	var (

--- a/genesyscloud/tfexporter/datasource_export_config.go
+++ b/genesyscloud/tfexporter/datasource_export_config.go
@@ -1,10 +1,23 @@
 package tfexporter
 
-var DataSourceExports []string
+import (
+	"sync"
+)
+
+var (
+	DataSourceExports []string
+	dsMutex           sync.Mutex
+)
 
 func SetDataSourceExports() []string {
 	if len(DataSourceExports) < 1 {
 		DataSourceExports = append(DataSourceExports, "")
 	}
 	return DataSourceExports
+}
+
+func AddToDataSource(resource string) {
+	dsMutex.Lock()
+	defer dsMutex.Unlock()
+	DataSourceExports = append(DataSourceExports, resource)
 }

--- a/genesyscloud/tfexporter/datasource_export_config.go
+++ b/genesyscloud/tfexporter/datasource_export_config.go
@@ -1,23 +1,10 @@
 package tfexporter
 
-import (
-	"sync"
-)
-
-var (
-	DataSourceExports []string
-	dsMutex           sync.Mutex
-)
+var DataSourceExports []string
 
 func SetDataSourceExports() []string {
 	if len(DataSourceExports) < 1 {
 		DataSourceExports = append(DataSourceExports, "")
 	}
 	return DataSourceExports
-}
-
-func AddToDataSource(resource string) {
-	dsMutex.Lock()
-	defer dsMutex.Unlock()
-	DataSourceExports = append(DataSourceExports, resource)
 }

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -19,7 +19,6 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	rRegistrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
-	"terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
 	"terraform-provider-genesyscloud/genesyscloud/util/files"
@@ -1604,7 +1603,7 @@ func (g *GenesysCloudResourceExporter) resourceIdExists(refID string, existingRe
 }
 
 func (g *GenesysCloudResourceExporter) isDataSource(resType string, name string) bool {
-	for _, element := range telephony_providers_edges_site.DataSourceManagedSites {
+	for _, element := range resourceExporter.ExportAsData {
 		if element == resType+"::"+name || fetchByRegex(element, resType, name) {
 			return true
 		}

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -56,10 +56,6 @@ var (
 	resourceExporters   map[string]*resourceExporter.ResourceExporter
 )
 
-var (
-	ManagedSites []string
-)
-
 type unresolvableAttributeInfo struct {
 	ResourceType string
 	ResourceName string
@@ -1607,7 +1603,7 @@ func (g *GenesysCloudResourceExporter) resourceIdExists(refID string, existingRe
 }
 
 func (g *GenesysCloudResourceExporter) isDataSource(resType string, name string) bool {
-	for _, element := range ManagedSites {
+	for _, element := range DataSourceExports {
 		if element == resType+"::"+name || fetchByRegex(element, resType, name) {
 			return true
 		}

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -1603,12 +1603,11 @@ func (g *GenesysCloudResourceExporter) resourceIdExists(refID string, existingRe
 }
 
 func (g *GenesysCloudResourceExporter) isDataSource(resType string, name string) bool {
-	for _, element := range resourceExporter.ExportAsData {
-		if element == resType+"::"+name || fetchByRegex(element, resType, name) {
-			return true
-		}
-	}
-	for _, element := range g.replaceWithDatasource {
+	return g.containsElement(resourceExporter.ExportAsData, resType, name) || g.containsElement(g.replaceWithDatasource, resType, name)
+}
+
+func (g *GenesysCloudResourceExporter) containsElement(elements []string, resType, name string) bool {
+	for _, element := range elements {
 		if element == resType+"::"+name || fetchByRegex(element, resType, name) {
 			return true
 		}

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -56,6 +56,10 @@ var (
 	resourceExporters   map[string]*resourceExporter.ResourceExporter
 )
 
+var (
+	ManagedSites []string
+)
+
 type unresolvableAttributeInfo struct {
 	ResourceType string
 	ResourceName string
@@ -539,7 +543,6 @@ func (g *GenesysCloudResourceExporter) generateZipForExporter() diag.Diagnostics
 }
 
 func (g *GenesysCloudResourceExporter) buildAndExportDependsOnResourcesForFlows() diag.Diagnostics {
-
 	if g.addDependsOn {
 		filterList, resources, err := g.processAndBuildDependencies()
 		if err != nil {
@@ -560,7 +563,6 @@ func (g *GenesysCloudResourceExporter) processAndBuildDependencies() (filters []
 	filterList := make([]string, 0)
 	totalResources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := dependentconsumers.GetDependentConsumerProxy(nil)
-
 	retrieveDependentConsumers := func(resourceKeys resourceExporter.ResourceInfo) func(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, *resourceExporter.DependencyResource, diag.Diagnostics) {
 		return func(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, *resourceExporter.DependencyResource, diag.Diagnostics) {
 			proxy = dependentconsumers.GetDependentConsumerProxy(clientConfig)
@@ -1605,6 +1607,11 @@ func (g *GenesysCloudResourceExporter) resourceIdExists(refID string, existingRe
 }
 
 func (g *GenesysCloudResourceExporter) isDataSource(resType string, name string) bool {
+	for _, element := range ManagedSites {
+		if element == resType+"::"+name || fetchByRegex(element, resType, name) {
+			return true
+		}
+	}
 	for _, element := range g.replaceWithDatasource {
 		if element == resType+"::"+name || fetchByRegex(element, resType, name) {
 			return true

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -19,6 +19,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	rRegistrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
+	"terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
 	"terraform-provider-genesyscloud/genesyscloud/util/files"
@@ -1603,7 +1604,7 @@ func (g *GenesysCloudResourceExporter) resourceIdExists(refID string, existingRe
 }
 
 func (g *GenesysCloudResourceExporter) isDataSource(resType string, name string) bool {
-	for _, element := range DataSourceExports {
+	for _, element := range telephony_providers_edges_site.DataSourceManagedSites {
 		if element == resType+"::"+name || fetchByRegex(element, resType, name) {
 			return true
 		}

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -1455,9 +1455,10 @@ func TestAccResourceExportManagedSitesAsData(t *testing.T) {
 		exportTestDir = filepath.Join("..", "..", ".terraform"+uuid.NewString())
 		resourceID    = "export"
 		configPath    = filepath.Join(exportTestDir, defaultTfJSONFile)
+		siteName      = "PureCloud Voice - AWS"
 	)
 
-	if err := telephonyProvidersEdgesSite.CheckForDefaultSite("PureCloud Voice - AWS"); err != nil {
+	if err := telephonyProvidersEdgesSite.CheckForDefaultSite(siteName); err != nil {
 		t.Skipf("failed to get default site %v", err)
 	}
 
@@ -1484,7 +1485,7 @@ func TestAccResourceExportManagedSitesAsData(t *testing.T) {
 					[]string{},
 				),
 				Check: resource.ComposeTestCheckFunc(
-					validateExportManagedSitesAsData(configPath),
+					validateExportManagedSitesAsData(configPath, siteName),
 				),
 			},
 		},
@@ -1492,7 +1493,7 @@ func TestAccResourceExportManagedSitesAsData(t *testing.T) {
 }
 
 // validateExportManagedSitesAsData verifies that the default managed site 'PureCloud Voice - AWS' is exported as a data source
-func validateExportManagedSitesAsData(filename string) resource.TestCheckFunc {
+func validateExportManagedSitesAsData(filename, siteName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		// Check if the file exists
 		_, err := os.Stat(filename)
@@ -1515,7 +1516,7 @@ func validateExportManagedSitesAsData(filename string) resource.TestCheckFunc {
 				return fmt.Errorf("no data sources exported for genesyscloud_telephony_providers_edges_site")
 			}
 
-			log.Println("Checking that managed site with name 'PureCloud Voice - AWS' is exported as data source")
+			log.Printf("checking that managed site with name %s is exported as data source", siteName)
 
 			// Validate each site's name
 			for siteID, site := range sites {
@@ -1524,13 +1525,13 @@ func validateExportManagedSitesAsData(filename string) resource.TestCheckFunc {
 					return fmt.Errorf("unexpected structure for site %s", siteID)
 				}
 
-				siteName, _ := siteAttributes["name"].(string)
-				if siteName == "PureCloud Voice - AWS" {
-					log.Printf("Site %s with name 'PureCloud Voice - AWS' is correctly exported as data source", siteID)
+				name, _ := siteAttributes["name"].(string)
+				if name == siteName {
+					log.Printf("Site %s with name '%s' is correctly exported as data source", siteID, siteName)
 					return nil
 				}
 			}
-			return fmt.Errorf("site with name 'PureCloud Voice - AWS' was not exported as data source")
+			return fmt.Errorf("site with name '%s' was not exported as data source", siteName)
 		} else {
 			return fmt.Errorf("no data sources found in exported data")
 		}

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -21,6 +21,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	routingQueue "terraform-provider-genesyscloud/genesyscloud/routing_queue"
+	telephonyProvidersEdgesSite "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
 	"time"
@@ -1445,6 +1446,95 @@ func TestAccResourceTfExportSplitFilesAsHCL(t *testing.T) {
 		},
 		CheckDestroy: testVerifyExportsDestroyedFunc(exportTestDir),
 	})
+}
+
+// TestAccResourceExportManagedSitesAsData checks that during an export, managed sites are exported as data source
+// Managed can't be set on sites, therefore the default managed site is checked during the test that it is exported as data
+func TestAccResourceExportManagedSitesAsData(t *testing.T) {
+	var (
+		exportTestDir = filepath.Join("..", "..", ".terraform"+uuid.NewString())
+		resourceID    = "export"
+		configPath    = filepath.Join(exportTestDir, defaultTfJSONFile)
+	)
+
+	if err := telephonyProvidersEdgesSite.CheckForDefaultSite("PureCloud Voice - AWS"); err != nil {
+		t.Skipf("failed to get default site %v", err)
+	}
+
+	defer func(path string) {
+		if err := os.RemoveAll(path); err != nil {
+			t.Logf("failed to remove dir %s: %s", path, err)
+		}
+	}(exportTestDir)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				Config: generateTfExportByIncludeFilterResources(
+					resourceID,
+					exportTestDir,
+					util.FalseValue, // include_state_file
+					[]string{ // include_filter_resources
+						strconv.Quote("genesyscloud_telephony_providers_edges_site"),
+					},
+					util.FalseValue, // export_as_hcl
+					util.FalseValue,
+					[]string{},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					validateExportManagedSitesAsData(configPath),
+				),
+			},
+		},
+	})
+}
+
+// validateExportManagedSitesAsData verifies that the default managed site 'PureCloud Voice - AWS' is exported as a data source
+func validateExportManagedSitesAsData(filename string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		// Check if the file exists
+		_, err := os.Stat(filename)
+		if err != nil {
+			return fmt.Errorf("failed to find file %s", filename)
+		}
+
+		// Load the JSON content of the export file
+		log.Println("Loading export config into map variable")
+		exportData, err := loadJsonFileToMap(filename)
+		if err != nil {
+			return err
+		}
+		log.Println("Successfully loaded export config into map variable ")
+
+		// Check if data sources exist in the exported data
+		if data, ok := exportData["data"].(map[string]interface{}); ok {
+			sites, ok := data["genesyscloud_telephony_providers_edges_site"].(map[string]interface{})
+			if !ok {
+				return fmt.Errorf("no data sources exported for genesyscloud_telephony_providers_edges_site")
+			}
+
+			log.Println("Checking that managed site with name 'PureCloud Voice - AWS' is exported as data source")
+
+			// Validate each site's name
+			for siteID, site := range sites {
+				siteAttributes, ok := site.(map[string]interface{})
+				if !ok {
+					return fmt.Errorf("unexpected structure for site %s", siteID)
+				}
+
+				siteName, _ := siteAttributes["name"].(string)
+				if siteName == "PureCloud Voice - AWS" {
+					log.Printf("Site %s with name 'PureCloud Voice - AWS' is correctly exported as data source", siteID)
+					return nil
+				}
+			}
+			return fmt.Errorf("site with name 'PureCloud Voice - AWS' was not exported as data source")
+		} else {
+			return fmt.Errorf("no data sources found in exported data")
+		}
+	}
 }
 
 // TestAccResourceTfExportCampaignScriptIdReferences exports two campaigns and ensures that the custom revolver OutboundCampaignAgentScriptResolver

--- a/genesyscloud/tfexporter/tf_exporter_resource_test.go
+++ b/genesyscloud/tfexporter/tf_exporter_resource_test.go
@@ -309,6 +309,7 @@ func (r *registerTestInstance) registerTestExporters() {
 func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_auth_division_home"] = gcloud.DataSourceAuthDivisionHome()
 	providerDataSources["genesyscloud_script"] = scripts.DataSourceScript()
+	providerDataSources["genesyscloud_telephony_providers_edges_site"] = edgeSite.DataSourceSite()
 }
 
 func RegisterExporter(exporterName string, resourceExporter *resourceExporter.ResourceExporter) {


### PR DESCRIPTION
Due to https://inindca.atlassian.net/browse/DEVTOOLING-606, this PR:

    Removes managed attribute from sites data source
    Automatically sets managed sites to data on export
    Searches both managed and unmanaged sites on getSiteByName function call
    Due to import cycles, the genesyscloud_resource_exporter will read the DataSourceManagedSites on export to determine which resources should be exported as data

