### PR TITLE
DEVTOOLING-750: Improving export speed for contact_lists and contact_lists_contacts resources

### DIFF
--- a/genesyscloud/outbound_contact_list/genesyscloud_outbound_contact_list_proxy.go
+++ b/genesyscloud/outbound_contact_list/genesyscloud_outbound_contact_list_proxy.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"log"
+	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
+	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v143/platformclientv2"
 )
@@ -14,8 +16,7 @@ with the Genesys Cloud SDK. We use composition here for each function on the pro
 out during testing.
 */
 
-// internalProxy holds a proxy instance that can be used throughout the package
-var internalProxy *outboundContactlistProxy
+var contactListCache = rc.NewResourceCache[platformclientv2.Contactlist]()
 
 // Type definitions for each func on our proxy so we can easily mock them out later
 type createOutboundContactlistFunc func(ctx context.Context, p *outboundContactlistProxy, contactList *platformclientv2.Contactlist) (*platformclientv2.Contactlist, *platformclientv2.APIResponse, error)
@@ -35,6 +36,7 @@ type outboundContactlistProxy struct {
 	getOutboundContactlistByIdAttr     getOutboundContactlistByIdFunc
 	updateOutboundContactlistAttr      updateOutboundContactlistFunc
 	deleteOutboundContactlistAttr      deleteOutboundContactlistFunc
+	contactListCache                   rc.CacheInterface[platformclientv2.Contactlist]
 }
 
 // newOutboundContactlistProxy initializes the outbound contactlist proxy with all of the data needed to communicate with Genesys Cloud
@@ -49,16 +51,12 @@ func newOutboundContactlistProxy(clientConfig *platformclientv2.Configuration) *
 		getOutboundContactlistByIdAttr:     getOutboundContactlistByIdFn,
 		updateOutboundContactlistAttr:      updateOutboundContactlistFn,
 		deleteOutboundContactlistAttr:      deleteOutboundContactlistFn,
+		contactListCache:                   contactListCache,
 	}
 }
 
-// getOutboundContactlistProxy acts as a singleton to for the internalProxy.  It also ensures
-// that we can still proxy our tests by directly setting internalProxy package variable
 func getOutboundContactlistProxy(clientConfig *platformclientv2.Configuration) *outboundContactlistProxy {
-	if internalProxy == nil {
-		internalProxy = newOutboundContactlistProxy(clientConfig)
-	}
-	return internalProxy
+	return newOutboundContactlistProxy(clientConfig)
 }
 
 // createOutboundContactlist creates a Genesys Cloud outbound contactlist
