### PR TITLE
Fix DEVTOOLING-936 - Allow updates to default outbound routes

### DIFF
--- a/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route.go
@@ -25,7 +25,7 @@ func dataSourceSiteOutboundRouteRead(ctx context.Context, d *schema.ResourceData
 	siteId := d.Get("site_id").(string)
 
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {
-		siteId, routeId, retryable, resp, err := proxy.getSiteOutboundRouteByName(ctx, name, siteId)
+		siteId, routeId, retryable, resp, err := proxy.getSiteOutboundRouteByName(ctx, siteId, name)
 		if err != nil {
 			if retryable {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("failed to get outbound route %s", name), resp))

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
@@ -128,7 +128,7 @@ func TestAccDataSourceSiteOutboundRoute(t *testing.T) {
 					util.FalseValue) + generateSiteOutboundRouteDataSource(
 					outboundRouteResourceLabel1,
 					"outboundRoute name 1",
-					"",
+					strconv.Quote(""),
 					"",
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -166,7 +166,7 @@ func TestAccDataSourceSiteManaged(t *testing.T) {
 				Config: generateSiteOutboundRouteDataSource(
 					dataResourceLabel,
 					name,
-					siteId,
+					strconv.Quote(siteId),
 					"",
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -188,7 +188,7 @@ func generateSiteOutboundRouteDataSource(
 ) string {
 	return fmt.Sprintf(`data "genesyscloud_telephony_providers_edges_site_outbound_route" "%s" {
 		name = "%s"
-		site_id = "%s"
+		site_id = %s
 		depends_on=[%s]
 	}
 	`, dataSourceLabel, name, siteId, dependsOnResource)

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_proxy.go
@@ -23,7 +23,7 @@ type getAllSiteOutboundRoutesFunc func(ctx context.Context, p *siteOutboundRoute
 type getSiteByIdFunc func(ctx context.Context, p *siteOutboundRouteProxy, siteId string) (*platformclientv2.Site, *platformclientv2.APIResponse, error)
 type createSiteOutboundRouteFunc func(ctx context.Context, p *siteOutboundRouteProxy, siteId string, outboundRoute *platformclientv2.Outboundroutebase) (*platformclientv2.Outboundroutebase, *platformclientv2.APIResponse, error)
 type getSiteOutboundRouteByIdFunc func(ctx context.Context, p *siteOutboundRouteProxy, siteId string, outboundRoute string) (*platformclientv2.Outboundroutebase, *platformclientv2.APIResponse, error)
-type getSiteOutboundRouteByNameFunc func(ctx context.Context, p *siteOutboundRouteProxy, outboundRouteName string, siteId string) (string, string, bool, *platformclientv2.APIResponse, error)
+type getSiteOutboundRouteByNameFunc func(ctx context.Context, p *siteOutboundRouteProxy, siteIdOrEmpty string, outboundRouteName string) (siteId string, outboundRouteId string, retryable bool, response *platformclientv2.APIResponse, err error)
 type updateSiteOutboundRouteFunc func(ctx context.Context, p *siteOutboundRouteProxy, siteId string, outboundRouteId string, outboundRoute *platformclientv2.Outboundroutebase) (*platformclientv2.Outboundroutebase, *platformclientv2.APIResponse, error)
 type deleteSiteOutboundRouteFunc func(ctx context.Context, p *siteOutboundRouteProxy, siteId string, outboundRouteId string) (*platformclientv2.APIResponse, error)
 
@@ -93,8 +93,8 @@ func (p *siteOutboundRouteProxy) getSiteOutboundRouteById(ctx context.Context, s
 }
 
 // getSiteByNameFunc returns the outbound route id
-func (p *siteOutboundRouteProxy) getSiteOutboundRouteByName(ctx context.Context, outboundRouteName string, siteId string) (string, string, bool, *platformclientv2.APIResponse, error) {
-	return p.getSiteOutboundRouteByNameAttr(ctx, p, outboundRouteName, siteId)
+func (p *siteOutboundRouteProxy) getSiteOutboundRouteByName(ctx context.Context, siteIdOrEmpty string, outboundRouteName string) (siteId string, outboundRouteId string, retryable bool, response *platformclientv2.APIResponse, err error) {
+	return p.getSiteOutboundRouteByNameAttr(ctx, p, siteIdOrEmpty, outboundRouteName)
 }
 
 // updateSiteFunc updates a Genesys Cloud Outbound Route for a Genesys Cloud Site
@@ -174,7 +174,7 @@ func getSiteOutboundRouteByIdFn(ctx context.Context, p *siteOutboundRouteProxy, 
 	return outboundRoute, resp, nil
 }
 
-func getSiteOutboundRouteByNameFn(ctx context.Context, p *siteOutboundRouteProxy, outboundRouteName string, siteIdOrEmpty string) (siteId string, outboundRouteId string, retryable bool, resp *platformclientv2.APIResponse, err error) {
+func getSiteOutboundRouteByNameFn(ctx context.Context, p *siteOutboundRouteProxy, siteIdOrEmpty string, outboundRouteName string) (siteId string, outboundRouteId string, retryable bool, resp *platformclientv2.APIResponse, err error) {
 	var allSites []platformclientv2.Site
 	unmanagedSites, resp, err := p.siteProxy.GetAllSites(ctx, false)
 	if err != nil {

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
@@ -12,6 +12,7 @@ import (
 	telephonyProvidersEdgesSite "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
+	"terraform-provider-genesyscloud/genesyscloud/util/testrunner"
 	"testing"
 
 	"github.com/google/uuid"
@@ -189,6 +190,176 @@ func TestAccResourceSiteoutboundRoutes(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "enabled", util.TrueValue),
 					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "external_trunk_base_ids.0", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1", "id"),
 					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "external_trunk_base_ids.1", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings3", "id"),
+				),
+			},
+			{
+				// Import/Read
+				ResourceName:      "genesyscloud_telephony_providers_edges_site_outbound_route." + outboundRouteResourceLabel1,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccResourceSiteoutboundRoutesDefaultOutboundRoute(t *testing.T) {
+
+	featureToggleCheck(t)
+
+	var (
+		outboundRouteResourceLabel1 = "outbound_route_1"
+		outboundRouteResourceLabel2 = "outbound_route_2"
+
+		// site
+		siteResourceLabel = "site"
+		siteName          = "site " + uuid.NewString()
+		siteDescription   = "terraform description 1"
+		mediaModel        = "Cloud"
+
+		// location
+		locationResourceLabel = "test-location1"
+	)
+
+	emergencyNumber := "+13173124741"
+	if err := telephonyProvidersEdgesSite.DeleteLocationWithNumber(emergencyNumber, sdkConfig); err != nil {
+		t.Skipf("failed to delete location with number %s, %v", emergencyNumber, err)
+	}
+
+	locationConfig := location.GenerateLocationResource(
+		locationResourceLabel,
+		"Terraform location"+uuid.NewString(),
+		"HQ1",
+		[]string{},
+		location.GenerateLocationEmergencyNum(
+			emergencyNumber,
+			util.NullValue, // Default number type
+		), location.GenerateLocationAddress(
+			"7601 Interactive Way",
+			"Indianapolis",
+			"IN",
+			"US",
+			"46278",
+		))
+
+	trunkBaseSettings1 := telephony_provider_edges_trunkbasesettings.GenerateTrunkBaseSettingsResourceWithCustomAttrs(
+		"trunkBaseSettings1",
+		"test trunk base settings "+uuid.NewString(),
+		"test description",
+		"external_sip.json",
+		"EXTERNAL",
+		false)
+
+	trunkBaseSettings2 := telephony_provider_edges_trunkbasesettings.GenerateTrunkBaseSettingsResourceWithCustomAttrs(
+		"trunkBaseSettings2",
+		"test trunk base settings "+uuid.NewString(),
+		"test description",
+		"external_sip.json",
+		"EXTERNAL",
+		false)
+
+	site := telephonyProvidersEdgesSite.GenerateSiteResourceWithCustomAttrs(
+		siteResourceLabel,
+		siteName,
+		siteDescription,
+		"genesyscloud_location."+locationResourceLabel+".id",
+		mediaModel,
+		false,
+		util.AssignRegion(),
+		strconv.Quote("+19205551212"),
+		strconv.Quote("Wilco plumbing"),
+		"set_as_default_site = false")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Check Default Outbound Route gets created when a Site is created
+				Config: trunkBaseSettings1 + locationConfig + site + generateSiteOutboundRouteDataSource(
+					outboundRouteResourceLabel1,
+					"Default Outbound Route",
+					testrunner.GenerateFullPathId(telephonyProvidersEdgesSite.ResourceType, siteResourceLabel),
+					"",
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrPair("data.genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "site_id", "genesyscloud_telephony_providers_edges_site."+siteResourceLabel, "id"),
+				),
+			},
+			// Check that the Default Outbound Route can be updated
+			{
+				Config: trunkBaseSettings1 + locationConfig + site + generateSiteOutboundRoutesResource(
+					outboundRouteResourceLabel1,
+					"genesyscloud_telephony_providers_edges_site."+siteResourceLabel+".id",
+					"Default Outbound Route",
+					"outboundRoute description 1",
+					strings.Join([]string{strconv.Quote("National"), strconv.Quote("International")}, ","),
+					"genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1.id",
+					"RANDOM",
+					util.FalseValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "name", "Default Outbound Route"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "description", "outboundRoute description 1"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "classification_types.1", "International"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "classification_types.0", "National"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "distribution", "RANDOM"),
+					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "external_trunk_base_ids.0", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1", "id"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "enabled", util.FalseValue),
+				),
+			},
+			// Check that a new outbound route can be added to the site
+			{
+				Config: trunkBaseSettings1 + trunkBaseSettings2 + locationConfig + site + generateSiteOutboundRoutesResource(
+					outboundRouteResourceLabel1,
+					"genesyscloud_telephony_providers_edges_site."+siteResourceLabel+".id",
+					"Default Outbound Route",
+					"outboundRoute description 1",
+					"\"International\"",
+					"genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1.id",
+					"RANDOM",
+					util.FalseValue) + generateSiteOutboundRoutesResource(
+					outboundRouteResourceLabel2,
+					"genesyscloud_telephony_providers_edges_site."+siteResourceLabel+".id",
+					"outboundRoute name 2",
+					"outboundRoute description 2",
+					"\"Network\"",
+					"genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings2.id",
+					"SEQUENTIAL",
+					util.FalseValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "name", "Default Outbound Route"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "description", "outboundRoute description 1"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "classification_types.0", "International"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "distribution", "RANDOM"),
+					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "external_trunk_base_ids.0", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1", "id"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "enabled", util.FalseValue),
+
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel2, "name", "outboundRoute name 2"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel2, "description", "outboundRoute description 2"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel2, "classification_types.0", "Network"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel2, "distribution", "SEQUENTIAL"),
+					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel2, "external_trunk_base_ids.0", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings2", "id"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel2, "enabled", util.FalseValue),
+				),
+			},
+			// Remove a route and update the description, classification types, trunk base ids, distribution and enabled value of another route
+			{
+				Config: trunkBaseSettings1 + trunkBaseSettings2 + locationConfig + site + generateSiteOutboundRoutesResource(
+					outboundRouteResourceLabel1,
+					"genesyscloud_telephony_providers_edges_site."+siteResourceLabel+".id",
+					"Default Outbound Route",
+					"outboundRoute description updated",
+					"\"International\"",
+					strings.Join([]string{"genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1.id", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings2.id"}, ","),
+					"RANDOM",
+					util.TrueValue),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "name", "Default Outbound Route"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "description", "outboundRoute description updated"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "classification_types.0", "International"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "distribution", "RANDOM"),
+					resource.TestCheckResourceAttr("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "enabled", util.TrueValue),
+					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "external_trunk_base_ids.0", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings1", "id"),
+					resource.TestCheckResourceAttrPair("genesyscloud_telephony_providers_edges_site_outbound_route."+outboundRouteResourceLabel1, "external_trunk_base_ids.1", "genesyscloud_telephony_providers_edges_trunkbasesettings.trunkBaseSettings2", "id"),
 				),
 			},
 			{

--- a/genesyscloud/util/testrunner/testrunner.go
+++ b/genesyscloud/util/testrunner/testrunner.go
@@ -107,3 +107,7 @@ func GenerateTestSteps(testType string, resourceType string, testCaseName string
 
 	return testSteps
 }
+
+func GenerateFullPathId(resourceType string, resourceLabel string) string {
+	return resourceType + "." + resourceLabel + "." + "id"
+}


### PR DESCRIPTION
Fix default outbound routes by enabling updating the default outbound route during terraform create