### PR TITLE
No jira: fix attempt limit test

### DIFF
--- a/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit.go
@@ -51,9 +51,9 @@ func dataSourceOutboundAttemptLimitRead(ctx context.Context, d *schema.ResourceD
 
 func GenerateOutboundAttemptLimitDataSource(dataSourceLabel string, attemptLimitName string, dependsOn string) string {
 	return fmt.Sprintf(`
-data "genesyscloud_outbound_attempt_limit" "%s" {
+data "%s" "%s" {
 	name = "%s"
 	depends_on = [%s]
 }
-`, dataSourceLabel, attemptLimitName, dependsOn)
+`, ResourceType, dataSourceLabel, attemptLimitName, dependsOn)
 }

--- a/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit_test.go
+++ b/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit_test.go
@@ -13,8 +13,10 @@ func TestAccDataSourceOutboundAttemptLimit(t *testing.T) {
 
 	var (
 		resourceLabel    = "attempt_limit"
+		resourcePath     = ResourceType + "." + resourceLabel
 		attemptLimitName = "Test Limit " + uuid.NewString()
 		dataSourceLabel  = "attempt_limit_data"
+		dataResourcePath = "data." + ResourceType + "." + dataSourceLabel
 	)
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
@@ -32,11 +34,11 @@ func TestAccDataSourceOutboundAttemptLimit(t *testing.T) {
 				) + GenerateOutboundAttemptLimitDataSource(
 					dataSourceLabel,
 					attemptLimitName,
-					"genesyscloud_outbound_attempt_limit."+resourceLabel,
+					resourcePath,
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.genesyscloud_outbound_attempt_limit."+dataSourceLabel, "id",
-						"genesyscloud_outbound_attempt_limit."+resourceLabel, "id"),
+					resource.TestCheckResourceAttrPair(dataResourcePath, "id",
+						resourcePath, "id"),
 				),
 			},
 		},

--- a/genesyscloud/outbound_attempt_limit/outbound_attempt_limit_resource_init.go
+++ b/genesyscloud/outbound_attempt_limit/outbound_attempt_limit_resource_init.go
@@ -5,7 +5,7 @@ import (
 )
 
 func SetRegistrar(regInstance registrar.Registrar) {
-	regInstance.RegisterDataSource("genesyscloud_outbound_attempt_limit", DataSourceOutboundAttemptLimit())
-	regInstance.RegisterResource("genesyscloud_outbound_attempt_limit", ResourceOutboundAttemptLimit())
-	regInstance.RegisterExporter("genesyscloud_outbound_attempt_limit", OutboundAttemptLimitExporter())
+	regInstance.RegisterDataSource(ResourceType, DataSourceOutboundAttemptLimit())
+	regInstance.RegisterResource(ResourceType, ResourceOutboundAttemptLimit())
+	regInstance.RegisterExporter(ResourceType, OutboundAttemptLimitExporter())
 }

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
@@ -182,7 +182,7 @@ func createOutboundAttemptLimit(ctx context.Context, d *schema.ResourceData, met
 	if resetPeriod != "" {
 		sdkAttemptLimits.ResetPeriod = &resetPeriod
 	}
-	if recallEntries != nil && len(recallEntries) > 0 {
+	if len(recallEntries) > 0 {
 		sdkAttemptLimits.RecallEntries = buildSdkOutboundAttemptLimitRecallEntryMap(recallEntries)
 	}
 
@@ -226,7 +226,7 @@ func updateOutboundAttemptLimit(ctx context.Context, d *schema.ResourceData, met
 	if resetPeriod != "" {
 		sdkAttemptLimits.ResetPeriod = &resetPeriod
 	}
-	if recallEntries != nil && len(recallEntries) > 0 {
+	if len(recallEntries) > 0 {
 		sdkAttemptLimits.RecallEntries = buildSdkOutboundAttemptLimitRecallEntryMap(recallEntries)
 	}
 
@@ -238,7 +238,7 @@ func updateOutboundAttemptLimit(ctx context.Context, d *schema.ResourceData, met
 			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to read outbound attempt limit %s error: %s", d.Id(), getErr), resp)
 		}
 		sdkAttemptLimits.Version = outboundAttemptLimit.Version
-		outboundAttemptLimit, resp, updateErr := outboundApi.PutOutboundAttemptlimit(d.Id(), sdkAttemptLimits)
+		_, resp, updateErr := outboundApi.PutOutboundAttemptlimit(d.Id(), sdkAttemptLimits)
 		if updateErr != nil {
 			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update outbound attempt limit %s error: %s", *sdkAttemptLimits.Name, updateErr), resp)
 		}

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
@@ -23,7 +23,7 @@ import (
 )
 
 const (
-	ResourceType = "genesyscloud_outbound_attemptlimit"
+	ResourceType = "genesyscloud_outbound_attempt_limit"
 )
 
 var (

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
@@ -24,6 +24,7 @@ func TestAccResourceOutboundAttemptLimit(t *testing.T) {
 	t.Parallel()
 	var (
 		resourceLabel = "attempt_limit"
+		resourcePath  = ResourceType + "." + resourceLabel
 		// Create
 		name                  = "Test Limit " + uuid.NewString()
 		maxAttemptsPerContact = "5"
@@ -68,13 +69,13 @@ func TestAccResourceOutboundAttemptLimit(t *testing.T) {
 					),
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "name", name),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "max_attempts_per_contact", maxAttemptsPerContact),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "max_attempts_per_number", maxAttemptsPerNumber),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "time_zone_id", timeZoneId),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "reset_period", resetPeriod),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "recall_entries.0.busy.0.minutes_between_attempts", recallEntryMinsBetweenAttempts1),
-					resource.TestCheckResourceAttrSet("genesyscloud_outbound_attempt_limit."+resourceLabel, "recall_entries.0.busy.0.nbr_attempts"),
+					resource.TestCheckResourceAttr(resourcePath, "name", name),
+					resource.TestCheckResourceAttr(resourcePath, "max_attempts_per_contact", maxAttemptsPerContact),
+					resource.TestCheckResourceAttr(resourcePath, "max_attempts_per_number", maxAttemptsPerNumber),
+					resource.TestCheckResourceAttr(resourcePath, "time_zone_id", timeZoneId),
+					resource.TestCheckResourceAttr(resourcePath, "reset_period", resetPeriod),
+					resource.TestCheckResourceAttr(resourcePath, "recall_entries.0.busy.0.minutes_between_attempts", recallEntryMinsBetweenAttempts1),
+					resource.TestCheckResourceAttrSet(resourcePath, "recall_entries.0.busy.0.nbr_attempts"),
 				),
 			},
 			{
@@ -92,21 +93,21 @@ func TestAccResourceOutboundAttemptLimit(t *testing.T) {
 					),
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "name", nameUpdated),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "max_attempts_per_contact", maxAttemptsPerContactUpdated),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "max_attempts_per_number", maxAttemptsPerNumberUpdated),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "time_zone_id", timeZoneIdUpdated),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "reset_period", resetPeriodUpdated),
-					resource.TestCheckNoResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "recall_entries.0."+recallEntryType1+".%"),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "recall_entries.0."+updatedRecallEntryType1+".0.nbr_attempts", updatedRecallEntryNbrAttempts1),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "recall_entries.0."+updatedRecallEntryType1+".0.minutes_between_attempts", updatedRecallEntryMinsBetweenAttempts1),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "recall_entries.0."+updatedRecallEntryType2+".0.nbr_attempts", updatedRecallEntryNbrAttempts2),
-					resource.TestCheckResourceAttr("genesyscloud_outbound_attempt_limit."+resourceLabel, "recall_entries.0."+updatedRecallEntryType2+".0.minutes_between_attempts", updatedRecallEntryMinsBetweenAttempts2),
+					resource.TestCheckResourceAttr(resourcePath, "name", nameUpdated),
+					resource.TestCheckResourceAttr(resourcePath, "max_attempts_per_contact", maxAttemptsPerContactUpdated),
+					resource.TestCheckResourceAttr(resourcePath, "max_attempts_per_number", maxAttemptsPerNumberUpdated),
+					resource.TestCheckResourceAttr(resourcePath, "time_zone_id", timeZoneIdUpdated),
+					resource.TestCheckResourceAttr(resourcePath, "reset_period", resetPeriodUpdated),
+					resource.TestCheckNoResourceAttr(resourcePath, "recall_entries.0."+recallEntryType1+".%"),
+					resource.TestCheckResourceAttr(resourcePath, "recall_entries.0."+updatedRecallEntryType1+".0.nbr_attempts", updatedRecallEntryNbrAttempts1),
+					resource.TestCheckResourceAttr(resourcePath, "recall_entries.0."+updatedRecallEntryType1+".0.minutes_between_attempts", updatedRecallEntryMinsBetweenAttempts1),
+					resource.TestCheckResourceAttr(resourcePath, "recall_entries.0."+updatedRecallEntryType2+".0.nbr_attempts", updatedRecallEntryNbrAttempts2),
+					resource.TestCheckResourceAttr(resourcePath, "recall_entries.0."+updatedRecallEntryType2+".0.minutes_between_attempts", updatedRecallEntryMinsBetweenAttempts2),
 				),
 			},
 			{
 				// Import/Read
-				ResourceName:      "genesyscloud_outbound_attempt_limit." + resourceLabel,
+				ResourceName:      resourcePath,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -138,7 +139,7 @@ func generateRecallEntry(recallType string, minsBetweenAttempts string, nbrAttem
 func testVerifyAttemptLimitDestroyed(state *terraform.State) error {
 	outboundAPI := platformclientv2.NewOutboundApi()
 	for _, rs := range state.RootModule().Resources {
-		if rs.Type != "genesyscloud_outbound_attempt_limit" {
+		if rs.Type != ResourceType {
 			continue
 		}
 


### PR DESCRIPTION
```
    data_source_genesyscloud_outbound_attempt_limit_test.go:19: Step 1/1 error: Error running pre-apply refresh: exit status 1
        
        Error: Invalid resource type
        
          on terraform_plugin_test.tf line 2, in resource "genesyscloud_outbound_attempt_limit" "attempt_limit":
           2: resource "genesyscloud_outbound_attempt_limit" "attempt_limit" {
        
        The provider hashicorp/genesyscloud does not support resource type
        "genesyscloud_outbound_attempt_limit". Did you mean
        "genesyscloud_outbound_attemptlimit"?
--- FAIL: TestAccDataSourceOutboundAttemptLimit (0.20s)
```