### PR TITLE
NOJIRA Fix/script filepath arg

### DIFF
--- a/genesyscloud/scripts/resource_genesyscloud_script_utils.go
+++ b/genesyscloud/scripts/resource_genesyscloud_script_utils.go
@@ -35,7 +35,7 @@ func ScriptResolver(scriptId, exportDirectory, subDirectory string, configMap ma
 	// Update filepath field in configMap to point to exported script file
 	fileNameVal := path.Join(subDirectory, exportFileName)
 	fileContentVal := fmt.Sprintf(`${filesha256("%s")}`, path.Join(subDirectory, exportFileName))
-	configMap["filename"] = fileNameVal
+	configMap["filepath"] = fileNameVal
 	configMap["file_content_hash"] = fileContentVal
 
 	resource.State.Attributes["filepath"] = fileNameVal


### PR DESCRIPTION
I noticed this while working with some exports. The attribute is actually `filepath` not `filename` in the schema.