### PR TITLE
No-JIRA: Allow user to set number of times consistency checker runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,23 @@ GENESYSCLOUD_PROXY_HOST
 GENESYSCLOUD_PROXY_PROTOCOL
 GENESYSCLOUD_PROXY_AUTH_USERNAME
 GENESYSCLOUD_PROXY_AUTH_PASSWORD
-
 ```
+
+### Customizing the consistency checker
+The provider uses a consistency checker to help deal with eventual consistency problems that might occur when a GET api does not return up-to-date data after a resource is updated. By default, the consistency checker will throw an error if, after retrying, there is still an unexpected mismatch between states. 
+To change this behaviour and make the consistency checker write errors to a file, you can set the following environment variable:
+```
+BYPASS_CONSISTENCY_CHECKER
+```
+
+When `BYPASS_CONSISTENCY_CHECKER` is set the provider will retry 5 times by default when it encounters a problem before writing the error to a file. You can specifically set how many times you want the consistency checker to run by setting the following environment variable.
+```
+CONSISTENCY_CHECKS=5
+```
+
+_Note_: `CONSISTENCY_CHECKS` can only be used when `BYPASS_CONSISTENCY_CHECKER` is set.
+
+_Note_: Settings `CONSISTENCY_CHECKS=0` will completely disable the consistency checker and stop it from running.
 
 ### Data Sources
 

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
@@ -103,7 +103,7 @@ func createArchitectDatatable(ctx context.Context, d *schema.ResourceData, meta 
 func readArchitectDatatable(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	archProxy := getArchitectDatatableProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectDatatable(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectDatatable(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading architect_datatable %s", d.Id())
 

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
@@ -108,7 +108,7 @@ func readArchitectDatatableRow(ctx context.Context, d *schema.ResourceData, meta
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	archProxy := getArchitectDatatableRowProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectDatatableRow(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectDatatableRow(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Datatable Row %s", d.Id())
 

--- a/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup.go
+++ b/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup.go
@@ -78,7 +78,7 @@ func createEmergencyGroup(ctx context.Context, d *schema.ResourceData, meta inte
 func readEmergencyGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	ap := getArchitectEmergencyGroupProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectEmergencyGroup(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectEmergencyGroup(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading emergency group %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar.go
+++ b/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar.go
@@ -65,7 +65,7 @@ func createArchitectGrammar(ctx context.Context, d *schema.ResourceData, meta in
 func readArchitectGrammar(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getArchitectGrammarProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectGrammar(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectGrammar(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Architect Grammar %s", d.Id())
 

--- a/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language.go
+++ b/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language.go
@@ -65,7 +65,7 @@ func createArchitectGrammarLanguage(ctx context.Context, d *schema.ResourceData,
 func readArchitectGrammarLanguage(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getArchitectGrammarLanguageProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectGrammarLanguage(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectGrammarLanguage(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Architect Grammar Language %s", d.Id())
 

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
@@ -66,7 +66,7 @@ func createIvrConfig(ctx context.Context, d *schema.ResourceData, meta interface
 func readIvrConfig(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	ap := getArchitectIvrProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectIvrConfig(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectIvrConfig(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading IVR config %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups.go
+++ b/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups.go
@@ -66,7 +66,7 @@ func createArchitectSchedulegroups(ctx context.Context, d *schema.ResourceData, 
 func readArchitectSchedulegroups(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getArchitectSchedulegroupsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectSchedulegroups(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectSchedulegroups(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading schedule group %s", d.Id())
 

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
@@ -100,7 +100,7 @@ func createArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta 
 func readArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getArchitectSchedulesProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectSchedules(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectSchedules(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading schedule %s", d.Id())
 

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
@@ -25,32 +25,14 @@ func getAllUserPrompts(ctx context.Context, clientConfig *platformclientv2.Confi
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := getArchitectUserPromptProxy(clientConfig)
 
-	var (
-		userPrompts *[]platformclientv2.Prompt
-		resp        *platformclientv2.APIResponse
-		err         error
-	)
-
-	pageCount, resp, err := proxy.getArchitectUserPromptPageCount(ctx, "")
+	userPrompts, resp, err := proxy.getAllArchitectUserPrompts(ctx, true, true, "")
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get user prompts: %s", err), resp)
 	}
-
-	if pageCount < 100 {
-		userPrompts, resp, err = proxy.getAllArchitectUserPrompts(ctx, true, true, "")
-		if err != nil {
-			return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get user prompts: %s", err), resp)
-		}
-	} else {
-		userPrompts, resp, err = proxy.getAllArchitectUserPromptsFilterByName(ctx, true, true, "abcdefghijklmnopqrstuvwxyz1234567890")
-		if err != nil {
-			return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get user prompts: %s", err), resp)
-		}
-	}
-
 	for _, userPrompt := range *userPrompts {
 		resources[*userPrompt.Id] = &resourceExporter.ResourceMeta{BlockLabel: *userPrompt.Name}
 	}
+
 	return resources, nil
 }
 
@@ -92,7 +74,7 @@ func createUserPrompt(ctx context.Context, d *schema.ResourceData, meta interfac
 func readUserPrompt(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getArchitectUserPromptProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectUserPrompt(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceArchitectUserPrompt(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading User Prompt %s", d.Id())
 

--- a/genesyscloud/auth_division/resource_genesyscloud_auth_division.go
+++ b/genesyscloud/auth_division/resource_genesyscloud_auth_division.go
@@ -73,7 +73,7 @@ func createAuthDivision(ctx context.Context, d *schema.ResourceData, meta interf
 func readAuthDivision(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getAuthDivisionProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceAuthDivision(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceAuthDivision(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading division %s", d.Id())
 

--- a/genesyscloud/auth_role/resource_genesyscloud_auth_role.go
+++ b/genesyscloud/auth_role/resource_genesyscloud_auth_role.go
@@ -94,7 +94,7 @@ func createAuthRole(ctx context.Context, d *schema.ResourceData, meta interface{
 func readAuthRole(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getAuthRoleProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceAuthRole(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceAuthRole(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading role %s", d.Id())
 

--- a/genesyscloud/consistency_checker/consistency_checker.go
+++ b/genesyscloud/consistency_checker/consistency_checker.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
 	"unsafe"
 
@@ -224,10 +225,10 @@ func (c *ConsistencyCheck) CheckState(currentState *schema.ResourceData) *retry.
 		return nil
 	}
 
-	if featureToggles.CCToggleExists() {
-		log.Printf("%s is set, write consistency errors to consistency-errors.log.json", featureToggles.CCToggleName())
-	} else {
-		log.Printf("%s is not set, consistency checker behaving as default", featureToggles.CCToggleName())
+	// If the user has set BYPASS_CONSISTENCY_CHECKER and CONSISTENCY_CHECKS=0 then the consistency checker will not run
+	if featureToggles.CCToggleExists() && constants.ConsistencyChecks() == 0 {
+		log.Print("Consistency checker disabled")
+		return nil
 	}
 
 	originalState := filterMap(c.originalState)

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram.go
@@ -76,7 +76,7 @@ func readConversationsMessagingIntegrationsInstagram(ctx context.Context, d *sch
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read conversations messaging integrations instagram %s: %s", d.Id(), getErr), resp))
 		}
 
-		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingIntegrationsInstagram(), constants.DefaultConsistencyChecks, ResourceType)
+		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingIntegrationsInstagram(), constants.ConsistencyChecks(), ResourceType)
 
 		resourcedata.SetNillableValue(d, "name", instagramIntegrationRequest.Name)
 

--- a/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open.go
+++ b/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open.go
@@ -68,7 +68,7 @@ func readConversationsMessagingIntegrationsOpen(ctx context.Context, d *schema.R
 
 	log.Printf("Reading conversations messaging integrations open %s", d.Id())
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingIntegrationsOpen(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingIntegrationsOpen(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
 		openIntegrationRequest, resp, err := proxy.getConversationsMessagingIntegrationsOpenById(ctx, d.Id())

--- a/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings.go
+++ b/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings.go
@@ -54,7 +54,7 @@ func createConversationsMessagingSettings(ctx context.Context, d *schema.Resourc
 func readConversationsMessagingSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getConversationsMessagingSettingsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingSettings(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingSettings(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading conversations messaging settings %s", d.Id())
 

--- a/genesyscloud/conversations_messaging_settings_default/resource_genesyscloud_conversations_messaging_settings_default.go
+++ b/genesyscloud/conversations_messaging_settings_default/resource_genesyscloud_conversations_messaging_settings_default.go
@@ -25,7 +25,7 @@ func createConversationsMessagingSettingsDefault(ctx context.Context, d *schema.
 func readConversationsMessagingSettingsDefault(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getConversationsMessagingSettingsDefaultProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingSettingsDefault(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingSettingsDefault(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading conversations messaging settings default %s", d.Id())
 

--- a/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent.go
@@ -67,7 +67,7 @@ func readSupportedContent(ctx context.Context, d *schema.ResourceData, meta inte
 
 	log.Printf("Reading supported content %s", d.Id())
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSupportedContent(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSupportedContent(), constants.ConsistencyChecks(), ResourceType)
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
 		supportedContent, resp, getErr := proxy.getSupportedContentById(ctx, d.Id())
 		if getErr != nil {

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
@@ -51,7 +51,7 @@ func createConversationsMessagingSupportedcontentDefault(ctx context.Context, d 
 func readConversationsMessagingSupportedcontentDefault(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getConversationsMessagingSupportedcontentDefaultProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingSupportedcontentDefault(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceConversationsMessagingSupportedcontentDefault(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading conversations supported content default %s", d.Id())
 

--- a/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions.go
+++ b/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions.go
@@ -74,7 +74,7 @@ func createEmployeeperformanceExternalmetricsDefinition(ctx context.Context, d *
 func readEmployeeperformanceExternalmetricsDefinition(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getEmployeeperformanceExternalmetricsDefinitionProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceEmployeeperformanceExternalmetricsDefinition(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceEmployeeperformanceExternalmetricsDefinition(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading employeeperformance externalmetrics definition %s", d.Id())
 

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
@@ -85,7 +85,7 @@ func createExternalContact(ctx context.Context, d *schema.ResourceData, meta int
 func readExternalContact(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	ep := getExternalContactsContactsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceExternalContact(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceExternalContact(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading external contact %s", d.Id())
 

--- a/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel.go
+++ b/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel.go
@@ -83,7 +83,7 @@ func readFlowLogLevel(ctx context.Context, d *schema.ResourceData, meta interfac
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	ep := getFlowLogLevelProxy(sdkConfig)
 	flowId := d.Get("flow_id").(string)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceFlowLoglevel(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceFlowLoglevel(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading readFlowLogLevel with flowId %s", flowId)
 

--- a/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone.go
+++ b/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone.go
@@ -62,7 +62,7 @@ func createFlowMilestone(ctx context.Context, d *schema.ResourceData, meta inter
 func readFlowMilestone(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getFlowMilestoneProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceFlowMilestone(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceFlowMilestone(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading flow milestone %s", d.Id())
 

--- a/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome.go
+++ b/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome.go
@@ -62,7 +62,7 @@ func createFlowOutcome(ctx context.Context, d *schema.ResourceData, meta interfa
 func readFlowOutcome(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getFlowOutcomeProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceFlowOutcome(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceFlowOutcome(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading flow outcome %s", d.Id())
 

--- a/genesyscloud/group/resource_genesyscloud_group.go
+++ b/genesyscloud/group/resource_genesyscloud_group.go
@@ -93,7 +93,7 @@ func createGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 
 func readGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceGroup(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceGroup(), constants.ConsistencyChecks(), ResourceType)
 	gp := getGroupProxy(sdkConfig)
 
 	log.Printf("Reading group %s", d.Id())

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles.go
@@ -3,13 +3,12 @@ package group_roles
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"log"
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -34,7 +33,7 @@ func deleteGroupRoles(_ context.Context, _ *schema.ResourceData, _ interface{}) 
 func readGroupRoles(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getGroupRolesProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceGroupRoles(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceGroupRoles(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading roles for group %s", d.Id())
 

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
@@ -61,7 +61,7 @@ func readIdpAdfs(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("Reading idp adfs %s", d.Id())
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpAdfs(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpAdfs(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForReadCustomTimeout(ctx, d.Timeout(schema.TimeoutRead), d, func() *retry.RetryError {
 		aDFS, resp, getErr := proxy.getIdpAdfs(ctx)

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
@@ -62,7 +62,7 @@ func readIdpGeneric(ctx context.Context, d *schema.ResourceData, meta interface{
 
 	log.Printf("Reading idp generic %s", d.Id())
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpGeneric(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpGeneric(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForReadCustomTimeout(ctx, d.Timeout(schema.TimeoutRead), d, func() *retry.RetryError {
 		genericSAML, resp, getErr := proxy.getIdpGeneric(ctx)

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
@@ -62,7 +62,7 @@ func readIdpGsuite(ctx context.Context, d *schema.ResourceData, meta interface{}
 
 	log.Printf("Reading idp gsuite")
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpGsuite(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpGsuite(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForReadCustomTimeout(ctx, d.Timeout(schema.TimeoutRead), d, func() *retry.RetryError {
 		gSuite, resp, getErr := proxy.getIdpGsuite(ctx)

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
@@ -72,7 +72,7 @@ func readIdpOkta(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read IDP Okta: %s", getErr), resp))
 		}
 
-		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpOkta(), constants.DefaultConsistencyChecks, "genesyscloud_idp_okta")
+		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpOkta(), constants.ConsistencyChecks(), "genesyscloud_idp_okta")
 
 		resourcedata.SetNillableValue(d, "name", okta.Name)
 		resourcedata.SetNillableValue(d, "disabled", okta.Disabled)

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
@@ -72,7 +72,7 @@ func readIdpOnelogin(ctx context.Context, d *schema.ResourceData, meta interface
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read IDP Onelogin: %s", getErr), resp))
 		}
 
-		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpOnelogin(), constants.DefaultConsistencyChecks, ResourceType)
+		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpOnelogin(), constants.ConsistencyChecks(), ResourceType)
 
 		if oneLogin.Certificate != nil {
 			d.Set("certificates", lists.StringListToInterfaceList([]string{*oneLogin.Certificate}))

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
@@ -62,7 +62,7 @@ func readIdpPing(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("Reading idp ping")
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpPing(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpPing(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForReadCustomTimeout(ctx, d.Timeout(schema.TimeoutRead), d, func() *retry.RetryError {
 		pingIdentity, resp, getErr := proxy.getIdpPing(ctx)

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
@@ -53,7 +53,7 @@ func createIdpSalesforce(ctx context.Context, d *schema.ResourceData, meta inter
 func readIdpSalesforce(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getIdpSalesforceProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpSalesforce(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIdpSalesforce(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading IDP Salesforce")
 

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
@@ -107,7 +107,7 @@ func createIntegrationAction(ctx context.Context, d *schema.ResourceData, meta i
 func readIntegrationAction(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	iap := getIntegrationActionsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationAction(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationAction(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading integration action %s", d.Id())
 

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
@@ -127,7 +127,7 @@ func retrieveCachedOauthClientSecret(sdkConfig *platformclientv2.Configuration, 
 func readCredential(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	ip := getIntegrationCredsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationCredential(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationCredential(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading credential %s", d.Id())
 

--- a/genesyscloud/integration_custom_auth_action/data_source_genesyscloud_integration_custom_auth_action_test.go
+++ b/genesyscloud/integration_custom_auth_action/data_source_genesyscloud_integration_custom_auth_action_test.go
@@ -23,12 +23,12 @@ func TestAccDataSourceIntegrationCustomAuthAction(t *testing.T) {
 	var (
 		// Integration Credentials
 		credentialResourceLabel1   = "test_integration_credential_1"
-		credentialResourceNameAttr = "Terraform Cred-" + uuid.NewString()
+		credentialResourceTypeAttr = "Terraform Cred-" + uuid.NewString()
 		credKey1                   = "loginUrl"
 		credVal1                   = "https://www.test-login.com"
 		credentialResourceConfig   = integrationCred.GenerateCredentialResource(
 			credentialResourceLabel1,
-			strconv.Quote(credentialResourceNameAttr),
+			strconv.Quote(credentialResourceTypeAttr),
 			strconv.Quote(customAuthCredentialType),
 			integrationCred.GenerateCredentialFields(
 				map[string]string{credKey1: strconv.Quote(credVal1)},
@@ -37,14 +37,14 @@ func TestAccDataSourceIntegrationCustomAuthAction(t *testing.T) {
 
 		// Web Services Data Action Integration
 		integResourceLabel1       = "test_integration1"
-		integResourceNameAttr1    = "Terraform Integration-" + uuid.NewString()
+		integResourceTypeAttr1    = "Terraform Integration-" + uuid.NewString()
 		integTypeID               = "custom-rest-actions"
 		integrationResourceConfig = integration.GenerateIntegrationResource(
 			integResourceLabel1,
 			util.NullValue,
 			strconv.Quote(integTypeID),
 			integration.GenerateIntegrationConfig(
-				strconv.Quote(integResourceNameAttr1),
+				strconv.Quote(integResourceTypeAttr1),
 				util.NullValue, // no notes
 				fmt.Sprintf("basicAuth = genesyscloud_integration_credential.%s.id", credentialResourceLabel1),
 				util.NullValue, // no properties

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action.go
@@ -136,7 +136,7 @@ func createIntegrationCustomAuthAction(ctx context.Context, d *schema.ResourceDa
 func readIntegrationCustomAuthAction(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	cap := getCustomAuthActionsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationCustomAuthAction(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationCustomAuthAction(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading integration action %s", d.Id())
 

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_test.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_test.go
@@ -46,12 +46,12 @@ func TestAccResourceIntegrationCustomAuthAction(t *testing.T) {
 	var (
 		// Integration Credentials
 		credentialResourceLabel1   = "test_integration_credential_1"
-		credentialResourceNameAttr = "Terraform Cred-" + uuid.NewString()
+		credentialResourceTypeAttr = "Terraform Cred-" + uuid.NewString()
 		credKey1                   = "loginUrl"
 		credVal1                   = "https://www.test-login.com"
 		credentialResourceConfig   = integrationCred.GenerateCredentialResource(
 			credentialResourceLabel1,
-			strconv.Quote(credentialResourceNameAttr),
+			strconv.Quote(credentialResourceTypeAttr),
 			strconv.Quote(customAuthCredentialType),
 			integrationCred.GenerateCredentialFields(
 				map[string]string{
@@ -62,14 +62,14 @@ func TestAccResourceIntegrationCustomAuthAction(t *testing.T) {
 
 		// Web Services Data Action Integration
 		integResourceLabel1       = "test_integration1"
-		integResourceNameAttr1    = "Terraform Integration-" + uuid.NewString()
+		integResourceTypeAttr1    = "Terraform Integration-" + uuid.NewString()
 		integTypeID               = "custom-rest-actions"
 		integrationResourceConfig = integration.GenerateIntegrationResource(
 			integResourceLabel1,
 			util.NullValue,
 			strconv.Quote(integTypeID),
 			integration.GenerateIntegrationConfig(
-				strconv.Quote(integResourceNameAttr1),
+				strconv.Quote(integResourceTypeAttr1),
 				util.NullValue, // no notes
 				fmt.Sprintf("basicAuth = genesyscloud_integration_credential.%s.id", credentialResourceLabel1),
 				util.NullValue, // no properties

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook.go
@@ -77,7 +77,7 @@ func readIntegrationFacebook(ctx context.Context, d *schema.ResourceData, meta i
 
 	log.Printf("Reading integration facebook ")
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationFacebook(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceIntegrationFacebook(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
 		facebookIntegrationRequest, resp, getErr := proxy.getIntegrationFacebookById(ctx, d.Id())

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map.go
@@ -57,7 +57,7 @@ func createJourneyActionMap(ctx context.Context, d *schema.ResourceData, meta in
 func readJourneyActionMap(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getJourneyActionMapProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyActionMap(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyActionMap(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading journey action map %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template.go
@@ -56,7 +56,7 @@ func createJourneyActionTemplate(ctx context.Context, data *schema.ResourceData,
 
 func readJourneyActionTemplate(ctx context.Context, data *schema.ResourceData, i interface{}) diag.Diagnostics {
 	journeyApi := journeyApiConfig(i)
-	cc := consistency_checker.NewConsistencyCheck(ctx, data, i, ResourceJourneyActionTemplate(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, data, i, ResourceJourneyActionTemplate(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Journey Action Template %s", data.Id())
 	return util.WithRetriesForRead(ctx, data, func() *retry.RetryError {

--- a/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor.go
+++ b/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor.go
@@ -72,7 +72,7 @@ func createJourneyOutcomePredictor(ctx context.Context, d *schema.ResourceData, 
 func readJourneyOutcomePredictor(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	op := getJourneyOutcomePredictorProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyOutcomePredictor(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyOutcomePredictor(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading predictor %s", d.Id())
 

--- a/genesyscloud/journey_views/resource_genesyscloud_journey_views.go
+++ b/genesyscloud/journey_views/resource_genesyscloud_journey_views.go
@@ -76,7 +76,7 @@ func updateJourneyView(ctx context.Context, d *schema.ResourceData, meta interfa
 func readJourneyView(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	viewId := d.Id()
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyViews(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyViews(), constants.ConsistencyChecks(), ResourceType)
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	gp := getJourneyViewProxy(sdkConfig)
 	log.Printf("Getting journeyView with viewId: %s", viewId)
@@ -94,11 +94,7 @@ func readJourneyView(ctx context.Context, d *schema.ResourceData, meta interface
 		resourcedata.SetNillableValue(d, "description", journeyView.Description)
 		resourcedata.SetNillableValue(d, "interval", journeyView.Interval)
 		resourcedata.SetNillableValue(d, "duration", journeyView.Duration)
-		resourcedata.SetNillableValue(d, "version", journeyView.Version)
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "elements", journeyView.Elements, flattenElements)
-		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "charts", journeyView.Charts, flattenCharts)
-
-		log.Printf("Retrieved journeyView with viewId: %s with version %d", viewId, journeyView.Version)
 
 		return cc.CheckState(d)
 	})
@@ -140,7 +136,6 @@ func makeJourneyViewFromSchema(d *schema.ResourceData) *platformclientv2.Journey
 	interval := d.Get("interval").(string)
 	duration := d.Get("duration").(string)
 	elements, _ := buildElements(d)
-	charts := buildCharts(d)
 
 	journeyView := &platformclientv2.Journeyview{
 		Name:        &name,
@@ -148,7 +143,6 @@ func makeJourneyViewFromSchema(d *schema.ResourceData) *platformclientv2.Journey
 		Interval:    &interval,
 		Duration:    &duration,
 		Elements:    elements,
-		Charts:      charts,
 	}
 	return journeyView
 }

--- a/genesyscloud/knowledge/resource_genesyscloud_knowledge_document_variation.go
+++ b/genesyscloud/knowledge/resource_genesyscloud_knowledge_document_variation.go
@@ -372,7 +372,7 @@ func readKnowledgeDocumentVariation(ctx context.Context, d *schema.ResourceData,
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	knowledgeAPI := platformclientv2.NewKnowledgeApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeDocumentVariation(), constants.DefaultConsistencyChecks, "genesyscloud_knowledge_document_variation")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeDocumentVariation(), constants.ConsistencyChecks(), "genesyscloud_knowledge_document_variation")
 
 	documentState := ""
 

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
@@ -104,7 +104,7 @@ func readKnowledgeDocument(ctx context.Context, d *schema.ResourceData, meta int
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := GetKnowledgeDocumentProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeDocument(), constants.DefaultConsistencyChecks, "genesyscloud_knowledge_document")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeDocument(), constants.ConsistencyChecks(), "genesyscloud_knowledge_document")
 
 	log.Printf("Reading knowledge document %s", knowledgeDocumentId)
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label.go
+++ b/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label.go
@@ -88,7 +88,7 @@ func readKnowledgeLabel(ctx context.Context, d *schema.ResourceData, meta interf
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := GetKnowledgeLabelProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeLabel(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeLabel(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading knowledge label %s", knowledgeLabelId)
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/location/resource_genesyscloud_location.go
+++ b/genesyscloud/location/resource_genesyscloud_location.go
@@ -69,7 +69,7 @@ func createLocation(ctx context.Context, d *schema.ResourceData, meta interface{
 func readLocation(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getLocationProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceLocation(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceLocation(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading location %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client.go
@@ -94,7 +94,7 @@ func createOAuthClient(ctx context.Context, d *schema.ResourceData, meta interfa
 func readOAuthClient(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	oAuthProxy := GetOAuthClientProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOAuthClient(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOAuthClient(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading oauth client %s", d.Id())
 

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
@@ -39,7 +39,7 @@ func getAllOrganizationAuthenticationSettings(ctx context.Context, clientConfig 
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s resource due to error: %s", ResourceType, err), resp)
 	}
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "authentication_settings"}
+	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: ResourceType}
 	return resources, nil
 }
 
@@ -54,7 +54,7 @@ func createOrganizationAuthenticationSettings(ctx context.Context, d *schema.Res
 func readOrganizationAuthenticationSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOrgAuthSettingsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOrganizationAuthenticationSettings(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOrganizationAuthenticationSettings(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading organization authentication settings %s", d.Id())
 

--- a/genesyscloud/orgauthorization_pairing/resource_genesyscloud_orgauthorization_pairing.go
+++ b/genesyscloud/orgauthorization_pairing/resource_genesyscloud_orgauthorization_pairing.go
@@ -44,7 +44,7 @@ func createOrgauthorizationPairing(ctx context.Context, d *schema.ResourceData, 
 func readOrgauthorizationPairing(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOrgauthorizationPairingProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOrgauthorizationPairing(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOrgauthorizationPairing(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Orgauthorization Pairing %s", d.Id())
 

--- a/genesyscloud/outbound/resource_genesyscloud_outbound_messagingcampaign.go
+++ b/genesyscloud/outbound/resource_genesyscloud_outbound_messagingcampaign.go
@@ -185,7 +185,7 @@ func updateOutboundMessagingcampaign(ctx context.Context, d *schema.ResourceData
 func readOutboundMessagingcampaign(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	outboundApi := platformclientv2.NewOutboundApiWithConfig(sdkConfig)
-	//cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundMessagingCampaign(), constants.DefaultConsistencyChecks, resourceType)
+	//cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundMessagingCampaign(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Messaging Campaign %s", d.Id())
 

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	ResourceType = "genesyscloud_outbound_attempt_limit"
+	ResourceType = "genesyscloud_outbound_attemptlimit"
 )
 
 var (
@@ -255,7 +255,7 @@ func updateOutboundAttemptLimit(ctx context.Context, d *schema.ResourceData, met
 func readOutboundAttemptLimit(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	outboundApi := platformclientv2.NewOutboundApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundAttemptLimit(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundAttemptLimit(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Attempt Limit %s", d.Id())
 
@@ -396,7 +396,7 @@ func GenerateAttemptLimitResource(
 		resetPeriod = fmt.Sprintf(`reset_period = "%s"`, resetPeriod)
 	}
 	return fmt.Sprintf(`
