### PR TITLE
Devtooling 625: fix export test

### DIFF
--- a/docs/resources/quality_forms_survey.md
+++ b/docs/resources/quality_forms_survey.md
@@ -158,6 +158,10 @@ Optional:
 
 - `assistance_conditions` (Block Set) Options from which to choose an answer for this question. (see [below for nested schema](#nestedblock--question_groups--questions--answer_options--assistance_conditions))
 
+Read-Only:
+
+- `id` (String) The ID for the answer option.
+
 <a id="nestedblock--question_groups--questions--answer_options--assistance_conditions"></a>
 ### Nested Schema for `question_groups.questions.answer_options.assistance_conditions`
 

--- a/docs/resources/quality_forms_survey.md
+++ b/docs/resources/quality_forms_survey.md
@@ -129,6 +129,10 @@ Optional:
 - `na_enabled` (Boolean) Specifies whether a not applicable answer is enabled. Defaults to `false`.
 - `visibility_condition` (Block List, Max: 1) Defines conditions where question would be visible (see [below for nested schema](#nestedblock--question_groups--visibility_condition))
 
+Read-Only:
+
+- `id` (String) The ID of the survey question group.
+
 <a id="nestedblock--question_groups--questions"></a>
 ### Nested Schema for `question_groups.questions`
 
@@ -146,6 +150,10 @@ Optional:
 - `type` (String) Valid Values: multipleChoiceQuestion, freeTextQuestion, npsQuestion, readOnlyTextBlockQuestion Defaults to `multipleChoiceQuestion`.
 - `visibility_condition` (Block List, Max: 1) Defines conditions where question would be visible (see [below for nested schema](#nestedblock--question_groups--questions--visibility_condition))
 
+Read-Only:
+
+- `id` (String) The ID of the survey question.
+
 <a id="nestedblock--question_groups--questions--answer_options"></a>
 ### Nested Schema for `question_groups.questions.answer_options`
 
@@ -160,7 +168,7 @@ Optional:
 
 Read-Only:
 
-- `id` (String) The ID for the answer option.
+- `id` (String) The ID of the survey answer option.
 
 <a id="nestedblock--question_groups--questions--answer_options--assistance_conditions"></a>
 ### Nested Schema for `question_groups.questions.answer_options.assistance_conditions`

--- a/genesyscloud/resource_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_survey.go
@@ -151,6 +151,11 @@ var (
 
 	surveyFormAnswerOptions = &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Type:        schema.TypeString,
+				Description: "The ID for the answer option.",
+				Computed:    true,
+			},
 			"text": {
 				Type:     schema.TypeString,
 				Required: true,
@@ -211,9 +216,10 @@ func getAllSurveyForms(_ context.Context, clientConfig *platformclientv2.Configu
 
 func SurveyFormExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
-		GetResourcesFunc: provider.GetAllWithPooledClient(getAllSurveyForms),
-		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No references
-		AllowZeroValues:  []string{"question_groups.questions.answer_options.value"},
+		GetResourcesFunc:   provider.GetAllWithPooledClient(getAllSurveyForms),
+		RefAttrs:           map[string]*resourceExporter.RefAttrSettings{}, // No references
+		AllowZeroValues:    []string{"question_groups.questions.answer_options.value"},
+		ExcludedAttributes: []string{"question_groups.questions.answer_options.id"},
 	}
 }
 
@@ -569,7 +575,7 @@ func flattenSurveyQuestions(questions *[]platformclientv2.Surveyquestion) []inte
 		return nil
 	}
 
-	questionList := []interface{}{}
+	var questionList []interface{}
 
 	for _, question := range *questions {
 		questionMap := make(map[string]interface{})

--- a/genesyscloud/resource_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_survey.go
@@ -53,6 +53,11 @@ type SurveyFormQuestionStruct struct {
 var (
 	surveyQuestionGroup = &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the survey question group.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"name": {
 				Description: "Name of display question in question group.",
 				Type:        schema.TypeString,
@@ -83,6 +88,11 @@ var (
 
 	surveyQuestion = &schema.Resource{
 		Schema: map[string]*schema.Schema{
+			"id": {
+				Description: "The ID of the survey question.",
+				Type:        schema.TypeString,
+				Computed:    true,
+			},
 			"text": {
 				Description: "Individual question",
 				Type:        schema.TypeString,
@@ -153,7 +163,7 @@ var (
 		Schema: map[string]*schema.Schema{
 			"id": {
 				Type:        schema.TypeString,
-				Description: "The ID for the answer option.",
+				Description: "The ID of the survey answer option.",
 				Computed:    true,
 			},
 			"text": {
@@ -216,10 +226,14 @@ func getAllSurveyForms(_ context.Context, clientConfig *platformclientv2.Configu
 
 func SurveyFormExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
-		GetResourcesFunc:   provider.GetAllWithPooledClient(getAllSurveyForms),
-		RefAttrs:           map[string]*resourceExporter.RefAttrSettings{}, // No references
-		AllowZeroValues:    []string{"question_groups.questions.answer_options.value"},
-		ExcludedAttributes: []string{"question_groups.questions.answer_options.id"},
+		GetResourcesFunc: provider.GetAllWithPooledClient(getAllSurveyForms),
+		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No references
+		AllowZeroValues:  []string{"question_groups.questions.answer_options.value"},
+		ExcludedAttributes: []string{
+			"question_groups.id",
+			"question_groups.questions.id",
+			"question_groups.questions.answer_options.id",
+		},
 	}
 }
 
@@ -548,10 +562,13 @@ func flattenSurveyQuestionGroups(questionGroups *[]platformclientv2.Surveyquesti
 		return nil
 	}
 
-	questionGroupList := []interface{}{}
+	var questionGroupList []interface{}
 
 	for _, questionGroup := range *questionGroups {
 		questionGroupMap := make(map[string]interface{})
+		if questionGroup.Id != nil {
+			questionGroupMap["id"] = *questionGroup.Id
+		}
 		if questionGroup.Name != nil {
 			questionGroupMap["name"] = *questionGroup.Name
 		}
@@ -579,6 +596,9 @@ func flattenSurveyQuestions(questions *[]platformclientv2.Surveyquestion) []inte
 
 	for _, question := range *questions {
 		questionMap := make(map[string]interface{})
+		if question.Id != nil {
+			questionMap["id"] = *question.Id
+		}
 		if question.Text != nil {
 			questionMap["text"] = *question.Text
 		}


### PR DESCRIPTION
DEVTOOLING-625 (adding ID fields to the forms_evaluation resource) broke the export tests. They started failing because of a problem with the forms_survey exporter. forms_evaluation and forms_survey both have `question_groups`, so they shares some plumbing. I added the IDs to the forms_survey resource to fix the problem.