### PR TITLE
[DEVTOOLING-849] API Limitation on Prompt Export

### DIFF
--- a/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
+++ b/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strings"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/files"
@@ -22,6 +23,7 @@ var internalProxy *architectUserPromptProxy
 
 type createArchitectUserPromptFunc func(ctx context.Context, p *architectUserPromptProxy, body platformclientv2.Prompt) (*platformclientv2.Prompt, *platformclientv2.APIResponse, error)
 type getArchitectUserPromptFunc func(ctx context.Context, p *architectUserPromptProxy, id string, includeMediaUris bool, includeResources bool, language []string, checkCache bool) (*platformclientv2.Prompt, *platformclientv2.APIResponse, error)
+type getAllArchitectUserPromptsFilterByNameFunc func(ctx context.Context, p *architectUserPromptProxy, includeMediaUris bool, includeResources bool, name string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error)
 type getArchitectUserPromptPageCountFunc func(ctx context.Context, p *architectUserPromptProxy, name string) (int, *platformclientv2.APIResponse, error)
 type getAllArchitectUserPromptsFunc func(ctx context.Context, p *architectUserPromptProxy, includeMediaUris bool, includeResources bool, name string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error)
 type updateArchitectUserPromptFunc func(ctx context.Context, p *architectUserPromptProxy, id string, body platformclientv2.Prompt) (*platformclientv2.Prompt, *platformclientv2.APIResponse, error)