-resource "%s" "%s" {
+resource "genesyscloud_outbound_attempt_limit" "%s" {
 	name = "%s"
 	%s
 	%s
@@ -404,5 +404,5 @@ resource "%s" "%s" {
 	%s
 	%s
 }
-	`, ResourceType, resourceLabel, name, maxAttemptsPerContact, maxAttemptsPerNumber, timeZoneId, resetPeriod, strings.Join(nestedBlocks, "\n"))
+	`, resourceLabel, name, maxAttemptsPerContact, maxAttemptsPerNumber, timeZoneId, resetPeriod, strings.Join(nestedBlocks, "\n"))
 }

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset.go
@@ -83,7 +83,7 @@ func readOutboundCallabletimeset(ctx context.Context, d *schema.ResourceData, me
 
 	log.Printf("Reading Outbound Callabletimeset %s", d.Id())
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCallabletimeset(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCallabletimeset(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
 		callableTimeset, resp, getErr := proxy.getOutboundCallabletimesetById(ctx, d.Id())

--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset.go
@@ -59,7 +59,7 @@ func createOutboundCallanalysisresponseset(ctx context.Context, d *schema.Resour
 func readOutboundCallanalysisresponseset(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundCallanalysisresponsesetProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCallanalysisresponseset(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCallanalysisresponseset(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Call Analysis Response Set %s", d.Id())
 

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
@@ -97,7 +97,7 @@ func createOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta in
 func readOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	clientConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundCampaignProxy(clientConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCampaign(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCampaign(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Campaign %s", d.Id())
 

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule.go
@@ -86,7 +86,7 @@ func updateOutboundCampaignRule(ctx context.Context, d *schema.ResourceData, met
 func readOutboundCampaignRule(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundCampaignruleProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCampaignrule(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundCampaignrule(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Campaign Rule %s", d.Id())
 

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
@@ -133,7 +133,7 @@ func updateOutboundContactList(ctx context.Context, d *schema.ResourceData, meta
 func readOutboundContactList(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundContactlistProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactList(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactList(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Contact List %s", d.Id())
 

--- a/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
+++ b/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
@@ -87,7 +87,7 @@ func readOutboundContactListContact(ctx context.Context, d *schema.ResourceData,
 		contactId = d.Get("contact_id").(string)
 	}
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactListContact(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactListContact(), constants.ConsistencyChecks(), ResourceType)
 
 	retryErr := util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
 		var contactResponseBody *platformclientv2.Dialercontact

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template.go
@@ -131,7 +131,7 @@ func updateOutboundContactListTemplate(ctx context.Context, d *schema.ResourceDa
 func readOutboundContactListTemplate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundContactlisttemplateProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactListTemplate(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactListTemplate(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Contact List Template %s", d.Id())
 

--- a/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter.go
+++ b/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter.go
@@ -62,7 +62,7 @@ func createOutboundContactlistfilter(ctx context.Context, d *schema.ResourceData
 func readOutboundContactlistfilter(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundContactlistfilterProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactlistfilter(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundContactlistfilter(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Contact List Filter %s", d.Id())
 

--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset.go
@@ -76,7 +76,7 @@ func readOutboundDigitalruleset(ctx context.Context, d *schema.ResourceData, met
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read outbound digitalruleset %s: %s", d.Id(), getErr), resp))
 		}
 
-		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundDigitalruleset(), constants.DefaultConsistencyChecks, ResourceType)
+		cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundDigitalruleset(), constants.ConsistencyChecks(), ResourceType)
 
 		resourcedata.SetNillableValue(d, "name", digitalRuleSet.Name)
 		resourcedata.SetNillableReference(d, "contact_list_id", digitalRuleSet.ContactList)

--- a/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate.go
+++ b/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate.go
@@ -72,7 +72,7 @@ func updateOutboundFileSpecificationTemplate(ctx context.Context, d *schema.Reso
 func readOutboundFileSpecificationTemplate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundFilespecificationtemplateProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundFileSpecificationTemplate(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundFileSpecificationTemplate(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound File Specification Template %s", d.Id())
 

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset.go
@@ -97,7 +97,7 @@ func createOutboundRuleset(ctx context.Context, d *schema.ResourceData, meta int
 func readOutboundRuleset(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := newOutboundRulesetProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundRuleset(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundRuleset(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Ruleset %s", d.Id())
 

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence.go
@@ -73,7 +73,7 @@ func createOutboundSequence(ctx context.Context, d *schema.ResourceData, meta in
 func readOutboundSequence(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundSequenceProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundSequence(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundSequence(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading outbound sequence %s", d.Id())
 

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
@@ -52,7 +52,7 @@ func createOutboundSettings(ctx context.Context, d *schema.ResourceData, meta in
 func readOutboundSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundSettingsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundSettings(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundSettings(), constants.ConsistencyChecks(), ResourceType)
 
 	maxCallsPerAgent := d.Get("max_calls_per_agent").(int)
 	maxLineUtilization := d.Get("max_line_utilization").(float64)

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
@@ -59,7 +59,7 @@ func createOutboundWrapUpCodeMappings(ctx context.Context, d *schema.ResourceDat
 func readOutboundWrapUpCodeMappings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getOutboundWrapupCodeMappingsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundWrapUpCodeMappings(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceOutboundWrapUpCodeMappings(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Outbound Wrap-up Code Mappings")
 

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -208,7 +208,7 @@ func createProcessAutomationTrigger(ctx context.Context, d *schema.ResourceData,
 func readProcessAutomationTrigger(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	integAPI := platformclientv2.NewIntegrationsApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceProcessAutomationTrigger(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceProcessAutomationTrigger(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading process automation trigger %s", d.Id())
 

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy.go
@@ -110,7 +110,7 @@ func createMediaRetentionPolicy(ctx context.Context, d *schema.ResourceData, met
 func readMediaRetentionPolicy(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	pp := getPolicyProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, gcloud.ResourceSurveyForm(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, gcloud.ResourceSurveyForm(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading media retention policy %s", d.Id())
 

--- a/genesyscloud/resource_genesyscloud_journey_outcome.go
+++ b/genesyscloud/resource_genesyscloud_journey_outcome.go
@@ -160,7 +160,7 @@ func createJourneyOutcome(ctx context.Context, d *schema.ResourceData, meta inte
 func readJourneyOutcome(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	journeyApi := platformclientv2.NewJourneyApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyOutcome(), constants.DefaultConsistencyChecks, "genesyscloud_journey_outcome")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneyOutcome(), constants.ConsistencyChecks(), "genesyscloud_journey_outcome")
 
 	log.Printf("Reading journey outcome %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/resource_genesyscloud_journey_segment.go
+++ b/genesyscloud/resource_genesyscloud_journey_segment.go
@@ -287,7 +287,7 @@ func createJourneySegment(ctx context.Context, d *schema.ResourceData, meta inte
 func readJourneySegment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	journeyApi := platformclientv2.NewJourneyApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneySegment(), constants.DefaultConsistencyChecks, "genesyscloud_journey_segment")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceJourneySegment(), constants.ConsistencyChecks(), "genesyscloud_journey_segment")
 
 	log.Printf("Reading journey segment %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/resource_genesyscloud_knowledge_category.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_category.go
@@ -184,7 +184,7 @@ func readKnowledgeCategory(ctx context.Context, d *schema.ResourceData, meta int
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	knowledgeAPI := platformclientv2.NewKnowledgeApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeCategory(), constants.DefaultConsistencyChecks, "genesyscloud_knowledge_category")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeCategory(), constants.ConsistencyChecks(), "genesyscloud_knowledge_category")
 
 	log.Printf("Reading knowledge category %s", knowledgeCategoryId)
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
@@ -156,7 +156,7 @@ func createKnowledgeKnowledgebase(ctx context.Context, d *schema.ResourceData, m
 func readKnowledgeKnowledgebase(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	knowledgeAPI := platformclientv2.NewKnowledgeApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeKnowledgebase(), constants.DefaultConsistencyChecks, "genesyscloud_knowledge_knowledgebase")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceKnowledgeKnowledgebase(), constants.ConsistencyChecks(), "genesyscloud_knowledge_knowledgebase")
 
 	log.Printf("Reading knowledge base %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
@@ -288,7 +288,7 @@ func createEvaluationForm(ctx context.Context, d *schema.ResourceData, meta inte
 func readEvaluationForm(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	qualityAPI := platformclientv2.NewQualityApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceEvaluationForm(), constants.DefaultConsistencyChecks, "genesyscloud_quality_forms_evaluation")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceEvaluationForm(), constants.ConsistencyChecks(), "genesyscloud_quality_forms_evaluation")
 
 	log.Printf("Reading evaluation form %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/resource_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_survey.go
@@ -347,7 +347,7 @@ func createSurveyForm(ctx context.Context, d *schema.ResourceData, meta interfac
 func readSurveyForm(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	qualityAPI := platformclientv2.NewQualityApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSurveyForm(), constants.DefaultConsistencyChecks, "genesyscloud_quality_forms_survey")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSurveyForm(), constants.ConsistencyChecks(), "genesyscloud_quality_forms_survey")
 
 	log.Printf("Reading survey form %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/resource_genesyscloud_widget_deployment.go
+++ b/genesyscloud/resource_genesyscloud_widget_deployment.go
@@ -150,7 +150,7 @@ func ResourceWidgetDeployment() *schema.Resource {
 func readWidgetDeployment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	widgetsAPI := platformclientv2.NewWidgetsApiWithConfig(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWidgetDeployment(), constants.DefaultConsistencyChecks, "genesyscloud_widget_deployment")
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWidgetDeployment(), constants.ConsistencyChecks(), "genesyscloud_widget_deployment")
 
 	log.Printf("Reading widget deployment %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library.go
+++ b/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library.go
@@ -64,7 +64,7 @@ func createResponsemanagementLibrary(ctx context.Context, d *schema.ResourceData
 func readResponsemanagementLibrary(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getResponsemanagementLibraryProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceResponsemanagementLibrary(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceResponsemanagementLibrary(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading responsemanagement library %s", d.Id())
 

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
@@ -69,7 +69,7 @@ func createResponsemanagementResponse(ctx context.Context, d *schema.ResourceDat
 func readResponsemanagementResponse(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getResponsemanagementResponseProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceResponsemanagementResponse(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceResponsemanagementResponse(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Responsemanagement Response %s", d.Id())
 

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
@@ -83,7 +83,7 @@ func createRespManagementRespAsset(ctx context.Context, d *schema.ResourceData, 
 func readRespManagementRespAsset(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRespManagementRespAssetProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceResponseManagementResponseAsset(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceResponseManagementResponseAsset(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Responsemanagement response asset %s", d.Id())
 

--- a/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain.go
+++ b/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain.go
@@ -76,7 +76,7 @@ func readRoutingEmailDomain(ctx context.Context, d *schema.ResourceData, meta in
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingEmailDomainProxy(sdkConfig)
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingEmailDomain(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingEmailDomain(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading routing email domain %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
@@ -93,7 +93,7 @@ func createRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta i
 func readRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingEmailRouteProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingEmailRoute(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingEmailRoute(), constants.ConsistencyChecks(), ResourceType)
 	domainId := d.Get("domain_id").(string)
 
 	log.Printf("Reading routing email route %s", d.Id())

--- a/genesyscloud/routing_language/resource_genesyscloud_routing_language.go
+++ b/genesyscloud/routing_language/resource_genesyscloud_routing_language.go
@@ -64,7 +64,7 @@ func createRoutingLanguage(ctx context.Context, d *schema.ResourceData, meta int
 func readRoutingLanguage(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingLanguageProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingLanguage(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingLanguage(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading routing language %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -149,7 +149,7 @@ func createRoutingQueue(ctx context.Context, d *schema.ResourceData, meta interf
 func readRoutingQueue(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := GetRoutingQueueProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingQueue(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingQueue(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading queue %s", d.Id())
 

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
@@ -67,7 +67,7 @@ func readRoutingQueueConditionalRoutingGroup(ctx context.Context, d *schema.Reso
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingQueueConditionalGroupRoutingProxy(sdkConfig)
-	cc := consistencyChecker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingQueueConditionalGroupRouting(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistencyChecker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingQueueConditionalGroupRouting(), constants.ConsistencyChecks(), ResourceType)
 	queueId := strings.Split(d.Id(), "/")[0]
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
@@ -65,7 +65,7 @@ func readRoutingQueueOutboundEmailAddress(ctx context.Context, d *schema.Resourc
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingQueueOutboundEmailAddressProxy(sdkConfig)
-	cc := consistencyChecker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingQueueOutboundEmailAddress(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistencyChecker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingQueueOutboundEmailAddress(), constants.ConsistencyChecks(), ResourceType)
 
 	queueId := d.Id()
 

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
@@ -69,7 +69,7 @@ func createRoutingSettings(ctx context.Context, d *schema.ResourceData, meta int
 func readRoutingSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingSettingsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSettings(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSettings(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading routing settings")
 

--- a/genesyscloud/routing_skill/resource_genesyscloud_routing_skill.go
+++ b/genesyscloud/routing_skill/resource_genesyscloud_routing_skill.go
@@ -59,7 +59,7 @@ func createRoutingSkill(ctx context.Context, d *schema.ResourceData, meta interf
 func readRoutingSkill(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingSkillProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSkill(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSkill(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading skill %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group.go
+++ b/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group.go
@@ -79,7 +79,7 @@ func createSkillGroups(ctx context.Context, d *schema.ResourceData, meta interfa
 func readSkillGroups(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingSkillGroupsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSkillGroup(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSkillGroup(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading skills group %s", d.Id())
 

--- a/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
+++ b/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
@@ -94,7 +94,7 @@ func createRoutingSmsAddress(ctx context.Context, d *schema.ResourceData, meta i
 func readRoutingSmsAddress(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingSmsAddressProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSmsAddress(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingSmsAddress(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Routing Sms Address %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
@@ -48,7 +48,7 @@ func createRoutingUtilization(ctx context.Context, d *schema.ResourceData, meta 
 func readRoutingUtilization(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingUtilizationProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingUtilization(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingUtilization(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Routing Utilization")
 

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label.go
@@ -58,7 +58,7 @@ func createRoutingUtilizationLabel(ctx context.Context, d *schema.ResourceData, 
 func readRoutingUtilizationLabel(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingUtilizationLabelProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingUtilizationLabel(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingUtilizationLabel(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading label %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode.go
+++ b/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode.go
@@ -59,7 +59,7 @@ func readRoutingWrapupCode(ctx context.Context, d *schema.ResourceData, meta int
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getRoutingWrapupcodeProxy(sdkConfig)
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingWrapupCode(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceRoutingWrapupCode(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading wrapupcode %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/scripts/resource_genesyscloud_script.go
+++ b/genesyscloud/scripts/resource_genesyscloud_script.go
@@ -83,7 +83,7 @@ func updateScript(ctx context.Context, d *schema.ResourceData, meta interface{})
 func readScript(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	scriptsProxy := getScriptsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceScript(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceScript(), constants.ConsistencyChecks(), ResourceType)
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
 		script, resp, err := scriptsProxy.getScriptById(ctx, d.Id())

--- a/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin.go
+++ b/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin.go
@@ -68,7 +68,7 @@ func createTaskManagementWorkbin(ctx context.Context, d *schema.ResourceData, me
 func readTaskManagementWorkbin(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTaskManagementWorkbinProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorkbin(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorkbin(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading task management workbin %s", d.Id())
 

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem.go
@@ -67,7 +67,7 @@ func createTaskManagementWorkitem(ctx context.Context, d *schema.ResourceData, m
 func readTaskManagementWorkitem(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTaskManagementWorkitemProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorkitem(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorkitem(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading task management workitem %s", d.Id())
 

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema.go
@@ -80,7 +80,7 @@ func createTaskManagementWorkitemSchema(ctx context.Context, d *schema.ResourceD
 func readTaskManagementWorkitemSchema(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTaskManagementProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorkitemSchema(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorkitemSchema(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading task management workitem schema %s", d.Id())
 

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
@@ -65,7 +65,7 @@ func createTaskManagementWorktype(ctx context.Context, d *schema.ResourceData, m
 func readTaskManagementWorktype(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := GetTaskManagementWorktypeProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorktype(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorktype(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading task management worktype %s", d.Id())
 

--- a/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status.go
+++ b/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status.go
@@ -134,7 +134,7 @@ func createTaskManagementWorktypeStatus(ctx context.Context, d *schema.ResourceD
 func readTaskManagementWorktypeStatus(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTaskManagementWorktypeStatusProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorktypeStatus(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTaskManagementWorktypeStatus(), constants.ConsistencyChecks(), ResourceType)
 	worktypeId, statusId := SplitWorktypeStatusTerraformId(d.Id())
 
 	log.Printf("Reading task management worktype %s status %s", worktypeId, statusId)

--- a/genesyscloud/team/resource_genesyscloud_team.go
+++ b/genesyscloud/team/resource_genesyscloud_team.go
@@ -65,7 +65,7 @@ func createTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func readTeam(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTeamProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTeam(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTeam(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading team %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -172,7 +172,7 @@ func readTrunkBaseSettings(ctx context.Context, d *schema.ResourceData, meta int
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTrunkBaseSettingProxy(sdkConfig)
 
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTrunkBaseSettings(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTrunkBaseSettings(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading trunk base settings %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -73,7 +73,7 @@ func createDidPool(ctx context.Context, d *schema.ResourceData, meta interface{}
 func readDidPool(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getTelephonyDidPoolProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTelephonyDidPool(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTelephonyDidPool(), constants.ConsistencyChecks(), ResourceType)
 	utilE164 := util.NewUtilE164Service()
 
 	log.Printf("Reading DID pool %s", d.Id())

--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
@@ -140,7 +140,7 @@ func deleteEdgeGroup(ctx context.Context, d *schema.ResourceData, meta interface
 func readEdgeGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	edgeGroupProxy := getEdgeGroupProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceEdgeGroup(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceEdgeGroup(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading edge group %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool.go
@@ -60,7 +60,7 @@ func createExtensionPool(ctx context.Context, d *schema.ResourceData, meta inter
 func readExtensionPool(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	extensionPoolProxy := getExtensionPoolProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTelephonyExtensionPool(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTelephonyExtensionPool(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading Extension pool %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -77,7 +77,7 @@ func createPhone(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 func readPhone(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	pp := getPhoneProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourcePhone(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourcePhone(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading phone %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
@@ -133,7 +133,7 @@ func updatePhoneBaseSettings(ctx context.Context, d *schema.ResourceData, meta i
 func readPhoneBaseSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	phoneBaseProxy := getPhoneBaseProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourcePhoneBaseSettings(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourcePhoneBaseSettings(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading phone base settings %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -148,7 +148,7 @@ func createSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func readSite(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	sp := GetSiteProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSite(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSite(), constants.ConsistencyChecks(), ResourceType)
 	utilE164 := util.NewUtilE164Service()
 
 	log.Printf("Reading site %s", d.Id())

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
@@ -90,7 +90,7 @@ func readSiteOutboundRoute(ctx context.Context, d *schema.ResourceData, meta int
 	}
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getSiteOutboundRouteProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSiteOutboundRoute(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceSiteOutboundRoute(), constants.ConsistencyChecks(), ResourceType)
 
 	siteId, outboundRouteId := splitSiteAndOutboundRoute(d.Id())
 

--- a/genesyscloud/telephony_providers_edges_trunk/resource_genesyscloud_telephony_providers_edges_trunk.go
+++ b/genesyscloud/telephony_providers_edges_trunk/resource_genesyscloud_telephony_providers_edges_trunk.go
@@ -126,7 +126,7 @@ func updateTrunk(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 func readTrunk(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	tp := getTrunkProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTrunk(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTrunk(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading trunk %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/user/resource_genesyscloud_user.go
+++ b/genesyscloud/user/resource_genesyscloud_user.go
@@ -135,7 +135,7 @@ func createUser(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 func readUser(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getUserProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceUser(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceUser(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading user %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {

--- a/genesyscloud/user_roles/resource_genesyscloud_user_roles.go
+++ b/genesyscloud/user_roles/resource_genesyscloud_user_roles.go
@@ -31,7 +31,7 @@ func createUserRoles(ctx context.Context, d *schema.ResourceData, meta interface
 func readUserRoles(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := getUserRolesProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceUserRoles(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceUserRoles(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading roles for user %s", d.Id())
 	d.Set("user_id", d.Id())

--- a/genesyscloud/util/constants/constants.go
+++ b/genesyscloud/util/constants/constants.go
@@ -1,10 +1,28 @@
 package constants
 
+import (
+	"os"
+	"strconv"
+)
+
 const (
 	DefaultOutboundScriptName = "Default Outbound Script"
 	DefaultInboundScriptName  = "Default Inbound Script"
 	DefaultCallbackScriptName = "Default Callback Script"
 )
 
-// DefaultConsistencyChecks The default number of times we will try to check a resources state before stopping
-const DefaultConsistencyChecks = 5
+// ConsistencyChecks will return the number of times the consistency checker should retry.
+// The use can specify this by setting the env variable CONSISTENCY_CHECKS
+func ConsistencyChecks() int {
+	defaultChecks := 5
+
+	if checks, exists := os.LookupEnv("CONSISTENCY_CHECKS"); exists {
+		if value, err := strconv.Atoi(checks); err == nil {
+			return value
+		}
+
+		return defaultChecks
+	}
+
+	return defaultChecks
+}

--- a/genesyscloud/util/constants/constants.go
+++ b/genesyscloud/util/constants/constants.go
@@ -1,6 +1,7 @@
 package constants
 
 import (
+	"log"
 	"os"
 	"strconv"
 )
@@ -12,7 +13,8 @@ const (
 )
 
 // ConsistencyChecks will return the number of times the consistency checker should retry.
-// The use can specify this by setting the env variable CONSISTENCY_CHECKS
+// The user can specify this by setting the env variable CONSISTENCY_CHECKS
+// This env variable will only be used when BYPASS_CONSISTENCY_CHECKER is set
 func ConsistencyChecks() int {
 	defaultChecks := 5
 
@@ -21,6 +23,7 @@ func ConsistencyChecks() int {
 			return value
 		}
 
+		log.Printf("CONSISTENCY_CHECKS set to invalid value, using default value %d", defaultChecks)
 		return defaultChecks
 	}
 

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
@@ -115,7 +115,7 @@ func createWebDeploymentConfiguration(ctx context.Context, d *schema.ResourceDat
 func readWebDeploymentConfiguration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	wp := getWebDeploymentConfigurationsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWebDeploymentConfiguration(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWebDeploymentConfiguration(), constants.ConsistencyChecks(), ResourceType)
 
 	version := d.Get("version").(string)
 	log.Printf("Reading web deployment configuration %s", d.Id())

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
@@ -139,7 +139,7 @@ func waitForDeploymentToBeActive(ctx context.Context, sdkConfig *platformclientv
 func readWebDeployment(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	wd := getWebDeploymentsProxy(sdkConfig)
-	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWebDeployment(), constants.DefaultConsistencyChecks, ResourceType)
+	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceWebDeployment(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading web deployment %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {


### PR DESCRIPTION
This PR adds another env variable that can be used to customise the consistency checker. `Consistency checks` can be used to allow the user to set how many times they want the consistency checker to retry. Setting it to 0 will disable the consistency checker and stop it from running. This env variable is only used if `BYPASS_CONSISTENCY_CHECKER` is set. 

I also added all this to the README.