### PR TITLE
Inspired by DEVTOOLING-741 - Hardening E.164 handling

### DIFF
--- a/docs/data-sources/telephony_providers_edges_did.md
+++ b/docs/data-sources/telephony_providers_edges_did.md
@@ -3,12 +3,12 @@
 page_title: "genesyscloud_telephony_providers_edges_did Data Source - terraform-provider-genesyscloud"
 subcategory: ""
 description: |-
-  Data source for Genesys Cloud DID. The identifier is the E-164 phone number.
+  Data source for Genesys Cloud DID. The identifier is the E.164 phone number.
 ---
 
 # genesyscloud_telephony_providers_edges_did (Data Source)
 
-Data source for Genesys Cloud DID. The identifier is the E-164 phone number.
+Data source for Genesys Cloud DID. The identifier is the E.164 phone number.
 
 ## Example Usage
 

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
@@ -84,7 +84,8 @@ func readIvrConfig(ctx context.Context, d *schema.ResourceData, meta interface{}
 		}
 
 		_ = d.Set("name", *ivrConfig.Name)
-		_ = d.Set("dnis", lists.StringListToSetOrNil(ivrConfig.Dnis))
+		dnis := lists.Map(*ivrConfig.Dnis, util.FormatAsCalculatedE164Number)
+		_ = d.Set("dnis", lists.StringListToSetOrNil(&dnis))
 
 		resourcedata.SetNillableValue(d, "description", ivrConfig.Description)
 		resourcedata.SetNillableReference(d, "open_hours_flow_id", ivrConfig.OpenHoursFlow)

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
@@ -84,8 +84,12 @@ func readIvrConfig(ctx context.Context, d *schema.ResourceData, meta interface{}
 		}
 
 		_ = d.Set("name", *ivrConfig.Name)
-		dnis := lists.Map(*ivrConfig.Dnis, util.FormatAsCalculatedE164Number)
-		_ = d.Set("dnis", lists.StringListToSetOrNil(&dnis))
+		if ivrConfig.Dnis == nil || *ivrConfig.Dnis == nil {
+			_ = d.Set("dnis", nil)
+		} else {
+			dnis := lists.Map(*ivrConfig.Dnis, util.FormatAsCalculatedE164Number)
+			_ = d.Set("dnis", lists.StringListToSetOrNil(&dnis))
+		}
 
 		resourcedata.SetNillableValue(d, "description", ivrConfig.Description)
 		resourcedata.SetNillableReference(d, "open_hours_flow_id", ivrConfig.OpenHoursFlow)

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
@@ -87,7 +87,8 @@ func readIvrConfig(ctx context.Context, d *schema.ResourceData, meta interface{}
 		if ivrConfig.Dnis == nil || *ivrConfig.Dnis == nil {
 			_ = d.Set("dnis", nil)
 		} else {
-			dnis := lists.Map(*ivrConfig.Dnis, util.FormatAsCalculatedE164Number)
+			utilE164 := util.NewUtilE164Service()
+			dnis := lists.Map(*ivrConfig.Dnis, utilE164.FormatAsCalculatedE164Number)
 			_ = d.Set("dnis", lists.StringListToSetOrNil(&dnis))
 		}
 

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
@@ -90,8 +90,11 @@ func flattenPhoneNumber(phonenumber *platformclientv2.Phonenumber) []interface{}
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "display", phonenumber.Display)
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "extension", phonenumber.Extension)
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "accepts_sms", phonenumber.AcceptsSMS)
-	phoneNumber := util.FormatAsCalculatedE164Number(*phonenumber.E164)
-	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "e164", &phoneNumber)
+	var phoneNumberE164 string
+	if phonenumber != nil && phonenumber.E164 != nil && *phonenumber.E164 != "" {
+		phoneNumberE164 = util.FormatAsCalculatedE164Number(*phonenumber.E164)
+	}
+	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "e164", &phoneNumberE164)
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "country_code", phonenumber.CountryCode)
 	return []interface{}{phonenumberInterface}
 }

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
@@ -92,7 +92,8 @@ func flattenPhoneNumber(phonenumber *platformclientv2.Phonenumber) []interface{}
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "accepts_sms", phonenumber.AcceptsSMS)
 	var phoneNumberE164 string
 	if phonenumber != nil && phonenumber.E164 != nil && *phonenumber.E164 != "" {
-		phoneNumberE164 = util.FormatAsCalculatedE164Number(*phonenumber.E164)
+		utilE164 := util.NewUtilE164Service()
+		phoneNumberE164 = utilE164.FormatAsCalculatedE164Number(*phonenumber.E164)
 	}
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "e164", &phoneNumberE164)
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "country_code", phonenumber.CountryCode)

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
@@ -2,6 +2,7 @@ package external_contacts
 
 import (
 	"fmt"
+	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -89,7 +90,8 @@ func flattenPhoneNumber(phonenumber *platformclientv2.Phonenumber) []interface{}
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "display", phonenumber.Display)
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "extension", phonenumber.Extension)
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "accepts_sms", phonenumber.AcceptsSMS)
-	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "e164", phonenumber.E164)
+	phoneNumber := util.FormatAsCalculatedE164Number(*phonenumber.E164)
+	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "e164", &phoneNumber)
 	resourcedata.SetMapValueIfNotNil(phonenumberInterface, "country_code", phonenumber.CountryCode)
 	return []interface{}{phonenumberInterface}
 }

