### PR TITLE
Feat/More validation in utilization label names

### DIFF
--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_schema.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_schema.go
@@ -1,6 +1,8 @@
 package routing_utilization_label
 
 import (
+	"fmt"
+	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
@@ -34,7 +36,12 @@ func ResourceRoutingUtilizationLabel() *schema.Resource {
 			"name": {
 				Description: "Label name.",
 				Type:        schema.TypeString,
-				Required:    true,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					stringDoesNotStartOrEndWithSpaces,
+					validation.StringDoesNotContainAny("*"),
+				),
+				Required: true,
 			},
 		},
 	}
@@ -46,10 +53,14 @@ func DataSourceRoutingUtilizationLabel() *schema.Resource {
 		ReadContext: provider.ReadWithPooledClient(dataSourceRoutingUtilizationLabelRead),
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Description:  "Label name.",
-				Type:         schema.TypeString,
-				ValidateFunc: validation.StringDoesNotContainAny("*"),
-				Required:     true,
+				Description: "Label name.",
+				Type:        schema.TypeString,
+				ValidateFunc: validation.All(
+					validation.StringIsNotEmpty,
+					stringDoesNotStartOrEndWithSpaces,
+					validation.StringDoesNotContainAny("*"),
+				),
+				Required: true,
 			},
 		},
 	}
@@ -59,4 +70,17 @@ func RoutingUtilizationLabelExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllRoutingUtilizationLabels),
 	}
+}
+
+func stringDoesNotStartOrEndWithSpaces(input interface{}, k string) ([]string, []error) {
+	inputAsString, ok := input.(string)
+	if !ok {
+		return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+	}
+
+	if len(strings.TrimSpace(inputAsString)) != len(inputAsString) {
+		return nil, []error{fmt.Errorf("expected %q to not start or end with spaces", k)}
+	}
+
+	return nil, nil
 }

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
@@ -2,6 +2,7 @@ package routing_utilization_label
 
 import (
 	"fmt"
+	"regexp"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
@@ -50,6 +51,36 @@ func TestAccResourceRoutingUtilizationLabelBasic(t *testing.T) {
 				ResourceName:      "genesyscloud_routing_utilization_label." + resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+		CheckDestroy: validateTestLabelDestroyed,
+	})
+}
+
+func TestAccResourceRoutingUtilizationLabelInvalidNames(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				Config:      GenerateRoutingUtilizationLabelResource("resource", " abc", ""),
+				ExpectError: regexp.MustCompile("to not start or end with spaces"),
+			},
+			{
+				Config:      GenerateRoutingUtilizationLabelResource("resource", "abc ", ""),
+				ExpectError: regexp.MustCompile("to not start or end with spaces"),
+			},
+			{
+				Config:      GenerateRoutingUtilizationLabelResource("resource", " abc ", ""),
+				ExpectError: regexp.MustCompile("to not start or end with spaces"),
+			},
+			{
+				Config:      GenerateRoutingUtilizationLabelResource("resource", "abc*", ""),
+				ExpectError: regexp.MustCompile("expected value of name to not contain any of"),
+			},
+			{
+				Config:      GenerateRoutingUtilizationLabelResource("resource", "", ""),
+				ExpectError: regexp.MustCompile("to not be an empty string"),
 			},
 		},
 		CheckDestroy: validateTestLabelDestroyed,


### PR DESCRIPTION
Just adding some more validation to utilization label names.

Not a breaking change, as the names blocked by this would already be blocked by the service.

The main thing is the spaces at the start and the end. The service trims the name, so if a terraform resource creates " label ", it will expect " label " back, but get "label" and never create.

This nips that in the bud with a better error message.