@@ -39,6 +41,7 @@ type architectUserPromptProxy struct {
 	architectApi                                   *platformclientv2.ArchitectApi
 	createArchitectUserPromptAttr                  createArchitectUserPromptFunc
 	getArchitectUserPromptAttr                     getArchitectUserPromptFunc
+	getAllArchitectUserPromptsFilterByNameAttr     getAllArchitectUserPromptsFilterByNameFunc
 	getArchitectUserPromptPageCountAttr            getArchitectUserPromptPageCountFunc
 	getAllArchitectUserPromptsAttr                 getAllArchitectUserPromptsFunc
 	updateArchitectUserPromptAttr                  updateArchitectUserPromptFunc
@@ -60,6 +63,7 @@ func newArchitectUserPromptProxy(clientConfig *platformclientv2.Configuration) *
 		architectApi:                                   api,
 		createArchitectUserPromptAttr:                  createArchitectUserPromptFn,
 		getArchitectUserPromptAttr:                     getArchitectUserPromptFn,
+		getAllArchitectUserPromptsFilterByNameAttr:     getAllArchitectUserPromptsFilterByNameFn,
 		getArchitectUserPromptPageCountAttr:            getArchitectUserPromptPageCountFn,
 		getAllArchitectUserPromptsAttr:                 getAllArchitectUserPromptsFn,
 		updateArchitectUserPromptAttr:                  updateArchitectUserPromptFn,
@@ -90,6 +94,10 @@ func (p *architectUserPromptProxy) createArchitectUserPrompt(ctx context.Context
 // getArchitectUserPrompt retrieves a user prompt
 func (p *architectUserPromptProxy) getArchitectUserPrompt(ctx context.Context, id string, includeMediaUris, includeResources bool, languages []string, checkCache bool) (*platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
 	return p.getArchitectUserPromptAttr(ctx, p, id, includeMediaUris, includeResources, languages, checkCache)
+}
+
+func (p *architectUserPromptProxy) getAllArchitectUserPromptsFilterByName(ctx context.Context, includeMediaUris, includeResources bool, name string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
+	return p.getAllArchitectUserPromptsFilterByNameAttr(ctx, p, includeMediaUris, includeResources, name)
 }
 
 func (p *architectUserPromptProxy) getArchitectUserPromptPageCount(ctx context.Context, name string) (int, *platformclientv2.APIResponse, error) {
@@ -160,6 +168,43 @@ func deleteArchitectUserPromptFn(_ context.Context, p *architectUserPromptProxy,
 	}
 	rc.DeleteCacheItem(p.promptCache, id)
 	return nil, nil
+}
+
+func getAllArchitectUserPromptsFilterByNameFn(_ context.Context, p *architectUserPromptProxy, includeMediaUris, includeResources bool, exportNameFilter string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
+	const pageSize = 100
+	var allPrompts []platformclientv2.Prompt
+	var response *platformclientv2.APIResponse
+
+	for _, filter := range strings.Split(exportNameFilter, "") {
+		userPrompts, response, err := p.architectApi.GetArchitectPrompts(1, pageSize, []string{filter + "*"}, "", "", "", "", includeMediaUris, includeResources, nil)
+		if err != nil {
+			return nil, response, err
+		}
+
+		allPrompts = append(allPrompts, *userPrompts.Entities...)
+
+		pageCount := *userPrompts.PageCount
+		if userPrompts.Entities != nil || len(*userPrompts.Entities) != 0 {
+			for pageNum := 2; pageNum <= pageCount; pageNum++ {
+				userPrompts, response, getErr := p.architectApi.GetArchitectPrompts(pageNum, pageSize, []string{filter + "*"}, "", "", "", "", includeMediaUris, includeResources, nil)
+				if getErr != nil {
+					return nil, response, getErr
+				}
+
+				if userPrompts == nil || userPrompts.Entities == nil || len(*userPrompts.Entities) == 0 {
+					break
+				}
+
+				allPrompts = append(allPrompts, *userPrompts.Entities...)
+			}
+		}
+	}
+
+	for _, prompt := range allPrompts {
+		rc.SetCache(p.promptCache, *prompt.Id, prompt)
+	}
+
+	return &allPrompts, response, nil
 }
 
 func getArchitectUserPromptPageCountFn(_ context.Context, p *architectUserPromptProxy, name string) (int, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
+++ b/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path/filepath"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
+	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/files"
 	"time"
@@ -22,7 +23,7 @@ var internalProxy *architectUserPromptProxy
 
 type createArchitectUserPromptFunc func(ctx context.Context, p *architectUserPromptProxy, body platformclientv2.Prompt) (*platformclientv2.Prompt, *platformclientv2.APIResponse, error)
 type getArchitectUserPromptFunc func(ctx context.Context, p *architectUserPromptProxy, id string, includeMediaUris bool, includeResources bool, language []string, checkCache bool) (*platformclientv2.Prompt, *platformclientv2.APIResponse, error)
-type getAllArchitectUserPromptsFunc func(ctx context.Context, p *architectUserPromptProxy, includeMediaUris bool, includeResources bool, name string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error)
+type getAllArchitectUserPromptsFunc func(ctx context.Context, p *architectUserPromptProxy, includeMediaUris bool, includeResources bool, name string, exportNames []string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error)
 type updateArchitectUserPromptFunc func(ctx context.Context, p *architectUserPromptProxy, id string, body platformclientv2.Prompt) (*platformclientv2.Prompt, *platformclientv2.APIResponse, error)
 type deleteArchitectUserPromptFunc func(ctx context.Context, p *architectUserPromptProxy, id string, allResources bool) (*platformclientv2.APIResponse, error)
 type createArchitectUserPromptResourceFunc func(ctx context.Context, p *architectUserPromptProxy, id string, resource platformclientv2.Promptassetcreate) (*platformclientv2.Promptasset, *platformclientv2.APIResponse, error)
@@ -90,8 +91,8 @@ func (p *architectUserPromptProxy) getArchitectUserPrompt(ctx context.Context, i
 }
 
 // getAllArchitectUserPrompts retrieves a list of user prompts
-func (p *architectUserPromptProxy) getAllArchitectUserPrompts(ctx context.Context, includeMediaUris, includeResources bool, name string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
-	return p.getAllArchitectUserPromptsAttr(ctx, p, includeMediaUris, includeResources, name)
+func (p *architectUserPromptProxy) getAllArchitectUserPrompts(ctx context.Context, includeMediaUris, includeResources bool, name string, exportNames []string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
+	return p.getAllArchitectUserPromptsAttr(ctx, p, includeMediaUris, includeResources, name, exportNames)
 }
 
 // updateArchitectUserPrompt updates a user prompt
@@ -155,21 +156,20 @@ func deleteArchitectUserPromptFn(_ context.Context, p *architectUserPromptProxy,
 	return nil, nil
 }
 
-func getAllArchitectUserPromptsFn(_ context.Context, p *architectUserPromptProxy, includeMediaUris, includeResources bool, name string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
+func getAllArchitectUserPromptsFn(_ context.Context, p *architectUserPromptProxy, includeMediaUris, includeResources bool, name string, exportNames []string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
 	const pageSize = 100
 	var allPrompts []platformclientv2.Prompt
-	var exportNameFilter []string
+	var nameFilter []string
 
+	// Determine whether to pass in a single name for getByName or export name filter
 	if name != "" {
-		exportNameFilter = append(exportNameFilter, name)
-	} else {
-		exportNameFilter = []string{
-			"a*", "b*", "c*", "d*", "e*", "f*", "g*", "h*", "i*", "j*", "k*", "l*", "m*",
-			"n*", "o*", "p*", "q*", "r*", "s*", "t*", "u*", "v*", "w*", "x*", "y*", "z*",
-		}
+		nameFilter = append(nameFilter, name)
+	}
+	if exportNames != nil && tfexporter_state.IsExporterActive() {
+		nameFilter = exportNames
 	}
 
-	userPrompts, response, err := p.architectApi.GetArchitectPrompts(1, pageSize, exportNameFilter, "", "", "", "", includeMediaUris, includeResources, nil)
+	userPrompts, response, err := p.architectApi.GetArchitectPrompts(1, pageSize, nameFilter, "", "", "", "", includeMediaUris, includeResources, nil)
 	if err != nil {
 		return nil, response, err
 	}
@@ -182,7 +182,7 @@ func getAllArchitectUserPromptsFn(_ context.Context, p *architectUserPromptProxy
 
 	pageCount := *userPrompts.PageCount
 	for pageNum := 2; pageNum <= pageCount; pageNum++ {
-		userPrompts, response, getErr := p.architectApi.GetArchitectPrompts(pageNum, pageSize, exportNameFilter, "", "", "", "", includeMediaUris, includeResources, nil)
+		userPrompts, response, getErr := p.architectApi.GetArchitectPrompts(pageNum, pageSize, nameFilter, "", "", "", "", includeMediaUris, includeResources, nil)
 		if getErr != nil {
 			return nil, response, getErr
 		}
@@ -385,7 +385,7 @@ func (p *architectUserPromptProxy) buildUserPromptResourcesForCreateAndUpdate(ct
 
 // getArchitectUserPromptIdByNameFn will query user prompt by name and retry if search has not yet indexed the user prompt.
 func getArchitectUserPromptIdByNameFn(ctx context.Context, p *architectUserPromptProxy, name string) (string, *platformclientv2.APIResponse, error, bool) {
-	prompts, response, err := p.getAllArchitectUserPrompts(ctx, true, true, name)
+	prompts, response, err := p.getAllArchitectUserPrompts(ctx, true, true, name, nil)
 	if err != nil {
 		return "", response, err, false
 	}

--- a/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
+++ b/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
@@ -158,8 +158,18 @@ func deleteArchitectUserPromptFn(_ context.Context, p *architectUserPromptProxy,
 func getAllArchitectUserPromptsFn(_ context.Context, p *architectUserPromptProxy, includeMediaUris, includeResources bool, name string) (*[]platformclientv2.Prompt, *platformclientv2.APIResponse, error) {
 	const pageSize = 100
 	var allPrompts []platformclientv2.Prompt
+	var exportNameFilter []string
 
-	userPrompts, response, err := p.architectApi.GetArchitectPrompts(1, pageSize, []string{name}, "", "", "", "", includeMediaUris, includeResources, nil)
+	if name != "" {
+		exportNameFilter = append(exportNameFilter, name)
+	} else {
+		exportNameFilter = []string{
+			"a*", "b*", "c*", "d*", "e*", "f*", "g*", "h*", "i*", "j*", "k*", "l*", "m*",
+			"n*", "o*", "p*", "q*", "r*", "s*", "t*", "u*", "v*", "w*", "x*", "y*", "z*",
+		}
+	}
+
+	userPrompts, response, err := p.architectApi.GetArchitectPrompts(1, pageSize, exportNameFilter, "", "", "", "", includeMediaUris, includeResources, nil)
 	if err != nil {
 		return nil, response, err
 	}
@@ -172,7 +182,7 @@ func getAllArchitectUserPromptsFn(_ context.Context, p *architectUserPromptProxy
 
 	pageCount := *userPrompts.PageCount
 	for pageNum := 2; pageNum <= pageCount; pageNum++ {
-		userPrompts, response, getErr := p.architectApi.GetArchitectPrompts(pageNum, pageSize, []string{name}, "", "", "", "", includeMediaUris, includeResources, nil)
+		userPrompts, response, getErr := p.architectApi.GetArchitectPrompts(pageNum, pageSize, exportNameFilter, "", "", "", "", includeMediaUris, includeResources, nil)
 		if getErr != nil {
 			return nil, response, getErr
 		}

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
@@ -25,26 +26,10 @@ func getAllUserPrompts(ctx context.Context, clientConfig *platformclientv2.Confi
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := getArchitectUserPromptProxy(clientConfig)
 
-	exportNameFilter := []interface{}{
-		[]string{
-			"a*", "b*", "c*", "d*", "e*", "f*",
-		},
-		[]string{
-			"g*", "h*", "i*", "j*", "k*",
-		},
-		[]string{
-			"l*", "m*", "n*", "o*", "p*",
-		},
-		[]string{
-			"q*", "r*", "s*", "t*", "u*",
-		},
-		[]string{
-			"v*", "w*", "x*", "y*", "z*",
-		},
-	}
+	exportNameFilter := "abcdefghijklmnopqrstuvwxyz"
 
-	for _, filter := range exportNameFilter {
-		userPrompts, resp, err := proxy.getAllArchitectUserPrompts(ctx, true, true, "", filter.([]string))
+	for _, filter := range strings.Split(exportNameFilter, "") {
+		userPrompts, resp, err := proxy.getAllArchitectUserPrompts(ctx, true, true, "", []string{fmt.Sprintf("%s*", filter)})
 		if err != nil {
 			return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to get user prompts: %s", err), resp)
 		}

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
@@ -25,14 +25,33 @@ func getAllUserPrompts(ctx context.Context, clientConfig *platformclientv2.Confi
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := getArchitectUserPromptProxy(clientConfig)
 
-	userPrompts, resp, err := proxy.getAllArchitectUserPrompts(ctx, true, true, "")
-	if err != nil {
-		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to get user prompts: %s", err), resp)
-	}
-	for _, userPrompt := range *userPrompts {
-		resources[*userPrompt.Id] = &resourceExporter.ResourceMeta{Name: *userPrompt.Name}
+	exportNameFilter := []interface{}{
+		[]string{
+			"a*", "b*", "c*", "d*", "e*", "f*",
+		},
+		[]string{
+			"g*", "h*", "i*", "j*", "k*",
+		},
+		[]string{
+			"l*", "m*", "n*", "o*", "p*",
+		},
+		[]string{
+			"q*", "r*", "s*", "t*", "u*",
+		},
+		[]string{
+			"v*", "w*", "x*", "y*", "z*",
+		},
 	}
 
+	for _, filter := range exportNameFilter {
+		userPrompts, resp, err := proxy.getAllArchitectUserPrompts(ctx, true, true, "", filter.([]string))
+		if err != nil {
+			return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to get user prompts: %s", err), resp)
+		}
+		for _, userPrompt := range *userPrompts {
+			resources[*userPrompt.Id] = &resourceExporter.ResourceMeta{Name: *userPrompt.Name}
+		}
+	}
 	return resources, nil
 }
 

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
@@ -31,9 +31,9 @@ func getAllUserPrompts(ctx context.Context, clientConfig *platformclientv2.Confi
 		err         error
 	)
 
-	pageCount, _, err := proxy.getArchitectUserPromptPageCount(ctx, "")
+	pageCount, resp, err := proxy.getArchitectUserPromptPageCount(ctx, "")
 	if err != nil {
-		return nil, util.BuildDiagnosticError(resourceName, fmt.Sprintf("failed to get user prompts: %s", err), err)
+		return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to get user prompts: %s", err), resp)
 	}
 
 	if pageCount < 100 {

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
@@ -26,10 +26,10 @@ func getAllUserPrompts(ctx context.Context, clientConfig *platformclientv2.Confi
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := getArchitectUserPromptProxy(clientConfig)
 
-	exportNameFilter := "abcdefghijklmnopqrstuvwxyz"
+	exportNameFilter := "abcdefghijklmnopqrstuvwxyz1234567890"
 
 	for _, filter := range strings.Split(exportNameFilter, "") {
-		userPrompts, resp, err := proxy.getAllArchitectUserPrompts(ctx, true, true, "", []string{fmt.Sprintf("%s*", filter)})
+		userPrompts, resp, err := proxy.getAllArchitectUserPrompts(ctx, true, true, filter+"*")
 		if err != nil {
 			return nil, util.BuildAPIDiagnosticError(resourceName, fmt.Sprintf("failed to get user prompts: %s", err), resp)
 		}

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -1671,7 +1671,7 @@ func validatePromptsExported(filename string) resource.TestCheckFunc {
 
 // TestAccResourceUserPromptsExported tests the new getAll functionality where it adds the name filter and makes a call per letter
 // This will prevent the 10,000 return limit being hit on export and not returning everything
-func TestAccResourceUserPromptsExported(t *testing.T) {
+func TestAccResourceTfExportUserPromptsExported(t *testing.T) {
 	var (
 		exportTestDir     = filepath.Join("..", "..", ".terraform"+uuid.NewString())
 		resourceID        = "export"
@@ -1737,7 +1737,11 @@ resource "genesyscloud_architect_user_prompt" "%s" {
 					},
 					util.FalseValue, // export_as_hcl
 					util.FalseValue,
-					[]string{},
+					[]string{
+						strconv.Quote("genesyscloud_architect_user_prompt." + dPromptResourceId),
+						strconv.Quote("genesyscloud_architect_user_prompt." + hPromptResourceId),
+						strconv.Quote("genesyscloud_architect_user_prompt." + zPromptResourceId),
+					},
 				),
 				Check: resource.ComposeTestCheckFunc(
 					validatePromptsExported(exportTestDir),

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -1679,7 +1679,7 @@ func TestAccResourceTfExportUserPromptsExported(t *testing.T) {
 		dPromptName       = "d_user_prompt_test"
 		hPromptResourceId = "h_user_prompt"
 		hPromptName       = "h_user_prompt_test"
-		zPromptResourceId = "z_user_prompt"
+		zPromptResourceId = "Z_user_prompt"
 		zPromptName       = "Z_user_prompt_test"
 	)
 


### PR DESCRIPTION
This PR changes the functionality of the getAllPrompts due to hitting the 10,000 limit.
To prevent this, the API will be called with different name filters based on starting letter of the prompt 