### PR TITLE
Fix DEVTOOLING-703

### DIFF
--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
@@ -38,7 +38,7 @@ func getAllAuthRoutingQueueOutboundEmailAddress(ctx context.Context, clientConfi
 	}
 
 	for _, queue := range *queues {
-		if queue.OutboundEmailAddress != nil && *queue.OutboundEmailAddress != nil {
+		if queue.OutboundEmailAddress != nil && !isQueueEmailAddressEmpty(*queue.OutboundEmailAddress) {
 			resources[*queue.Id] = &resourceExporter.ResourceMeta{Name: *queue.Name + "-email-address"}
 		}
 	}

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_schema.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_schema.go
@@ -1,10 +1,11 @@
 package routing_queue_outbound_email_address
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const resourceName = "genesyscloud_routing_queue_outbound_email_address"

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils.go
@@ -1,0 +1,25 @@
+package routing_queue_outbound_email_address
+
+import "github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
+
+func isQueueEmailAddressEmpty(qea *platformclientv2.Queueemailaddress) bool {
+	if qea == nil {
+		return true
+	}
+
+	// Compare relevant fields of the struct
+	if qea.Domain == nil || qea.Domain.Id == nil || *qea.Domain.Id == "" {
+		return true
+	}
+
+	if qea.Route != nil && *qea.Route != nil {
+		routeId := (*qea.Route).Id
+		if routeId == nil || *routeId == "" {
+			return true
+		}
+	} else {
+		return true
+	}
+
+	return false
+}

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils_unit_test.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils_unit_test.go
@@ -1,0 +1,30 @@
+package routing_queue_outbound_email_address
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitResourceRoutingQueueOutboundEmailAddressEmpty(t *testing.T) {
+	address := platformclientv2.Queueemailaddress{}
+	result := isQueueEmailAddressEmpty(&address)
+	assert.Equal(t, true, result)
+}
+
+func TestUnitResourceRoutingQueueOutboundEmailAddressNotEmpty(t *testing.T) {
+	tDomainId := uuid.NewString()
+	tRouteId := uuid.NewString()
+
+	route := &platformclientv2.Inboundroute{
+		Id: &tRouteId,
+	}
+	address := platformclientv2.Queueemailaddress{
+		Domain: &platformclientv2.Domainentityref{Id: &tDomainId},
+		Route:  &route,
+	}
+	result := isQueueEmailAddressEmpty(&address)
+	assert.Equal(t, false, result)
+}


### PR DESCRIPTION
This bug occurs because there are routing queues with empty objects (`outboundEmailAddress: {}`). We need to filter those queues out when exporting the `genesyscloud_routing_queue_outbound_email_address` resource