### PR TITLE
Devtooling-819: not hard-coded division_id 

### DIFF
--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
@@ -96,10 +96,10 @@ func readRespManagementRespAsset(ctx context.Context, d *schema.ResourceData, me
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(resourceName, fmt.Sprintf("failed to read response asset %s | error: %s", d.Id(), getErr), resp))
 		}
 
-		d.Set("filename", *sdkAsset.Name)
+		_ = d.Set("filename", *sdkAsset.Name)
 
 		if sdkAsset.Division != nil && sdkAsset.Division.Id != nil {
-			d.Set("division_id", *sdkAsset.Division.Id)
+			_ = d.Set("division_id", *sdkAsset.Division.Id)
 		}
 
 		log.Printf("Read Responsemanagement response asset %s %s", d.Id(), *sdkAsset.Name)

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_schema.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_schema.go
@@ -79,6 +79,9 @@ func DataSourceResponseManagementResponseAsset() *schema.Resource {
 func ExporterResponseManagementResponseAsset() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllResponseAssets),
+		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
+			"division_id": {RefType: "genesyscloud_auth_division"},
+		},
 		CustomFileWriter: resourceExporter.CustomFileWriterSettings{
 			RetrieveAndWriteFilesFunc: responsemanagementResponseassetResolver,
 			SubDirectory:              "response_assets",


### PR DESCRIPTION
Removes the hard coded `division_id` on `responsemanagement_responseasset` export