@@ -93,11 +91,7 @@ func (p *outboundContactlistProxy) deleteOutboundContactlist(ctx context.Context
 
 // createOutboundContactlistFn is an implementation function for creating a Genesys Cloud outbound contactlist
 func createOutboundContactlistFn(ctx context.Context, p *outboundContactlistProxy, outboundContactlist *platformclientv2.Contactlist) (*platformclientv2.Contactlist, *platformclientv2.APIResponse, error) {
-	contactList, resp, err := p.outboundApi.PostOutboundContactlists(*outboundContactlist)
-	if err != nil {
-		return nil, resp, err
-	}
-	return contactList, resp, nil
+	return p.outboundApi.PostOutboundContactlists(*outboundContactlist)
 }
 
 // getAllOutboundContactlistFn is the implementation for retrieving all outbound contactlist in Genesys Cloud
@@ -114,9 +108,7 @@ func getAllOutboundContactlistFn(ctx context.Context, p *outboundContactlistProx
 		return &allContactlists, resp, nil
 	}
 
-	for _, contactList := range *contactLists.Entities {
-		allContactlists = append(allContactlists, contactList)
-	}
+	allContactlists = append(allContactlists, *contactLists.Entities...)
 
 	for pageNum := 2; pageNum <= *contactLists.PageCount; pageNum++ {
 		contactLists, resp, err := p.outboundApi.GetOutboundContactlists(false, false, pageSize, pageNum, true, "", name, []string{}, []string{}, "", "")
@@ -128,9 +120,11 @@ func getAllOutboundContactlistFn(ctx context.Context, p *outboundContactlistProx
 			break
 		}
 
-		for _, contactList := range *contactLists.Entities {
-			allContactlists = append(allContactlists, contactList)
-		}
+		allContactlists = append(allContactlists, *contactLists.Entities...)
+	}
+
+	for _, contactList := range allContactlists {
+		rc.SetCache(p.contactListCache, *contactList.Id, contactList)
 	}
 
 	return &allContactlists, resp, nil
@@ -143,25 +137,25 @@ func getOutboundContactlistIdByNameFn(ctx context.Context, p *outboundContactlis
 		return "", false, resp, fmt.Errorf("error searching outbound contact list  %s: %s", name, err)
 	}
 
-	var list platformclientv2.Contactlist
 	for _, contactList := range *contactLists {
 		if *contactList.Name == name {
 			log.Printf("Retrieved the contact list id %s by name %s", *contactList.Id, name)
-			list = contactList
-			return *list.Id, false, resp, nil
+			return *contactList.Id, false, resp, nil
 		}
 	}
 
-	return "", true, resp, nil
+	return "", true, resp, fmt.Errorf("no contact lists found with the name '%s'", name)
 }
 
 // getOutboundContactlistByIdFn is an implementation of the function to get a Genesys Cloud outbound contactlist by Id
 func getOutboundContactlistByIdFn(ctx context.Context, p *outboundContactlistProxy, id string) (outboundContactlist *platformclientv2.Contactlist, response *platformclientv2.APIResponse, err error) {
-	contactList, resp, err := p.outboundApi.GetOutboundContactlist(id, false, false)
-	if err != nil {
-		return nil, resp, err
+	if contactList := rc.GetCacheItem(p.contactListCache, id); contactList != nil {
+		return contactList, nil, nil
 	}
-	return contactList, resp, nil
+	if tfexporter_state.IsExporterActive() {
+		log.Printf("Could not read contact list '%s' from cache. Reading from the API...", id)
+	}
+	return p.outboundApi.GetOutboundContactlist(id, false, false)
 }
 
 // updateOutboundContactlistFn is an implementation of the function to update a Genesys Cloud outbound contactlist
@@ -172,14 +166,15 @@ func updateOutboundContactlistFn(ctx context.Context, p *outboundContactlistProx
 	}
 
 	outboundContactlist.Version = contactList.Version
-	outboundContactlist, resp, updateErr := p.outboundApi.PutOutboundContactlist(id, *outboundContactlist)
-	if updateErr != nil {
-		return nil, resp, updateErr
-	}
-	return outboundContactlist, resp, nil
+	return p.outboundApi.PutOutboundContactlist(id, *outboundContactlist)
 }
 
 // deleteOutboundContactlistFn is an implementation function for deleting a Genesys Cloud outbound contactlist
 func deleteOutboundContactlistFn(ctx context.Context, p *outboundContactlistProxy, id string) (response *platformclientv2.APIResponse, err error) {
-	return p.outboundApi.DeleteOutboundContactlist(id)
+	resp, err := p.outboundApi.DeleteOutboundContactlist(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.contactListCache, id)
+	return resp, nil
 }

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
@@ -153,11 +153,7 @@ func readOutboundContactList(ctx context.Context, d *schema.ResourceData, meta i
 			_ = d.Set("division_id", *sdkContactList.Division.Id)
 		}
 		if sdkContactList.ColumnNames != nil {
-			var columnNames []string
-			for _, name := range *sdkContactList.ColumnNames {
-				columnNames = append(columnNames, name)
-			}
-			_ = d.Set("column_names", columnNames)
+			_ = d.Set("column_names", *sdkContactList.ColumnNames)
 		}
 		if sdkContactList.PhoneColumns != nil {
 			_ = d.Set("phone_columns", flattenSdkOutboundContactListContactPhoneNumberColumnSlice(*sdkContactList.PhoneColumns))
@@ -169,11 +165,7 @@ func readOutboundContactList(ctx context.Context, d *schema.ResourceData, meta i
 			_ = d.Set("preview_mode_column_name", *sdkContactList.PreviewModeColumnName)
 		}
 		if sdkContactList.PreviewModeAcceptedValues != nil {
-			var acceptedValues []string
-			for _, val := range *sdkContactList.PreviewModeAcceptedValues {
-				acceptedValues = append(acceptedValues, val)
-			}
-			_ = d.Set("preview_mode_accepted_values", acceptedValues)
+			_ = d.Set("preview_mode_accepted_values", *sdkContactList.PreviewModeAcceptedValues)
 		}
 		if sdkContactList.AttemptLimits != nil && sdkContactList.AttemptLimits.Id != nil {
 			_ = d.Set("attempt_limit_id", *sdkContactList.AttemptLimits.Id)

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
@@ -139,7 +139,7 @@ func buildSdkOutboundContactListColumnDataTypeSpecifications(columnDataTypeSpeci
 }
 
 func flattenSdkOutboundContactListColumnDataTypeSpecifications(columnDataTypeSpecifications []platformclientv2.Columndatatypespecification) []interface{} {
-	if columnDataTypeSpecifications == nil || len(columnDataTypeSpecifications) == 0 {
+	if len(columnDataTypeSpecifications) == 0 {
 		return nil
 	}
 

--- a/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
+++ b/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
@@ -9,7 +9,6 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v143/platformclientv2"
 )
 
-var internalProxy *contactProxy
 var contactCache = rc.NewResourceCache[platformclientv2.Dialercontact]()
 
 type createContactFunc func(ctx context.Context, p *contactProxy, contactListId string, contact platformclientv2.Writabledialercontact, priority, clearSystemData, doNotQueue bool) ([]platformclientv2.Dialercontact, *platformclientv2.APIResponse, error)

--- a/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
+++ b/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
@@ -2,12 +2,15 @@ package outbound_contact_list_contact
 
 import (
 	"context"
+	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
+	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v143/platformclientv2"
 )
 
 var internalProxy *contactProxy
+var contactCache = rc.NewResourceCache[platformclientv2.Dialercontact]()
 
 type createContactFunc func(ctx context.Context, p *contactProxy, contactListId string, contact platformclientv2.Writabledialercontact, priority, clearSystemData, doNotQueue bool) ([]platformclientv2.Dialercontact, *platformclientv2.APIResponse, error)
 type readContactByIdFunc func(ctx context.Context, p *contactProxy, contactListId, contactId string) (*platformclientv2.Dialercontact, *platformclientv2.APIResponse, error)
@@ -28,7 +31,6 @@ type contactProxy struct {
 
 func newContactProxy(clientConfig *platformclientv2.Configuration) *contactProxy {
 	api := platformclientv2.NewOutboundApiWithConfig(clientConfig)
-	contactCache := rc.NewResourceCache[platformclientv2.Dialercontact]()
 	return &contactProxy{
 		clientConfig:        clientConfig,
 		outboundApi:         api,
@@ -42,11 +44,7 @@ func newContactProxy(clientConfig *platformclientv2.Configuration) *contactProxy
 }
 
 func getContactProxy(clientConfig *platformclientv2.Configuration) *contactProxy {
-	if internalProxy == nil {
-		internalProxy = newContactProxy(clientConfig)
-	}
-
-	return internalProxy
+	return newContactProxy(clientConfig)
 }
 
 func (p *contactProxy) createContact(ctx context.Context, contactListId string, contact platformclientv2.Writabledialercontact, priority, clearSystemData, doNotQueue bool) ([]platformclientv2.Dialercontact, *platformclientv2.APIResponse, error) {
@@ -77,6 +75,9 @@ func readContactByIdFn(_ context.Context, p *contactProxy, contactListId, contac
 	if contact := rc.GetCacheItem(p.contactCache, createComplexContact(contactListId, contactId)); contact != nil {
 		return contact, nil, nil
 	}
+	if tfexporter_state.IsExporterActive() {
+		log.Printf("Could not read contact '%s' from cache (Contact list '%s'). Reading from the API...", contactId, contactListId)
+	}
 	return p.outboundApi.GetOutboundContactlistContact(contactListId, contactId)
 }
 
@@ -85,7 +86,12 @@ func updateContactFn(_ context.Context, p *contactProxy, contactListId, contactI
 }
 
 func deleteContactFn(_ context.Context, p *contactProxy, contactListId, contactId string) (*platformclientv2.APIResponse, error) {
-	return p.outboundApi.DeleteOutboundContactlistContact(contactListId, contactId)
+	resp, err := p.outboundApi.DeleteOutboundContactlistContact(contactListId, contactId)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.contactCache, createComplexContact(contactListId, contactId))
+	return resp, nil
 }
 
 func getAllContactsFn(ctx context.Context, p *contactProxy) ([]platformclientv2.Dialercontact, *platformclientv2.APIResponse, error) {
@@ -106,10 +112,9 @@ func getAllContactsFn(ctx context.Context, p *contactProxy) ([]platformclientv2.
 		contactMatrix[contactListId] = contacts
 	}
 
-	for contactListId, contactList := range contactMatrix {
-		for _, contact := range contactList {
+	for contactListId, contactListContacts := range contactMatrix {
+		for _, contact := range contactListContacts {
 			rc.SetCache(p.contactCache, createComplexContact(contactListId, *contact.Id), contact)
-
 		}
 	}
 
@@ -119,7 +124,7 @@ func getAllContactsFn(ctx context.Context, p *contactProxy) ([]platformclientv2.
 func (p *contactProxy) getContactsByContactListId(_ context.Context, contactListId string) ([]platformclientv2.Dialercontact, *platformclientv2.APIResponse, error) {
 	var (
 		pageNum     = 1
-		pageSize    = 50
+		pageSize    = 100
 		allContacts []platformclientv2.Dialercontact
 	)
 
@@ -132,10 +137,14 @@ func (p *contactProxy) getContactsByContactListId(_ context.Context, contactList
 	if err != nil {
 		return nil, resp, err
 	}
-	if data.Entities == nil || len(*data.Entities) == 0 {
+	if data == nil || data.Entities == nil || len(*data.Entities) == 0 {
 		return nil, nil, nil
 	}
 	allContacts = append(allContacts, *data.Entities...)
+
+	if data.PageCount == nil {
+		return allContacts, nil, nil
+	}
 
 	for pageNum = 2; pageNum <= *data.PageCount; pageNum++ {
 		body.PageNumber = &pageNum
@@ -143,7 +152,7 @@ func (p *contactProxy) getContactsByContactListId(_ context.Context, contactList
 		if err != nil {
 			return nil, resp, err
 		}
-		if data.Entities == nil || len(*data.Entities) == 0 {
+		if data == nil || data.Entities == nil || len(*data.Entities) == 0 {
 			break
 		}
 		allContacts = append(allContacts, *data.Entities...)

--- a/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
+++ b/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
@@ -61,7 +61,7 @@ func createOutboundContactListContact(ctx context.Context, d *schema.ResourceDat
 		return util.BuildDiagnosticError(resourceName, msg, fmt.Errorf("%v", msg))
 	}
 	contactId := *contactResponseBody[0].Id
-	d.Set("contact_id", contactId)
+	_ = d.Set("contact_id", contactId)
 	id := createComplexContact(contactListId, contactId)
 	d.SetId(id)
 	log.Printf("Finished creating contact '%s' in contact list '%s'", contactId, contactListId)


### PR DESCRIPTION
This is done by:

* Implementing caching in the contact_lists package 
* Removing the singleton pattern in the proxies of both packages (this may not increase export speed but it will for read/plan operations)
* Increasing pageSize from 50 to 100 when paginating through contacts 

(The issue described in the ticket DEVTOOLING-750 was mostly fixed in [PR 1136](https://github.com/MyPureCloud/terraform-provider-genesyscloud/pull/1336). These changes only improved the export time marginally) 