### PR TITLE
NOJIRA fix oauth client.authorized_grant_type to accept SAML2-BEARER value

### DIFF
--- a/docs/resources/oauth_client.md
+++ b/docs/resources/oauth_client.md
@@ -41,7 +41,7 @@ resource "genesyscloud_oauth_client" "example-client" {
 
 ### Required
 
-- `authorized_grant_type` (String) The OAuth Grant/Client type supported by this client (CODE | TOKEN | SAML2BEARER | PASSWORD | CLIENT-CREDENTIALS).
+- `authorized_grant_type` (String) The OAuth Grant/Client type supported by this client (CODE | TOKEN | SAML2-BEARER | PASSWORD | CLIENT-CREDENTIALS).
 - `name` (String) The name of the OAuth client.
 
 ### Optional

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_schema.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_schema.go
@@ -1,11 +1,12 @@
 package oauth_client
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "terraform-provider-genesyscloud/genesyscloud/resource_register"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 const (
@@ -73,10 +74,10 @@ func ResourceOAuthClient() *schema.Resource {
 				Optional:    true,
 			},
 			"authorized_grant_type": {
-				Description:  "The OAuth Grant/Client type supported by this client (CODE | TOKEN | SAML2BEARER | PASSWORD | CLIENT-CREDENTIALS).",
+				Description:  "The OAuth Grant/Client type supported by this client (CODE | TOKEN | SAML2-BEARER | PASSWORD | CLIENT-CREDENTIALS).",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"CODE", "TOKEN", "SAML2BEARER", "PASSWORD", "CLIENT-CREDENTIALS"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"CODE", "TOKEN", "SAML2BEARER", "SAML2-BEARER", "PASSWORD", "CLIENT-CREDENTIALS"}, false),
 			},
 			"scopes": {
 				Description: "The scopes requested by this client. Scopes must be set for clients not using the CLIENT-CREDENTIALS grant.",


### PR DESCRIPTION
Update `oauth_client`'s `authorized_grant_type` attribute to accept both `SAML2BEARER` and `SAML2-BEARER` values (the API allows both versions, but outputs as SAML2-BEARER in the API and export. It's important that the export be able to be reapplied right away, so this fix handles that).

Otherwise, this can happen when trying to apply an export of the oauth_client resource:

```
│ Error: expected authorized_grant_type to be one of ["CODE" "TOKEN" "SAML2BEARER" "PASSWORD" "CLIENT-CREDENTIALS"], got SAML2-BEARER
│
│   with genesyscloud_oauth_client.TT_SAML,
│   on genesyscloud.tf line 2799, in resource "genesyscloud_oauth_client" "TT_SAML":
│ 2799:   authorized_grant_type         = "SAML2-BEARER"
│
╵
```