### PR TITLE
No jira: go checks

### DIFF
--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -1,10 +1,10 @@
-name: Ensure Documentation in Sync
+name: Go Checks
 on:
   push:
     paths-ignore:
       - 'README.md'
 jobs:
-  # ensure the documentation is up to date
+  # ensure the documentation is up-to-date
   generate:
     name: Generate
     runs-on: ubuntu-latest
@@ -35,5 +35,20 @@ jobs:
           if [[ -n $(git status -s) ]]; then
               echo "There are untracked documentation changes:\n"
               git status
+          fi
+
+      - name: Tidy
+        run: |
+          go mod tidy
+          if [[ -n $(git status -s) ]]; then
+              echo "go mod tidy produced changes:\n"
+              git status
+          fi
+
+      - name: Vet
+        run: |
+          if [[ -n $(go vet ./genesyscloud/...) ]]; then
+              echo "go vet highlighted the following:\n"
+              go vet ./genesyscloud/...
               exit 1
           fi

--- a/.github/workflows/go-checks.yml
+++ b/.github/workflows/go-checks.yml
@@ -4,9 +4,8 @@ on:
     paths-ignore:
       - 'README.md'
 jobs:
-  # ensure the documentation is up-to-date
-  generate:
-    name: Generate
+  go-checks:
+    name: Go Checks
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -47,7 +46,7 @@ jobs:
 
       - name: Vet
         run: |
-          if [[ -n $(go vet ./genesyscloud/...) ]]; then
+          if [[ -n $(go vet ./genesyscloud/... 2>&1) ]]; then
               echo "go vet highlighted the following:\n"
               go vet ./genesyscloud/...
               exit 1

--- a/genesyscloud/architect_ivr/data_source_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/data_source_genesyscloud_architect_ivr.go
@@ -18,6 +18,7 @@ func dataSourceIvrRead(ctx context.Context, d *schema.ResourceData, m interface{
 	sdkConfig := m.(*provider.ProviderMeta).ClientConfig
 	ap := getArchitectIvrProxy(sdkConfig)
 	name := d.Get("name").(string)
+
 	// Query ivr by name. Retry in case search has not yet indexed the ivr.
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {
 		id, retryable, resp, err := ap.getArchitectIvrIdByName(ctx, name)


### PR DESCRIPTION
Even though we'll be disabling the acceptance tests on GitHub soon, I think it would be a good idea to keep a workflow that checks the following:

1. `go generate` doesn't change any files
2. `go mod tidy` doesn't change any files
3. `go vet ./genesyscloud/...` doesn't produce any output 

I renamed the "Generate" job to "Go Checks" and added all the steps outlined above. Eventually, we can add the linter as well.