### PR TITLE
feat/GPE-14463 add support for App stream type on Journey resources

### DIFF
--- a/docs/resources/journey_action_map.md
+++ b/docs/resources/journey_action_map.md
@@ -170,8 +170,8 @@ Required:
 Required:
 
 - `key` (String) The event key.
-- `session_type` (String) The session type for which this condition can be satisfied.
-- `stream_type` (String) The stream type for which this condition can be satisfied. Valid values: Web, Custom, Conversation.
+- `session_type` (String) The session type for which this condition can be satisfied. Valid values: web, app.
+- `stream_type` (String) The stream type for which this condition can be satisfied. Valid values: Web, App.
 - `values` (Set of String) The event values.
 
 Optional:

--- a/docs/resources/journey_outcome.md
+++ b/docs/resources/journey_outcome.md
@@ -126,8 +126,8 @@ Required:
 
 - `count` (Number) The number of times the pattern must match.
 - `criteria` (Block Set, Min: 1) A list of one or more criteria to satisfy. (see [below for nested schema](#nestedblock--journey--patterns--criteria))
-- `session_type` (String) The session type for which this pattern can be matched on.
-- `stream_type` (String) The stream type for which this pattern can be matched on.Valid values: Web, Custom, Conversation.
+- `session_type` (String) The session type for which this pattern can be matched on. Valid values: web, app.
+- `stream_type` (String) The stream type for which this pattern can be matched on. Valid values: Web, App.
 
 Optional:
 

--- a/docs/resources/journey_segment.md
+++ b/docs/resources/journey_segment.md
@@ -119,8 +119,8 @@ Required:
 
 - `count` (Number) The number of times the pattern must match.
 - `criteria` (Block Set, Min: 1) A list of one or more criteria to satisfy. (see [below for nested schema](#nestedblock--journey--patterns--criteria))
-- `session_type` (String) The session type for which this pattern can be matched on.
-- `stream_type` (String) The stream type for which this pattern can be matched on.Valid values: Web, Custom, Conversation.
+- `session_type` (String) The session type for which this pattern can be matched on. Valid values: web, app.
+- `stream_type` (String) The stream type for which this pattern can be matched on. Valid values: Web, App.
 
 Optional:
 

--- a/genesyscloud/resource_genesyscloud_journey_action_map.go
+++ b/genesyscloud/resource_genesyscloud_journey_action_map.go
@@ -134,15 +134,16 @@ var (
 				ValidateFunc: validation.StringInSlice([]string{"containsAll", "containsAny", "notContainsAll", "notContainsAny", "equal", "notEqual", "greaterThan", "greaterThanOrEqual", "lessThan", "lessThanOrEqual", "startsWith", "endsWith"}, false),
 			},
 			"stream_type": {
-				Description:  "The stream type for which this condition can be satisfied. Valid values: Web, Custom, Conversation.",
+				Description:  "The stream type for which this condition can be satisfied. Valid values: Web, App.",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Web", "Custom", "Conversation"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"Web", "App" /*,"Custom", "Conversation" */}, false), // Custom and Conversation seem not to be supported by the API despite the documentation (DEVENGSD-607)
 			},
 			"session_type": {
-				Description: "The session type for which this condition can be satisfied.",
+				Description: "The session type for which this condition can be satisfied. Valid values: web, app.",
 				Type:        schema.TypeString,
 				Required:    true,
+				ValidateFunc: validation.StringInSlice([]string{"web", "app"}, false), // custom value seems not to be supported by the API despite the documentation
 			},
 			"event_name": {
 				Description: "The name of the event for which this condition can be satisfied.",

--- a/genesyscloud/resource_genesyscloud_journey_segment.go
+++ b/genesyscloud/resource_genesyscloud_journey_segment.go
@@ -162,16 +162,16 @@ var (
 				Required:    true,
 			},
 			"stream_type": {
-				Description:  "The stream type for which this pattern can be matched on.Valid values: Web, Custom, Conversation.",
+				Description:  "The stream type for which this pattern can be matched on. Valid values: Web, App.",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"Web" /*, "Custom", "Conversation"*/}, false), // Custom and Conversation seem not to be supported by the API despite the documentation
+				ValidateFunc: validation.StringInSlice([]string{"Web", "App" /*, "Custom", "Conversation"*/}, false), // Custom and Conversation seem not to be supported by the API despite the documentation (DEVENGSD-607)
 			},
 			"session_type": {
-				Description:  "The session type for which this pattern can be matched on.",
+				Description:  "The session type for which this pattern can be matched on. Valid values: web, app.",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"web"}, false), // custom value seems not to be supported by the API despite the documentation
+				ValidateFunc: validation.StringInSlice([]string{"web", "app"}, false), // custom value seems not to be supported by the API despite the documentation
 			},
 			"event_name": {
 				Description: "The name of the event for which this pattern can be matched on.",


### PR DESCRIPTION
When configuring Journey resources like segments, outcomes or action maps, it is now possible to use App stream type. Also, the documentation around supported session types was updated, to specify the allowed values.