### PR TITLE
Fixes DEVTOOLING-791

### DIFF
--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -39,7 +39,7 @@ func getAllRoutingQueues(ctx context.Context, clientConfig *platformclientv2.Con
 
 	queues, resp, err := proxy.GetAllRoutingQueues(ctx)
 	if err != nil {
-		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to get routing queues"), resp)
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to get routing queues: %s", err), resp)
 	}
 
 	for _, queue := range *queues {


### PR DESCRIPTION
🐛 Fix: adds missing error object to Summary argument in `BuildAPIDiagnosticError()` call [DEVTOOLING-791]

This PR addresses a specific instance where we forgot to include the error object in the Summary argument string when calling `BuildAPIDiagnosticError()`.

Changes:
- Add the error message to the Summary string in the affected `BuildAPIDiagnosticError()` call
- Ensure the error can be properly picked up when checking for logging errors

🔍 Context:
This fix highlights a larger issue with our current approach to error handling, particularly in how we work with `BuildAPIDiagnosticError()` and check for logging errors related to permissions. While this PR addresses a specific instance, a broader refactor may be beneficial in the future.

📝 Note:
A separate bug will be opened to track the larger refactoring effort for improving our error handling practices. This future work will aim to standardize how we pass error objects and enhance our overall error management strategy.

---

Reviewers: Please confirm that the error message is correctly added to the Summary string and that it resolves the immediate issue.