### PR TITLE
NO-JIRA: Adds extra Export RefAttrs on genesyscloud_outbound_callanalysisresponseset

### DIFF
--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_schema.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_schema.go
@@ -1,11 +1,12 @@
 package outbound_callanalysisresponseset
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 /*
@@ -164,8 +165,16 @@ func OutboundCallanalysisresponsesetExporter() *resourceExporter.ResourceExporte
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthOutboundCallanalysisresponsesets),
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
-			"responses.callable_person.data":  {RefType: "genesyscloud_flow"},
-			"responses.callable_machine.data": {RefType: "genesyscloud_flow"},
+			"responses.callable_busy.data":          {RefType: "genesyscloud_flow"},
+			"responses.callable_disconnect.data":    {RefType: "genesyscloud_flow"},
+			"responses.callable_fax.data":           {RefType: "genesyscloud_flow"},
+			"responses.callable_lineconnected.data": {RefType: "genesyscloud_flow"},
+			"responses.callable_machine.data":       {RefType: "genesyscloud_flow"},
+			"responses.callable_noanswer.data":      {RefType: "genesyscloud_flow"},
+			"responses.callable_person.data":        {RefType: "genesyscloud_flow"},
+			"responses.callable_sit.data":           {RefType: "genesyscloud_flow"},
+			"responses.uncallable_notfound.data":    {RefType: "genesyscloud_flow"},
+			"responses.uncallable_sit.data":         {RefType: "genesyscloud_flow"},
 		},
 	}
 }


### PR DESCRIPTION
Adds extra Export RefAttrs that could exist and reference flows on genesyscloud_outbound_callanalysisresponseset.

Found this while reviewing export outputs from Japan orgs.