--- a/genesyscloud/group/resource_genesyscloud_group_utils.go
+++ b/genesyscloud/group/resource_genesyscloud_group_utils.go
@@ -34,7 +34,7 @@ func flattenGroupAddresses(d *schema.ResourceData, addresses *[]platformclientv2
 
 				// Strip off any parentheses from phone numbers
 				if address.Address != nil {
-					phoneNumber["number"], _ = util.FormatAsE164Number(strings.Trim(*address.Address, "()"))
+					phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Address, "()"))
 				}
 
 				resourcedata.SetMapValueIfNotNil(phoneNumber, "extension", address.Extension)
@@ -77,7 +77,7 @@ func setExtensionOrNumberBasedOnDisplay(d *schema.ResourceData, addressMap map[s
 		if ext, _ := currentAddress["extension"].(string); ext != "" {
 			addressMap["extension"] = display
 		} else if number, _ := currentAddress["number"].(string); number != "" {
-			addressMap["number"], _ = util.FormatAsE164Number(display)
+			addressMap["number"] = util.FormatAsCalculatedE164Number(display)
 		}
 	}
 }

--- a/genesyscloud/group/resource_genesyscloud_group_utils.go
+++ b/genesyscloud/group/resource_genesyscloud_group_utils.go
@@ -27,6 +27,7 @@ func validateAddressesMap(m map[string]interface{}) error {
 
 func flattenGroupAddresses(d *schema.ResourceData, addresses *[]platformclientv2.Groupcontact) []interface{} {
 	addressSlice := make([]interface{}, 0)
+	utilE164 := util.NewUtilE164Service()
 	for _, address := range *addresses {
 		if address.MediaType != nil {
 			if *address.MediaType == groupPhoneType {
@@ -34,7 +35,7 @@ func flattenGroupAddresses(d *schema.ResourceData, addresses *[]platformclientv2
 
 				// Strip off any parentheses from phone numbers
 				if address.Address != nil {
-					phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Address, "()"))
+					phoneNumber["number"] = utilE164.FormatAsCalculatedE164Number(strings.Trim(*address.Address, "()"))
 				}
 
 				resourcedata.SetMapValueIfNotNil(phoneNumber, "extension", address.Extension)
@@ -44,7 +45,7 @@ func flattenGroupAddresses(d *schema.ResourceData, addresses *[]platformclientv2
 				if address.Address == nil &&
 					address.Extension == nil &&
 					address.Display != nil {
-					setExtensionOrNumberBasedOnDisplay(d, phoneNumber, &address)
+					setExtensionOrNumberBasedOnDisplay(d, phoneNumber, &address, utilE164)
 				}
 
 				addressSlice = append(addressSlice, phoneNumber)
@@ -62,7 +63,7 @@ func flattenGroupAddresses(d *schema.ResourceData, addresses *[]platformclientv2
 *  This function establishes which field was set in the schema data (`extension` or `address`)
 *  and then sets that field in the map to the value that came back in `display`
  */
-func setExtensionOrNumberBasedOnDisplay(d *schema.ResourceData, addressMap map[string]interface{}, address *platformclientv2.Groupcontact) {
+func setExtensionOrNumberBasedOnDisplay(d *schema.ResourceData, addressMap map[string]interface{}, address *platformclientv2.Groupcontact, utilE164 *util.UtilE164Service) {
 	display := strings.Trim(*address.Display, "()")
 	schemaAddresses := d.Get("addresses").([]interface{})
 	for _, a := range schemaAddresses {
@@ -77,7 +78,7 @@ func setExtensionOrNumberBasedOnDisplay(d *schema.ResourceData, addressMap map[s
 		if ext, _ := currentAddress["extension"].(string); ext != "" {
 			addressMap["extension"] = display
 		} else if number, _ := currentAddress["number"].(string); number != "" {
-			addressMap["number"] = util.FormatAsCalculatedE164Number(display)
+			addressMap["number"] = utilE164.FormatAsCalculatedE164Number(display)
 		}
 	}
 }

--- a/genesyscloud/provider/provider.go
+++ b/genesyscloud/provider/provider.go
@@ -19,6 +19,8 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
 )
 
+var orgDefaultCountryCode string
+
 func init() {
 	// Set descriptions to support markdown syntax, this will be used in document generation
 	// and the language server.
@@ -171,6 +173,7 @@ type ProviderMeta struct {
 	Version      string
 	ClientConfig *platformclientv2.Configuration
 	Domain       string
+	Organization *platformclientv2.Organization
 }
 
 func configure(version string) schema.ConfigureContextFunc {
@@ -194,12 +197,30 @@ func configure(version string) schema.ConfigureContextFunc {
 				return nil, err
 			}
 		}
+
+		defaultConfig := platformclientv2.GetDefaultConfiguration()
+
+		currentOrg, err := getOrganizationMe(defaultConfig)
+		if err != nil {
+			return nil, err
+		}
+		orgDefaultCountryCode = *currentOrg.DefaultCountryCode
 		return &ProviderMeta{
 			Version:      version,
-			ClientConfig: platformclientv2.GetDefaultConfiguration(),
+			ClientConfig: defaultConfig,
 			Domain:       getRegionDomain(data.Get("aws_region").(string)),
+			Organization: currentOrg,
 		}, nil
 	}
+}
+
+func getOrganizationMe(defaultConfig *platformclientv2.Configuration) (*platformclientv2.Organization, diag.Diagnostics) {
+	orgApiClient := platformclientv2.NewOrganizationApiWithConfig(defaultConfig)
+	me, _, err := orgApiClient.GetOrganizationsMe()
+	if err != nil {
+		return nil, diag.FromErr(err)
+	}
+	return me, nil
 }
 
 func getRegionMap() map[string]string {

--- a/genesyscloud/provider/provider_utils.go
+++ b/genesyscloud/provider/provider_utils.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
@@ -41,4 +42,8 @@ func TestDefaultHomeDivision(resource string) resource.TestCheckFunc {
 
 		return nil
 	}
+}
+
+func GetOrgDefaultCountryCode() string {
+	return orgDefaultCountryCode
 }

--- a/genesyscloud/resource_genesyscloud_location.go
+++ b/genesyscloud/resource_genesyscloud_location.go
@@ -381,7 +381,8 @@ func flattenLocationEmergencyNumber(numberConfig *platformclientv2.Locationemerg
 	}
 	numberSettings := make(map[string]interface{})
 	if numberConfig.Number != nil {
-		numberSettings["number"] = util.FormatAsCalculatedE164Number(*numberConfig.Number)
+		utilE164 := util.NewUtilE164Service()
+		numberSettings["number"] = utilE164.FormatAsCalculatedE164Number(*numberConfig.Number)
 	}
 	if numberConfig.VarType != nil {
 		numberSettings["type"] = *numberConfig.VarType

--- a/genesyscloud/resource_genesyscloud_location.go
+++ b/genesyscloud/resource_genesyscloud_location.go
@@ -381,7 +381,7 @@ func flattenLocationEmergencyNumber(numberConfig *platformclientv2.Locationemerg
 	}
 	numberSettings := make(map[string]interface{})
 	if numberConfig.Number != nil {
-		numberSettings["number"], _ = util.FormatAsE164Number(*numberConfig.Number)
+		numberSettings["number"] = util.FormatAsCalculatedE164Number(*numberConfig.Number)
 	}
 	if numberConfig.VarType != nil {
 		numberSettings["type"] = *numberConfig.VarType

--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -967,7 +967,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 
 					//     	1.) Addresses that return an "address" field are phone numbers without extensions
 					if address.Address != nil {
-						phoneNumber["number"], _ = util.FormatAsE164Number(strings.Trim(*address.Address, "()"))
+						phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Address, "()"))
 					}
 
 					// 		2.) Addresses that return an "extension" field that matches the "display" field are
@@ -986,7 +986,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 						if address.Display != nil {
 							if *address.Extension != *address.Display {
 								phoneNumber["extension"] = *address.Extension
-								phoneNumber["number"], _ = util.FormatAsE164Number(strings.Trim(*address.Display, "()"))
+								phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
 							}
 						}
 					}
@@ -1007,7 +1007,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 						isNumber, isExtension := getNumbers(d, i)
 
 						if isNumber && phoneNumber["number"] != "" {
-							phoneNumber["number"] = strings.Trim(*address.Display, "()")
+							phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
 						}
 						if isExtension {
 							phoneNumber["extension"] = strings.Trim(*address.Display, "()")
@@ -1017,7 +1017,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 							if address.Extension == nil {
 								phoneNumber["extension"] = strings.Trim(*address.Display, "()")
 							} else if phoneNumber["number"] != "" {
-								phoneNumber["number"] = strings.Trim(*address.Display, "()")
+								phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
 							}
 						}
 					}

--- a/genesyscloud/resource_genesyscloud_user.go
+++ b/genesyscloud/resource_genesyscloud_user.go
@@ -953,6 +953,8 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 	emailSet := schema.NewSet(schema.HashResource(otherEmailResource), []interface{}{})
 	phoneNumSet := schema.NewSet(phoneNumberHash, []interface{}{})
 
+	utilE164 := util.NewUtilE164Service()
+
 	for i, address := range *addresses {
 		if address.MediaType != nil {
 			if *address.MediaType == "SMS" || *address.MediaType == "PHONE" {
@@ -967,7 +969,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 
 					//     	1.) Addresses that return an "address" field are phone numbers without extensions
 					if address.Address != nil {
-						phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Address, "()"))
+						phoneNumber["number"] = utilE164.FormatAsCalculatedE164Number(strings.Trim(*address.Address, "()"))
 					}
 
 					// 		2.) Addresses that return an "extension" field that matches the "display" field are
@@ -986,7 +988,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 						if address.Display != nil {
 							if *address.Extension != *address.Display {
 								phoneNumber["extension"] = *address.Extension
-								phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
+								phoneNumber["number"] = utilE164.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
 							}
 						}
 					}
@@ -1007,7 +1009,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 						isNumber, isExtension := getNumbers(d, i)
 
 						if isNumber && phoneNumber["number"] != "" {
-							phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
+							phoneNumber["number"] = utilE164.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
 						}
 						if isExtension {
 							phoneNumber["extension"] = strings.Trim(*address.Display, "()")
@@ -1017,7 +1019,7 @@ func flattenUserAddresses(d *schema.ResourceData, addresses *[]platformclientv2.
 							if address.Extension == nil {
 								phoneNumber["extension"] = strings.Trim(*address.Display, "()")
 							} else if phoneNumber["number"] != "" {
-								phoneNumber["number"] = util.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
+								phoneNumber["number"] = utilE164.FormatAsCalculatedE164Number(strings.Trim(*address.Display, "()"))
 							}
 						}
 					}

--- a/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
@@ -68,6 +68,7 @@ func (t *telephonyProvidersEdgesDidProxy) getTelephonyProvidersEdgesDidIdByDid(c
 
 // getTelephonyProvidersEdgesDidIdByDidFn is an implementation function for getting a telephony DID ID by DID number.
 func getTelephonyProvidersEdgesDidIdByDidFn(_ context.Context, t *telephonyProvidersEdgesDidProxy, did string) (string, bool, *platformclientv2.APIResponse, error) {
+	utilE164 := util.NewUtilE164Service()
 	const pageSize = 100
 
 	pageNum := 1
@@ -85,7 +86,7 @@ func getTelephonyProvidersEdgesDidIdByDidFn(_ context.Context, t *telephonyProvi
 			break
 		}
 		for _, entity := range *dids.Entities {
-			if util.FormatAsCalculatedE164Number(*entity.PhoneNumber) == did {
+			if utilE164.FormatAsCalculatedE164Number(*entity.PhoneNumber) == did {
 				return *entity.Id, false, resp, nil
 			}
 		}

--- a/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
@@ -3,6 +3,7 @@ package telephony_providers_edges_did
 import (
 	"context"
 	"fmt"
+	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
 )
@@ -84,7 +85,7 @@ func getTelephonyProvidersEdgesDidIdByDidFn(_ context.Context, t *telephonyProvi
 			break
 		}
 		for _, entity := range *dids.Entities {
-			if *entity.PhoneNumber == did {
+			if util.FormatAsCalculatedE164Number(*entity.PhoneNumber) == did {
 				return *entity.Id, false, resp, nil
 			}
 		}

--- a/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_schema.go
+++ b/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_schema.go
@@ -1,10 +1,11 @@
 package telephony_providers_edges_did
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
 	"terraform-provider-genesyscloud/genesyscloud/validators"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 const resourceName = "genesyscloud_telephony_providers_edges_did"
@@ -17,7 +18,7 @@ func SetRegistrar(l registrar.Registrar) {
 // DataSourceDid registers the genesyscloud_telephony_providers_edges_did data source
 func DataSourceDid() *schema.Resource {
 	return &schema.Resource{
-		Description: "Data source for Genesys Cloud DID. The identifier is the E-164 phone number.",
+		Description: "Data source for Genesys Cloud DID. The identifier is the E.164 phone number.",
 		ReadContext: provider.ReadWithPooledClient(dataSourceDidRead),
 		Schema: map[string]*schema.Schema{
 			"phone_number": {

--- a/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
@@ -3,6 +3,7 @@ package telephony_providers_edges_did_pool
 import (
 	"context"
 	"fmt"
+	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v133/platformclientv2"
 )
@@ -178,13 +179,14 @@ func getAllTelephonyDidPoolsFn(_ context.Context, t *telephonyDidPoolProxy) (*[]
 
 // getTelephonyDidPoolIdByStartAndEndNumberFn is an implementation function for finding a Genesys Cloud did pool using the start and end number
 func getTelephonyDidPoolIdByStartAndEndNumberFn(ctx context.Context, t *telephonyDidPoolProxy, start, end string) (string, bool, *platformclientv2.APIResponse, error) {
+	utilE164 := util.NewUtilE164Service()
 	allDidPools, resp, err := getAllTelephonyDidPoolsFn(ctx, t)
 	if err != nil {
 		return "", false, resp, fmt.Errorf("failed to read did pools: %v", err)
 	}
 	for _, didPool := range *allDidPools {
-		if didPool.StartPhoneNumber != nil && *didPool.StartPhoneNumber == start &&
-			didPool.EndPhoneNumber != nil && *didPool.EndPhoneNumber == end &&
+		if didPool.StartPhoneNumber != nil && utilE164.FormatAsCalculatedE164Number(*didPool.StartPhoneNumber) == start &&
+			didPool.EndPhoneNumber != nil && utilE164.FormatAsCalculatedE164Number(*didPool.EndPhoneNumber) == end &&
 			didPool.State != nil && *didPool.State != "deleted" {
 			return *didPool.Id, false, resp, nil
 		}

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -74,6 +74,7 @@ func readDidPool(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTelephonyDidPoolProxy(sdkConfig)
 	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTelephonyDidPool(), constants.DefaultConsistencyChecks, resourceName)
+	utilE164 := util.NewUtilE164Service()
 
 	log.Printf("Reading DID pool %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
@@ -90,8 +91,8 @@ func readDidPool(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 
-		_ = d.Set("start_phone_number", util.FormatAsCalculatedE164Number(*didPool.StartPhoneNumber))
-		_ = d.Set("end_phone_number", util.FormatAsCalculatedE164Number(*didPool.EndPhoneNumber))
+		_ = d.Set("start_phone_number", utilE164.FormatAsCalculatedE164Number(*didPool.StartPhoneNumber))
+		_ = d.Set("end_phone_number", utilE164.FormatAsCalculatedE164Number(*didPool.EndPhoneNumber))
 
 		resourcedata.SetNillableValue(d, "description", didPool.Description)
 		resourcedata.SetNillableValue(d, "comments", didPool.Comments)

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -90,8 +90,8 @@ func readDidPool(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 			return nil
 		}
 
-		_ = d.Set("start_phone_number", *didPool.StartPhoneNumber)
-		_ = d.Set("end_phone_number", *didPool.EndPhoneNumber)
+		_ = d.Set("start_phone_number", util.FormatAsCalculatedE164Number(*didPool.StartPhoneNumber))
+		_ = d.Set("end_phone_number", util.FormatAsCalculatedE164Number(*didPool.EndPhoneNumber))
 
 		resourcedata.SetNillableValue(d, "description", didPool.Description)
 		resourcedata.SetNillableValue(d, "comments", didPool.Comments)

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
@@ -322,7 +322,8 @@ func flattenLines(phoneLines *[]platformclientv2.Line) []interface{} {
 	}
 
 	if len(lineAddressList) > 0 {
-		formattedLineAddresses := lists.Map(lineAddressList, util.FormatAsCalculatedE164Number)
+		utilE164 := util.NewUtilE164Service()
+		formattedLineAddresses := lists.Map(lineAddressList, utilE164.FormatAsCalculatedE164Number)
 		resourcedata.SetMapValueIfNotNil(linePropertiesMap, "line_address", &formattedLineAddresses)
 	}
 	if len(remoteAddressList) > 0 {

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 
+	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -321,7 +322,8 @@ func flattenLines(phoneLines *[]platformclientv2.Line) []interface{} {
 	}
 
 	if len(lineAddressList) > 0 {
-		resourcedata.SetMapValueIfNotNil(linePropertiesMap, "line_address", &lineAddressList)
+		formattedLineAddresses := lists.Map(lineAddressList, util.FormatAsCalculatedE164Number)
+		resourcedata.SetMapValueIfNotNil(linePropertiesMap, "line_address", &formattedLineAddresses)
 	}
 	if len(remoteAddressList) > 0 {
 		resourcedata.SetMapValueIfNotNil(linePropertiesMap, "remote_address", &remoteAddressList)

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -44,7 +44,7 @@ func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 	}
 	for _, managedSite := range *managedSites {
 		resources[*managedSite.Id] = &resourceExporter.ResourceMeta{Name: *managedSite.Name}
-		// When exporting managed sites, they must automatically be exported as data source 
+		// When exporting managed sites, they must automatically be exported as data source
 		// Managed sites are added to the ExportAsData []string in resource_exporter
 		if tfexporter_state.IsExporterActive() {
 			resourceExporter.AddDataSourceItems(resourceName, *managedSite.Name)
@@ -172,7 +172,7 @@ func readSite(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "edge_auto_update_config", currentSite.EdgeAutoUpdateConfig, flattenSdkEdgeAutoUpdateConfig)
 		resourcedata.SetNillableValue(d, "media_regions", currentSite.MediaRegions)
 
-		_ = d.Set("caller_id", currentSite.CallerId)
+		_ = d.Set("caller_id", util.FormatAsCalculatedE164Number(*currentSite.CallerId))
 		_ = d.Set("caller_name", currentSite.CallerName)
 
 		if currentSite.PrimarySites != nil {

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -172,7 +172,10 @@ func readSite(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "edge_auto_update_config", currentSite.EdgeAutoUpdateConfig, flattenSdkEdgeAutoUpdateConfig)
 		resourcedata.SetNillableValue(d, "media_regions", currentSite.MediaRegions)
 
-		_ = d.Set("caller_id", util.FormatAsCalculatedE164Number(*currentSite.CallerId))
+		d.Set("caller_id", nil)
+		if currentSite.CallerId != nil && *currentSite.CallerId != "" {
+			_ = d.Set("caller_id", util.FormatAsCalculatedE164Number(*currentSite.CallerId))
+		}
 		_ = d.Set("caller_name", currentSite.CallerName)
 
 		if currentSite.PrimarySites != nil {

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -149,6 +149,7 @@ func readSite(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	sp := GetSiteProxy(sdkConfig)
 	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSite(), constants.DefaultConsistencyChecks, resourceName)
+	utilE164 := util.NewUtilE164Service()
 
 	log.Printf("Reading site %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
@@ -174,7 +175,7 @@ func readSite(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 
 		d.Set("caller_id", nil)
 		if currentSite.CallerId != nil && *currentSite.CallerId != "" {
-			_ = d.Set("caller_id", util.FormatAsCalculatedE164Number(*currentSite.CallerId))
+			_ = d.Set("caller_id", utilE164.FormatAsCalculatedE164Number(*currentSite.CallerId))
 		}
 		_ = d.Set("caller_name", currentSite.CallerName)
 

--- a/genesyscloud/util/lists/util_lists.go
+++ b/genesyscloud/util/lists/util_lists.go
@@ -183,3 +183,12 @@ func ConvertMapStringAnyToMapStringString(m map[string]any) map[string]string {
 	}
 	return sm
 }
+
+// Generic function to apply a function for each item over a list
+func Map[T, V any](ts []T, fn func(T) V) []V {
+	result := make([]V, len(ts))
+	for i, t := range ts {
+		result[i] = fn(t)
+	}
+	return result
+}

--- a/genesyscloud/util/util_e164.go
+++ b/genesyscloud/util/util_e164.go
@@ -5,11 +5,21 @@ import (
 	"github.com/nyaruka/phonenumbers"
 )
 
-func FormatAsE164Number(number string) (string, diag.Diagnostics) {
+// Formats string as a valid E.164 international standard telephone format.
+// Use this when data is coming from the user so we can appropriately error.
+func FormatAsValidE164Number(number string) (string, diag.Diagnostics) {
 	phoneNumber, err := phonenumbers.Parse(number, "US")
 	if err != nil {
 		return "", diag.Errorf("Failed to format phone number %s: %s", number, err)
 	}
 	formattedNum := phonenumbers.Format(phoneNumber, phonenumbers.E164)
 	return formattedNum, nil
+}
+
+// Formats string as a valid E.164 international standard telephone format.
+// Use this function when data is being returned back from the API already in expected format
+func FormatAsCalculatedE164Number(number string) string {
+	phoneNumber, _ := phonenumbers.Parse(number, "US")
+	formattedNum := phonenumbers.Format(phoneNumber, phonenumbers.E164)
+	return formattedNum
 }

--- a/genesyscloud/util/util_e164.go
+++ b/genesyscloud/util/util_e164.go
@@ -1,14 +1,31 @@
 package util
 
 import (
+	"log"
+	"terraform-provider-genesyscloud/genesyscloud/provider"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/nyaruka/phonenumbers"
 )
 
-// Formats string as a valid E.164 international standard telephone format.
+type UtilE164Service struct {
+	GetDefaultCountryCodeFunc func() string
+}
+
+func NewUtilE164Service() *UtilE164Service {
+	return &UtilE164Service{GetDefaultCountryCodeFunc: provider.GetOrgDefaultCountryCode}
+}
+
+// Formats string as a valid E.164 international standard telephone format, parsing the number with
+// a default region that matches the default country code set on the GC organization.
 // Use this when data is coming from the user so we can appropriately error.
-func FormatAsValidE164Number(number string) (string, diag.Diagnostics) {
-	phoneNumber, err := phonenumbers.Parse(number, "US")
+func (m *UtilE164Service) FormatAsValidE164Number(number string) (string, diag.Diagnostics) {
+	defaultLang := m.GetDefaultCountryCodeFunc()
+	if defaultLang == "" {
+		defaultLang = "US"
+	}
+	log.Printf("Default language is %s", defaultLang)
+	phoneNumber, err := phonenumbers.Parse(number, defaultLang)
 	if err != nil {
 		return "", diag.Errorf("Failed to format phone number %s: %s", number, err)
 	}
@@ -16,10 +33,16 @@ func FormatAsValidE164Number(number string) (string, diag.Diagnostics) {
 	return formattedNum, nil
 }
 
-// Formats string as a valid E.164 international standard telephone format.
+// Formats string as a valid E.164 international standard telephone format, parsing the number with
+// a default region that matches the default country code set on the GC organization.
 // Use this function when data is being returned back from the API already in expected format
-func FormatAsCalculatedE164Number(number string) string {
-	phoneNumber, _ := phonenumbers.Parse(number, "US")
+func (m *UtilE164Service) FormatAsCalculatedE164Number(number string) string {
+	defaultLang := m.GetDefaultCountryCodeFunc()
+	if defaultLang == "" {
+		defaultLang = "US"
+	}
+	log.Printf("Default language is %s", defaultLang)
+	phoneNumber, _ := phonenumbers.Parse(number, defaultLang)
 	formattedNum := phonenumbers.Format(phoneNumber, phonenumbers.E164)
 	return formattedNum
 }

--- a/genesyscloud/util/util_e164_test.go
+++ b/genesyscloud/util/util_e164_test.go
@@ -10,6 +10,12 @@ func TestUnitFormatsAsValidE164Number(t *testing.T) {
 		expectedValue string
 	}
 
+	countryCodeUS := func() string {
+		return "US"
+	}
+	var utilE164 = *NewUtilE164Service()
+	utilE164.GetDefaultCountryCodeFunc = countryCodeUS
+
 	testCases := &[]testCase{
 		// US phone numbers
 		{
@@ -93,7 +99,113 @@ func TestUnitFormatsAsValidE164Number(t *testing.T) {
 	}
 
 	for _, testCase := range *testCases {
-		val, err := FormatAsValidE164Number(testCase.number)
+		val, err := utilE164.FormatAsValidE164Number(testCase.number)
+		if err != nil {
+			t.Errorf("expected error to be nil, got: %v", err)
+		}
+		if val != testCase.expectedValue {
+			t.Errorf("number: %s, expected value: %s, actual value: %s", testCase.number, testCase.expectedValue, val)
+		}
+	}
+}
+
+// Same tests as above, but use a different default if the country code is different
+func TestUnitFormatsAsValidE164NumberWithAltCountryCode(t *testing.T) {
+	type testCase struct {
+		number        string
+		expectedValue string
+	}
+
+	countryCodeJP := func() string {
+		return "JP"
+	}
+	var utilE164 = *NewUtilE164Service()
+	utilE164.GetDefaultCountryCodeFunc = countryCodeJP
+
+	testCases := &[]testCase{
+		// US phone numbers
+		{
+			number:        "+1 (919) 333-1234",
+			expectedValue: "+19193331234",
+		},
+		{
+			number:        "1-919-333-1234",
+			expectedValue: "+8119193331234",
+		},
+		// By default, add JP international code if one is not given
+		{
+			number:        "(919) 333-1234",
+			expectedValue: "+819193331234",
+		},
+		{
+			number:        "919-333-1234",
+			expectedValue: "+819193331234",
+		},
+		// UK phone numbers
+		{
+			number:        "+44 20 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		{
+			number:        "+44 (020) 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		// German phone numbers
+		{
+			number:        "+49 (89) 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 089 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 89 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		// Indian phone numbers
+		{
+			number:        "+91 (22) 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 022 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 22 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		// Australian phone numbers
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 03 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		// Edge cases
+		{
+			number:        "123-456-7890",
+			expectedValue: "+811234567890", // Assuming US number without country code
+		},
+		{
+			number:        "+81 123",
+			expectedValue: "+81123", // Invalid but still formatted
+		},
+		{
+			number:        "12345",
+			expectedValue: "+8112345", // Invalid but still formatted
+		},
+	}
+
+	for _, testCase := range *testCases {
+		val, err := utilE164.FormatAsValidE164Number(testCase.number)
 		if err != nil {
 			t.Errorf("expected error to be nil, got: %v", err)
 		}
@@ -107,6 +219,12 @@ func TestUnitFormatsAsValidE164NumberError(t *testing.T) {
 	type testCase struct {
 		number string
 	}
+
+	countryCodeUS := func() string {
+		return "US"
+	}
+	var utilE164 = *NewUtilE164Service()
+	utilE164.GetDefaultCountryCodeFunc = countryCodeUS
 
 	testCases := &[]testCase{
 		// Random characters
@@ -133,7 +251,7 @@ func TestUnitFormatsAsValidE164NumberError(t *testing.T) {
 	}
 
 	for _, testCase := range *testCases {
-		val, err := FormatAsValidE164Number(testCase.number)
+		val, err := utilE164.FormatAsValidE164Number(testCase.number)
 		// We expect the error to be present for these cases
 		if err == nil {
 			t.Errorf("expected error to be to not be nil for number: %s, value: %s", testCase.number, val)
@@ -146,6 +264,12 @@ func TestUnitFormatsAsCalculatedE164Number(t *testing.T) {
 		number        string
 		expectedValue string
 	}
+
+	countryCodeUS := func() string {
+		return "US"
+	}
+	var utilE164 = *NewUtilE164Service()
+	utilE164.GetDefaultCountryCodeFunc = countryCodeUS
 
 	testCases := &[]testCase{
 		// US phone numbers
@@ -228,9 +352,110 @@ func TestUnitFormatsAsCalculatedE164Number(t *testing.T) {
 			expectedValue: "+112345", // Invalid but still formatted
 		},
 	}
+	for _, testCase := range *testCases {
+		val := utilE164.FormatAsCalculatedE164Number(testCase.number)
+		if val != testCase.expectedValue {
+			t.Errorf("number: %s, expected value: %s, actual value: %s", testCase.number, testCase.expectedValue, val)
+		}
+	}
+}
+
+func TestUnitFormatsAsCalculatedE164NumberWithAltCountryCode(t *testing.T) {
+	type testCase struct {
+		number        string
+		expectedValue string
+	}
+
+	countryCodeJP := func() string {
+		return "JP"
+	}
+	var utilE164 = *NewUtilE164Service()
+	utilE164.GetDefaultCountryCodeFunc = countryCodeJP
+
+	testCases := &[]testCase{
+		// US phone numbers
+		{
+			number:        "+1 (919) 333-1234",
+			expectedValue: "+19193331234",
+		},
+		{
+			number:        "1-919-333-1234",
+			expectedValue: "+8119193331234",
+		},
+		// By default, add US international code if one is not given
+		{
+			number:        "(919) 333-1234",
+			expectedValue: "+819193331234",
+		},
+		{
+			number:        "919-333-1234",
+			expectedValue: "+819193331234",
+		},
+		// UK phone numbers
+		{
+			number:        "+44 20 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		{
+			number:        "+44 (020) 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		// German phone numbers
+		{
+			number:        "+49 (89) 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 089 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 89 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		// Indian phone numbers
+		{
+			number:        "+91 (22) 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 022 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 22 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		// Australian phone numbers
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 03 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		// Edge cases
+		{
+			number:        "123-456-7890",
+			expectedValue: "+811234567890", // Assuming US number without country code
+		},
+		{
+			number:        "+81 123",
+			expectedValue: "+81123", // Invalid but still formatted
+		},
+		{
+			number:        "12345",
+			expectedValue: "+8112345", // Invalid but still formatted
+		},
+	}
 
 	for _, testCase := range *testCases {
-		val := FormatAsCalculatedE164Number(testCase.number)
+		val := utilE164.FormatAsCalculatedE164Number(testCase.number)
 		if val != testCase.expectedValue {
 			t.Errorf("number: %s, expected value: %s, actual value: %s", testCase.number, testCase.expectedValue, val)
 		}
@@ -242,6 +467,12 @@ func TestUnitFormatsAsCalculatedE164NumberError(t *testing.T) {
 		number        string
 		expectedValue string
 	}
+
+	countryCodeUS := func() string {
+		return "US"
+	}
+	var utilE164 = *NewUtilE164Service()
+	utilE164.GetDefaultCountryCodeFunc = countryCodeUS
 
 	testCases := &[]testCase{
 		// Random characters
@@ -274,7 +505,7 @@ func TestUnitFormatsAsCalculatedE164NumberError(t *testing.T) {
 	}
 
 	for _, testCase := range *testCases {
-		val := FormatAsCalculatedE164Number(testCase.number)
+		val := utilE164.FormatAsCalculatedE164Number(testCase.number)
 		// We expect the value to be blank for invalid calculated values
 		if val != testCase.expectedValue {
 			t.Errorf("expected value to be to blank for number: %s, value: %s", testCase.number, val)

--- a/genesyscloud/util/util_e164_test.go
+++ b/genesyscloud/util/util_e164_test.go
@@ -1,0 +1,283 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestUnitFormatsAsValidE164Number(t *testing.T) {
+	type testCase struct {
+		number        string
+		expectedValue string
+	}
+
+	testCases := &[]testCase{
+		// US phone numbers
+		{
+			number:        "+1 (919) 333-1234",
+			expectedValue: "+19193331234",
+		},
+		{
+			number:        "1-919-333-1234",
+			expectedValue: "+19193331234",
+		},
+		// By default, add US international code if one is not given
+		{
+			number:        "(919) 333-1234",
+			expectedValue: "+19193331234",
+		},
+		{
+			number:        "919-333-1234",
+			expectedValue: "+19193331234",
+		},
+		// UK phone numbers
+		{
+			number:        "+44 20 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		{
+			number:        "+44 (020) 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		// German phone numbers
+		{
+			number:        "+49 (89) 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 089 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 89 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		// Indian phone numbers
+		{
+			number:        "+91 (22) 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 022 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 22 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		// Australian phone numbers
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 03 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		// Edge cases
+		{
+			number:        "123-456-7890",
+			expectedValue: "+11234567890", // Assuming US number without country code
+		},
+		{
+			number:        "+1 123",
+			expectedValue: "+1123", // Invalid but still formatted
+		},
+		{
+			number:        "12345",
+			expectedValue: "+112345", // Invalid but still formatted
+		},
+	}
+
+	for _, testCase := range *testCases {
+		val, err := FormatAsValidE164Number(testCase.number)
+		if err != nil {
+			t.Errorf("expected error to be nil, got: %v", err)
+		}
+		if val != testCase.expectedValue {
+			t.Errorf("number: %s, expected value: %s, actual value: %s", testCase.number, testCase.expectedValue, val)
+		}
+	}
+}
+
+func TestUnitFormatsAsValidE164NumberError(t *testing.T) {
+	type testCase struct {
+		number string
+	}
+
+	testCases := &[]testCase{
+		// Random characters
+		{
+			number: "+1@@##3i-[0340-231234",
+		},
+		{
+			number: "adahsioidaodah",
+		},
+		// Invalid international codes
+		{
+			number: "+4239 (372) (332 20 7123) 23223 4334 232323 1234",
+		},
+		{
+			number: "+59",
+		},
+		// Edge cases
+		{
+			number: "102082308230320927092371982317932179821938143986439187639846398634963493496349634983419834",
+		},
+		{
+			number: "0",
+		},
+	}
+
+	for _, testCase := range *testCases {
+		val, err := FormatAsValidE164Number(testCase.number)
+		// We expect the error to be present for these cases
+		if err == nil {
+			t.Errorf("expected error to be to not be nil for number: %s, value: %s", testCase.number, val)
+		}
+	}
+}
+
+func TestUnitFormatsAsCalculatedE164Number(t *testing.T) {
+	type testCase struct {
+		number        string
+		expectedValue string
+	}
+
+	testCases := &[]testCase{
+		// US phone numbers
+		{
+			number:        "+1 (919) 333-1234",
+			expectedValue: "+19193331234",
+		},
+		{
+			number:        "1-919-333-1234",
+			expectedValue: "+19193331234",
+		},
+		// By default, add US international code if one is not given
+		{
+			number:        "(919) 333-1234",
+			expectedValue: "+19193331234",
+		},
+		{
+			number:        "919-333-1234",
+			expectedValue: "+19193331234",
+		},
+		// UK phone numbers
+		{
+			number:        "+44 20 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		{
+			number:        "+44 (020) 7123 1234",
+			expectedValue: "+442071231234",
+		},
+		// German phone numbers
+		{
+			number:        "+49 (89) 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 089 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		{
+			number:        "+49 89 1234-5678",
+			expectedValue: "+498912345678",
+		},
+		// Indian phone numbers
+		{
+			number:        "+91 (22) 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 022 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		{
+			number:        "+91 22 1234-5678",
+			expectedValue: "+912212345678",
+		},
+		// Australian phone numbers
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 03 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		{
+			number:        "+61 3 1234 5678",
+			expectedValue: "+61312345678",
+		},
+		// Edge cases
+		{
+			number:        "123-456-7890",
+			expectedValue: "+11234567890", // Assuming US number without country code
+		},
+		{
+			number:        "+1 123",
+			expectedValue: "+1123", // Invalid but still formatted
+		},
+		{
+			number:        "12345",
+			expectedValue: "+112345", // Invalid but still formatted
+		},
+	}
+
+	for _, testCase := range *testCases {
+		val := FormatAsCalculatedE164Number(testCase.number)
+		if val != testCase.expectedValue {
+			t.Errorf("number: %s, expected value: %s, actual value: %s", testCase.number, testCase.expectedValue, val)
+		}
+	}
+}
+
+func TestUnitFormatsAsCalculatedE164NumberError(t *testing.T) {
+	type testCase struct {
+		number        string
+		expectedValue string
+	}
+
+	testCases := &[]testCase{
+		// Random characters
+		{
+			number:        "+1@@##3i-[0340-231234",
+			expectedValue: "+00",
+		},
+		{
+			number:        "adahsioidaodah",
+			expectedValue: "+00",
+		},
+		// Invalid international codes
+		{
+			number:        "+4239 (372) (332 20 7123) 23223 4334 232323 1234",
+			expectedValue: "+4230",
+		},
+		{
+			number:        "+59",
+			expectedValue: "+00",
+		},
+		// Edge cases
+		{
+			number:        "102082308230320927092371982317932179821938143986439187639846398634963493496349634983419834",
+			expectedValue: "+10",
+		},
+		{
+			number:        "0",
+			expectedValue: "+00",
+		},
+	}
+
+	for _, testCase := range *testCases {
+		val := FormatAsCalculatedE164Number(testCase.number)
+		// We expect the value to be blank for invalid calculated values
+		if val != testCase.expectedValue {
+			t.Errorf("expected value to be to blank for number: %s, value: %s", testCase.number, val)
+		}
+	}
+}

--- a/genesyscloud/validators/validators.go
+++ b/genesyscloud/validators/validators.go
@@ -22,7 +22,8 @@ import (
 func ValidatePhoneNumber(number interface{}, _ cty.Path) diag.Diagnostics {
 	if numberStr, ok := number.(string); ok {
 
-		formattedNum, err := util.FormatAsValidE164Number(numberStr)
+		utilE164 := util.NewUtilE164Service()
+		formattedNum, err := utilE164.FormatAsValidE164Number(numberStr)
 		if err != nil {
 			return err
 		}

--- a/genesyscloud/validators/validators.go
+++ b/genesyscloud/validators/validators.go
@@ -22,7 +22,7 @@ import (
 func ValidatePhoneNumber(number interface{}, _ cty.Path) diag.Diagnostics {
 	if numberStr, ok := number.(string); ok {
 
-		formattedNum, err := util.FormatAsE164Number(numberStr)
+		formattedNum, err := util.FormatAsValidE164Number(numberStr)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Hardening E.164 handling that may occur by ensuring all instances that we validate for an E.164 formatted number from user config (which are applied on create/update) are also returned (via read) as an E.164 formatted number to maintain consistency in number handling. This likely means we could remove the custom validate export handling for E164 that was inconsistently applied and used custom logic.