### PR TITLE
NOJIRA - Fix data resource not outputting dynamic references

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -389,13 +389,13 @@ func (g *GenesysCloudResourceExporter) buildResourceConfigMap() diag.Diagnostics
 			g.updateSanitiseMap(*g.exporters, resource)
 		}
 
-		if !isDataSource {
-			// Removes zero values and sets proper reference expressions
-			unresolved, _ := g.sanitizeConfigMap(resource, jsonResult, "", *g.exporters, g.includeStateFile, g.exportAsHCL, true)
-			if len(unresolved) > 0 {
-				g.unresolvedAttrs = append(g.unresolvedAttrs, unresolved...)
-			}
-		} else {
+		// Removes zero values and sets proper reference expressions
+		unresolved, _ := g.sanitizeConfigMap(resource, jsonResult, "", *g.exporters, g.includeStateFile, g.exportAsHCL, true)
+		if len(unresolved) > 0 {
+			g.unresolvedAttrs = append(g.unresolvedAttrs, unresolved...)
+		}
+
+		if isDataSource {
 			g.sanitizeDataConfigMap(jsonResult)
 		}
 


### PR DESCRIPTION
NOJIRA - Fixes an issue where some data resources return more than just the name, and these can have dynamic references. The biggest offender of this is the genesyscloud_telephony_providers_edges_site_outbound_route data resource, which can have multiple routes named Default with different site ids

```
data "genesyscloud_telephony_providers_edges_site_outbound_route" "Default_Outbound_Route_1394897235" {
  name    = "Default Outbound Route"
  site_id = "6cd953fd-7040-4963-8f50-b4ebd866027a"
}
```

becomes
```
data "genesyscloud_telephony_providers_edges_site_outbound_route" "Default_Outbound_Route_1394897235" {
  name    = "Default Outbound Route"
  site_id = "${genesyscloud_telephony_providers_edges_site.Phone.id}"
}
```