### PR TITLE
Fixes DEVTOOLING-786 and DEVTOOLING-740 as well as other resources that could be impacted

### DIFF
--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
@@ -28,6 +28,10 @@ The resource_genesyscloud_idp_adfs.go contains all of the methods that perform t
 
 // getAllAuthIdpAdfss retrieves all of the idp adfs via Terraform in the Genesys Cloud and is used for the exporter
 func getAllAuthIdpAdfss(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getIdpAdfsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
@@ -28,6 +28,10 @@ The resource_genesyscloud_idp_generic.go contains all of the methods that perfor
 
 // getAllAuthIdpGeneric retrieves all of the idp generic via Terraform in the Genesys Cloud and is used for the exporter
 func getAllAuthIdpGenerics(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getIdpGenericProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
@@ -28,6 +28,10 @@ The resource_genesyscloud_idp_gsuite.go contains all of the methods that perform
 
 // getAllAuthIdpGsuite retrieves all of the idp gsuite via Terraform in the Genesys Cloud and is used for the exporter
 func getAllAuthIdpGsuites(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getIdpGsuiteProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
@@ -28,6 +28,10 @@ The resource_genesyscloud_idp_okta.go contains all of the methods that perform t
 
 // getAllAuthIdpOkta retrieves all of the idp okta via Terraform in the Genesys Cloud and is used for the exporter
 func getAllAuthIdpOktas(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getIdpOktaProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
@@ -28,6 +28,10 @@ The resource_genesyscloud_idp_onelogin.go contains all of the methods that perfo
 
 // getAllAuthIdpOnelogin retrieves all of the idp onelogin via Terraform in the Genesys Cloud and is used for the exporter
 func getAllAuthIdpOnelogins(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getIdpOneloginProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
@@ -28,6 +28,10 @@ The resource_genesyscloud_idp_ping.go contains all of the methods that perform t
 
 // getAllAuthIdpPing retrieves all of the idp ping via Terraform in the Genesys Cloud and is used for the exporter
 func getAllAuthIdpPings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getIdpPingProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
@@ -24,6 +24,10 @@ The resource_genesyscloud_idp_salesforce.go contains all of the methods that per
 */
 
 func getAllIdpSalesforce(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getIdpSalesforceProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 

--- a/genesyscloud/organization_authentication_settings/genesyscloud_organization_authentication_settings_proxy.go
+++ b/genesyscloud/organization_authentication_settings/genesyscloud_organization_authentication_settings_proxy.go
@@ -17,25 +17,25 @@ out during testing.
 var internalProxy *orgAuthSettingsProxy
 
 // Type definitions for each func on our proxy so we can easily mock them out later
-type getOrgAuthSettingsByIdFunc func(ctx context.Context, p *orgAuthSettingsProxy, id string) (orgAuthSettings *platformclientv2.Orgauthsettings, response *platformclientv2.APIResponse, err error)
+type getOrgAuthSettingsFunc func(ctx context.Context, p *orgAuthSettingsProxy) (orgAuthSettings *platformclientv2.Orgauthsettings, response *platformclientv2.APIResponse, err error)
 type updateOrgAuthSettingsFunc func(ctx context.Context, p *orgAuthSettingsProxy, orgAuthSettings *platformclientv2.Orgauthsettings) (*platformclientv2.Orgauthsettings, *platformclientv2.APIResponse, error)
 
 // orgAuthSettingsProxy contains all of the methods that call genesys cloud APIs.
 type orgAuthSettingsProxy struct {
-	clientConfig               *platformclientv2.Configuration
-	organizationApi            *platformclientv2.OrganizationApi
-	getOrgAuthSettingsByIdAttr getOrgAuthSettingsByIdFunc
-	updateOrgAuthSettingsAttr  updateOrgAuthSettingsFunc
+	clientConfig              *platformclientv2.Configuration
+	organizationApi           *platformclientv2.OrganizationApi
+	getOrgAuthSettingsAttr    getOrgAuthSettingsFunc
+	updateOrgAuthSettingsAttr updateOrgAuthSettingsFunc
 }
 
 // newOrgAuthSettingsProxy initializes the organization authentication settings proxy with all of the data needed to communicate with Genesys Cloud
 func newOrgAuthSettingsProxy(clientConfig *platformclientv2.Configuration) *orgAuthSettingsProxy {
 	api := platformclientv2.NewOrganizationApiWithConfig(clientConfig)
 	return &orgAuthSettingsProxy{
-		clientConfig:               clientConfig,
-		organizationApi:            api,
-		getOrgAuthSettingsByIdAttr: getOrgAuthSettingsByIdFn,
-		updateOrgAuthSettingsAttr:  updateOrgAuthSettingsFn,
+		clientConfig:              clientConfig,
+		organizationApi:           api,
+		getOrgAuthSettingsAttr:    getOrgAuthSettingsFn,
+		updateOrgAuthSettingsAttr: updateOrgAuthSettingsFn,
 	}
 }
 
@@ -48,9 +48,9 @@ func getOrgAuthSettingsProxy(clientConfig *platformclientv2.Configuration) *orgA
 	return internalProxy
 }
 
-// getOrgAuthSettingsById returns a single Genesys Cloud organization authentication settings by Id
-func (p *orgAuthSettingsProxy) getOrgAuthSettingsById(ctx context.Context, id string) (orgAuthSettings *platformclientv2.Orgauthsettings, response *platformclientv2.APIResponse, err error) {
-	return p.getOrgAuthSettingsByIdAttr(ctx, p, id)
+// getOrgAuthSettings returns a single Genesys Cloud organization authentication settings by Id
+func (p *orgAuthSettingsProxy) getOrgAuthSettings(ctx context.Context) (orgAuthSettings *platformclientv2.Orgauthsettings, response *platformclientv2.APIResponse, err error) {
+	return p.getOrgAuthSettingsAttr(ctx, p)
 }
 
 // updateOrgAuthSettings updates a Genesys Cloud organization authentication settings
@@ -58,11 +58,11 @@ func (p *orgAuthSettingsProxy) updateOrgAuthSettings(ctx context.Context, orgAut
 	return p.updateOrgAuthSettingsAttr(ctx, p, orgAuthSettings)
 }
 
-// getOrgAuthSettingsByIdFn is an implementation of the function to get a Genesys Cloud organization authentication settings by Id
-func getOrgAuthSettingsByIdFn(ctx context.Context, p *orgAuthSettingsProxy, id string) (orgAuthSettings *platformclientv2.Orgauthsettings, response *platformclientv2.APIResponse, err error) {
+// getOrgAuthSettingsFn is an implementation of the function to get a Genesys Cloud organization authentication settings by Id
+func getOrgAuthSettingsFn(ctx context.Context, p *orgAuthSettingsProxy) (orgAuthSettings *platformclientv2.Orgauthsettings, response *platformclientv2.APIResponse, err error) {
 	orgAuthSettings, resp, err := p.organizationApi.GetOrganizationsAuthenticationSettings()
 	if err != nil {
-		return nil, resp, fmt.Errorf("Failed to retrieve organization authentication settings by id %s: %s", id, err)
+		return nil, resp, fmt.Errorf("failed to retrieve organization authentication settings: %s", err)
 	}
 	return orgAuthSettings, resp, nil
 }

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
@@ -23,9 +23,23 @@ import (
 The resource_genesyscloud_organization_authentication_settings.go contains all the methods that perform the core logic for a resource.
 */
 
-func getAllOrganizationAuthenticationSettings(_ context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+func getAllOrganizationAuthenticationSettings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
+	proxy := getOrgAuthSettingsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
-	resources["0"] = &resourceExporter.ResourceMeta{Name: "organization_authentication_settings"}
+
+	_, resp, err := proxy.getOrgAuthSettings(ctx)
+	if err != nil {
+		if util.IsStatus404(resp) {
+			// Don't export if config doesn't exist
+			return resources, nil
+		}
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get %s resource due to error: %s", resourceName, err), resp)
+	}
+	resources["0"] = &resourceExporter.ResourceMeta{Name: resourceName}
 	return resources, nil
 }
 
@@ -45,7 +59,7 @@ func readOrganizationAuthenticationSettings(ctx context.Context, d *schema.Resou
 	log.Printf("Reading organization authentication settings %s", d.Id())
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
-		orgAuthSettings, resp, getErr := proxy.getOrgAuthSettingsById(ctx, d.Id())
+		orgAuthSettings, resp, getErr := proxy.getOrgAuthSettings(ctx)
 		if getErr != nil {
 			if util.IsStatus404(resp) {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Failed to read organization authentication settings %s | error: %s", d.Id(), getErr), resp))

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
@@ -50,7 +50,7 @@ func TestUnitResourceOrganizationAuthenticationSettingsRead(t *testing.T) {
 	}
 	testOrgAuthSettings := generateAuthSettingsData(domainAllowList, ipAllowList)
 	orgAuthProxy := &orgAuthSettingsProxy{}
-	orgAuthProxy.getOrgAuthSettingsByIdAttr = func(ctx context.Context, o *orgAuthSettingsProxy, id string) (*platformclientv2.Orgauthsettings, *platformclientv2.APIResponse, error) {
+	orgAuthProxy.getOrgAuthSettingsAttr = func(ctx context.Context, o *orgAuthSettingsProxy) (*platformclientv2.Orgauthsettings, *platformclientv2.APIResponse, error) {
 		orgAuthSettings := &testOrgAuthSettings
 
 		apiResponse := &platformclientv2.APIResponse{StatusCode: http.StatusOK}
@@ -92,7 +92,7 @@ func TestUnitResourceOrganizationAuthenticationSettingsUpdate(t *testing.T) {
 	testOrgAuthSettings := generateAuthSettingsData(domainAllowList, ipAllowList)
 
 	orgAuthProxy := &orgAuthSettingsProxy{}
-	orgAuthProxy.getOrgAuthSettingsByIdAttr = func(ctx context.Context, p *orgAuthSettingsProxy, id string) (*platformclientv2.Orgauthsettings, *platformclientv2.APIResponse, error) {
+	orgAuthProxy.getOrgAuthSettingsAttr = func(ctx context.Context, p *orgAuthSettingsProxy) (*platformclientv2.Orgauthsettings, *platformclientv2.APIResponse, error) {
 		orgAuthSettings := &testOrgAuthSettings
 
 		apiResponse := &platformclientv2.APIResponse{StatusCode: http.StatusOK}

--- a/genesyscloud/outbound_settings/genesyscloud_outbound_settings_proxy.go
+++ b/genesyscloud/outbound_settings/genesyscloud_outbound_settings_proxy.go
@@ -17,25 +17,25 @@ out during testing.
 var internalProxy *outboundSettingsProxy
 
 // Type definitions for each func on our proxy so we can easily mock them out later
-type getOutboundSettingsByIdFunc func(ctx context.Context, p *outboundSettingsProxy, id string) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error)
-type updateOutboundSettingsFunc func(ctx context.Context, p *outboundSettingsProxy, id string, outboundSettings *platformclientv2.Outboundsettings) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error)
+type getOutboundSettingsFunc func(ctx context.Context, p *outboundSettingsProxy) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error)
+type updateOutboundSettingsFunc func(ctx context.Context, p *outboundSettingsProxy, outboundSettings *platformclientv2.Outboundsettings) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error)
 
 // outboundSettingsProxy contains all of the methods that call genesys cloud APIs.
 type outboundSettingsProxy struct {
-	clientConfig                *platformclientv2.Configuration
-	outboundApi                 *platformclientv2.OutboundApi
-	getOutboundSettingsByIdAttr getOutboundSettingsByIdFunc
-	updateOutboundSettingsAttr  updateOutboundSettingsFunc
+	clientConfig               *platformclientv2.Configuration
+	outboundApi                *platformclientv2.OutboundApi
+	getOutboundSettingsAttr    getOutboundSettingsFunc
+	updateOutboundSettingsAttr updateOutboundSettingsFunc
 }
 
 // newOutboundSettingsProxy initializes the outbound settings proxy with all of the data needed to communicate with Genesys Cloud
 func newOutboundSettingsProxy(clientConfig *platformclientv2.Configuration) *outboundSettingsProxy {
 	api := platformclientv2.NewOutboundApiWithConfig(clientConfig)
 	return &outboundSettingsProxy{
-		clientConfig:                clientConfig,
-		outboundApi:                 api,
-		getOutboundSettingsByIdAttr: getOutboundSettingsByIdFn,
-		updateOutboundSettingsAttr:  updateOutboundSettingsFn,
+		clientConfig:               clientConfig,
+		outboundApi:                api,
+		getOutboundSettingsAttr:    getOutboundSettingsFn,
+		updateOutboundSettingsAttr: updateOutboundSettingsFn,
 	}
 }
 
@@ -48,30 +48,30 @@ func getOutboundSettingsProxy(clientConfig *platformclientv2.Configuration) *out
 	return internalProxy
 }
 
-// getOutboundSettingsById returns a single Genesys Cloud outbound settings by Id
-func (p *outboundSettingsProxy) getOutboundSettingsById(ctx context.Context, id string) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
-	return p.getOutboundSettingsByIdAttr(ctx, p, id)
+// getOutboundSettings returns a single Genesys Cloud outbound settings by Id
+func (p *outboundSettingsProxy) getOutboundSettings(ctx context.Context) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
+	return p.getOutboundSettingsAttr(ctx, p)
 }
 
 // updateOutboundSettings updates a Genesys Cloud outbound settings
-func (p *outboundSettingsProxy) updateOutboundSettings(ctx context.Context, id string, outboundSettings *platformclientv2.Outboundsettings) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
-	return p.updateOutboundSettingsAttr(ctx, p, id, outboundSettings)
+func (p *outboundSettingsProxy) updateOutboundSettings(ctx context.Context, outboundSettings *platformclientv2.Outboundsettings) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
+	return p.updateOutboundSettingsAttr(ctx, p, outboundSettings)
 }
 
-// getOutboundSettingsByIdFn is an implementation of the function to get a Genesys Cloud outbound settings by Id
-func getOutboundSettingsByIdFn(ctx context.Context, p *outboundSettingsProxy, id string) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
+// getOutboundSettingsFn is an implementation of the function to get a Genesys Cloud outbound settings by Id
+func getOutboundSettingsFn(ctx context.Context, p *outboundSettingsProxy) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
 	outboundSettings, resp, err := p.outboundApi.GetOutboundSettings()
 	if err != nil {
-		return nil, resp, fmt.Errorf("Failed to retrieve outbound settings by id %s: %s", id, err)
+		return nil, resp, fmt.Errorf("failed to retrieve outbound settings: %s", err)
 	}
 	return outboundSettings, resp, nil
 }
 
 // updateOutboundSettingsFn is an implementation of the function to update a Genesys Cloud outbound settings
-func updateOutboundSettingsFn(ctx context.Context, p *outboundSettingsProxy, id string, outboundSettings *platformclientv2.Outboundsettings) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
+func updateOutboundSettingsFn(ctx context.Context, p *outboundSettingsProxy, outboundSettings *platformclientv2.Outboundsettings) (*platformclientv2.Outboundsettings, *platformclientv2.APIResponse, error) {
 	resp, err := p.outboundApi.PatchOutboundSettings(*outboundSettings)
 	if err != nil {
-		return nil, nil, fmt.Errorf("Failed to update outbound settings: %s", err)
+		return nil, nil, fmt.Errorf("failed to update outbound settings: %s", err)
 	}
 	return outboundSettings, resp, nil
 }

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
@@ -22,8 +22,21 @@ import (
 The resource_genesyscloud_outbound_settings.go contains all the methods that perform the core logic for a resource.
 */
 
-func getAllOutboundSettings(_ context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+func getAllOutboundSettings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
+	proxy := getOutboundSettingsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
+	_, resp, err := proxy.getOutboundSettings(ctx)
+	if err != nil {
+		if util.IsStatus404(resp) {
+			// Don't export if config doesn't exist
+			return resources, nil
+		}
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get %s due to error: %s", resourceName, err), resp)
+	}
 	resources["0"] = &resourceExporter.ResourceMeta{Name: "outbound_settings"}
 	return resources, nil
 }
@@ -48,10 +61,10 @@ func readOutboundSettings(ctx context.Context, d *schema.ResourceData, meta inte
 	automaticTimeZoneMapping := d.Get("automatic_time_zone_mapping").([]interface{})
 	rescheduleTimeZoneSkippedContacts := d.Get("reschedule_time_zone_skipped_contacts").(bool)
 
-	log.Printf("Reading Outbound setting %s", d.Id())
+	log.Printf("Reading Outbound Settings %s", d.Id())
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
-		settings, resp, getErr := proxy.getOutboundSettingsById(ctx, d.Id())
+		settings, resp, getErr := proxy.getOutboundSettings(ctx)
 		if getErr != nil {
 			if util.IsStatus404(resp) {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("Failed to read Outbound Setting: %s", getErr), resp))
@@ -98,7 +111,7 @@ func updateOutboundSettings(ctx context.Context, d *schema.ResourceData, meta in
 
 	diagErr := util.RetryWhen(util.IsVersionMismatch, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
 		// Get current Outbound settings version
-		setting, resp, getErr := proxy.getOutboundSettingsById(ctx, d.Id())
+		setting, resp, getErr := proxy.getOutboundSettings(ctx)
 		if getErr != nil {
 			return resp, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to update Outbound Setting %s error: %s", d.Id(), getErr), resp)
 		}
@@ -124,7 +137,7 @@ func updateOutboundSettings(ctx context.Context, d *schema.ResourceData, meta in
 			update.AutomaticTimeZoneMapping = buildOutboundSettingsAutomaticTimeZoneMapping(d)
 		}
 
-		_, resp, err := proxy.updateOutboundSettings(ctx, d.Id(), &update)
+		_, resp, err := proxy.updateOutboundSettings(ctx, &update)
 		if err != nil {
 			return resp, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to update Outbound settings %s error: %s", *setting.Name, err), resp)
 		}

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
@@ -24,7 +24,26 @@ import (
 
 // getOutboundWrapupCodeMappings is used by the exporter to return all wrapupcode mappings
 func getOutboundWrapupCodeMappings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	proxy := getOutboundWrapupCodeMappingsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
+
+	_, resp, err := proxy.getAllOutboundWrapupCodeMappings(ctx)
+	if err != nil {
+		if util.IsStatus404(resp) {
+			// Don't export if config doesn't exist
+			return resources, nil
+		}
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get %s due to error: %s", resourceName, err), resp)
+	}
+
+	_, resp, err = proxy.getAllWrapupCodes(ctx)
+	if err != nil {
+		if util.IsStatus404(resp) {
+			// Don't export if config doesn't exist
+			return resources, nil
+		}
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get %s due to error: %s", resourceName, err), resp)
+	}
 	resources["0"] = &resourceExporter.ResourceMeta{Name: "wrapupcodemappings"}
 	return resources, nil
 }

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
@@ -22,6 +22,10 @@ import (
 )
 
 func getAllRoutingSettings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+	// Although this resource typically has only a single instance,
+	// we are attempting to fetch the data from the API in order to
+	// verify the user's permission to access this resource's API endpoint(s).
+
 	proxy := getRoutingSettingsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 
@@ -33,6 +37,25 @@ func getAllRoutingSettings(ctx context.Context, clientConfig *platformclientv2.C
 		}
 		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get %s due to error: %s", resourceName, err), resp)
 	}
+
+	_, resp, err = proxy.getRoutingSettingsContactCenter(ctx)
+	if err != nil {
+		if util.IsStatus404(resp) {
+			// Don't export if config doesn't exist
+			return resources, nil
+		}
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get %s contact center due to error: %s", resourceName, err), resp)
+	}
+
+	_, resp, err = proxy.getRoutingSettingsTranscription(ctx)
+	if err != nil {
+		if util.IsStatus404(resp) {
+			// Don't export if config doesn't exist
+			return resources, nil
+		}
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("Failed to get %s transcription due to error: %s", resourceName, err), resp)
+	}
+
 	resources["0"] = &resourceExporter.ResourceMeta{Name: "routing_settings"}
 	return resources, nil
 }


### PR DESCRIPTION
This PR fixes DEVTOOLING-786 and DEVTOOLING-740 by improving permission handling for single-instance resources

Background:
- Many single-instance resources (e.g., `genesyscloud_outbound_settings`) return a simple `ResourceMeta` object in their `getAll...()` function.
- These resources have API access permissions associated with them.
- The exporter checks for permission errors after the initial `getAll...()` call and handles them via logging if `log_permissions_errors` is configured.
- Constructing a simple `ResourceMeta` object bypasses this check, causing errors in the downstream `read` functions even when `log_permissions_errors` is set.

Fix:
- Update the `getAll...()` function for single-instance resources that return key-value objects.
- Implement an API call to confirm user permissions before returning data.
- This approach aligns with the existing convention used in `genesyscloud_idp_*` resources.

This change ensures proper permission checking and error handling for single-instance resources, resolving the issue with the `log_permissions_errors` configuration.