### PR TITLE
DEVTOOLING-966: Validating that the schedule start date matches the rrule

### DIFF
--- a/docs/resources/architect_schedules.md
+++ b/docs/resources/architect_schedules.md
@@ -36,7 +36,7 @@ resource "genesyscloud_architect_schedules" "sample_schedule" {
 
 - `end` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000.
 - `name` (String) Name of the schedule.
-- `start` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000.
+- `start` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. Cannot be a Saturday or Sunday.
 
 ### Optional
 

--- a/docs/resources/architect_schedules.md
+++ b/docs/resources/architect_schedules.md
@@ -36,7 +36,7 @@ resource "genesyscloud_architect_schedules" "sample_schedule" {
 
 - `end` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000.
 - `name` (String) Name of the schedule.
-- `start` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. Cannot be a Saturday or Sunday.
+- `start` (String) Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. The start date should be applicable to the schedule's recurrence rule.
 
 ### Optional
 

--- a/genesyscloud/architect_schedules/data_source_genesyscloud_architect_schedules_test.go
+++ b/genesyscloud/architect_schedules/data_source_genesyscloud_architect_schedules_test.go
@@ -19,6 +19,9 @@ func TestAccDataSourceArchitectSchedule(t *testing.T) {
 		start              = "2021-08-04T08:00:00.000000"
 		end                = "2021-08-04T17:00:00.000000"
 		rrule              = "FREQ=DAILY;INTERVAL=1"
+
+		resourcePath     = ResourceType + "." + schedResourceLabel
+		dataResourcePath = "data." + ResourceType + "." + schedDataLabel
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -37,9 +40,9 @@ func TestAccDataSourceArchitectSchedule(t *testing.T) {
 				) + generateScheduleDataSource(
 					schedDataLabel,
 					name,
-					"genesyscloud_architect_schedules."+schedResourceLabel),
+					resourcePath),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.genesyscloud_architect_schedules."+schedDataLabel, "id", "genesyscloud_architect_schedules."+schedResourceLabel, "id"),
+					resource.TestCheckResourceAttrPair(dataResourcePath, "id", resourcePath, "id"),
 				),
 			},
 		},
@@ -47,14 +50,12 @@ func TestAccDataSourceArchitectSchedule(t *testing.T) {
 }
 
 func generateScheduleDataSource(
-	resourceLabel string,
-	name string,
-	// Must explicitly use depends_on in terraform v0.13 when a data source references a resource
-	// Fixed in v0.14 https://github.com/hashicorp/terraform/pull/26284
+	resourceLabel,
+	name,
 	dependsOnResource string) string {
-	return fmt.Sprintf(`data "genesyscloud_architect_schedules" "%s" {
+	return fmt.Sprintf(`data "%s" "%s" {
 		name = "%s"
 		depends_on=[%s]
 	}
-	`, resourceLabel, name, dependsOnResource)
+	`, ResourceType, resourceLabel, name, dependsOnResource)
 }

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
@@ -49,7 +49,7 @@ func createArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta 
 	description := d.Get("description").(string)
 	start := d.Get("start").(string)
 	end := d.Get("end").(string)
-	rrule := d.Get("rrule").(string)
+	rrule, _ := d.Get("rrule").(string)
 
 	//The first parameter of the Parse() method specifies the date and time format/layout that should be used to interpret the second parameter.
 	schedStart, err := time.Parse(timeFormat, start)
@@ -57,8 +57,10 @@ func createArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta 
 		return util.BuildDiagnosticError(ResourceType, fmt.Sprintf("Failed to parse date %s", start), err)
 	}
 
-	if err := verifyDateTimeIsWeekday(schedStart); err != nil {
-		return util.BuildDiagnosticError(ResourceType, err.Error(), err)
+	if rrule != "" {
+		if err := verifyStartDateConformsToRRule(schedStart, rrule, name); err != nil {
+			return util.BuildDiagnosticError(ResourceType, err.Error(), err)
+		}
 	}
 
 	schedEnd, err := time.Parse(timeFormat, end)
@@ -118,7 +120,6 @@ func readArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta in
 		start := new(string)
 		if scheduleResponse.Start != nil {
 			*start = timeutil.Strftime(scheduleResponse.Start, "%Y-%m-%dT%H:%M:%S.%f")
-
 		} else {
 			start = nil
 		}
@@ -126,7 +127,6 @@ func readArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta in
 		end := new(string)
 		if scheduleResponse.End != nil {
 			*end = timeutil.Strftime(scheduleResponse.End, "%Y-%m-%dT%H:%M:%S.%f")
-
 		} else {
 			end = nil
 		}
@@ -153,7 +153,7 @@ func updateArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta 
 	description := d.Get("description").(string)
 	start := d.Get("start").(string)
 	end := d.Get("end").(string)
-	rrule := d.Get("rrule").(string)
+	rrule, _ := d.Get("rrule").(string)
 
 	//The first parameter of the Parse() method specifies the date and time format/layout that should be used to interpret the second parameter.
 	schedStart, err := time.Parse(timeFormat, start)
@@ -161,8 +161,10 @@ func updateArchitectSchedules(ctx context.Context, d *schema.ResourceData, meta 
 		return diag.Errorf("Failed to parse date %s: %s", start, err)
 	}
 
-	if err := verifyDateTimeIsWeekday(schedStart); err != nil {
-		return util.BuildDiagnosticError(ResourceType, err.Error(), err)
+	if rrule != "" {
+		if err := verifyStartDateConformsToRRule(schedStart, rrule, name); err != nil {
+			return util.BuildDiagnosticError(ResourceType, err.Error(), err)
+		}
 	}
 
 	schedEnd, err := time.Parse(timeFormat, end)

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_schema.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_schema.go
@@ -49,7 +49,7 @@ func ResourceArchitectSchedules() *schema.Resource {
 				Optional:    true,
 			},
 			"start": {
-				Description:      "Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. Start date cannot be a Saturday or Sunday.",
+				Description:      "Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. Cannot be a Saturday or Sunday.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validators.ValidateLocalDateTimes,

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_schema.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_schema.go
@@ -49,7 +49,7 @@ func ResourceArchitectSchedules() *schema.Resource {
 				Optional:    true,
 			},
 			"start": {
-				Description:      "Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000.",
+				Description:      "Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. Start date cannot be a Saturday or Sunday.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validators.ValidateLocalDateTimes,

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_schema.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_schema.go
@@ -49,7 +49,7 @@ func ResourceArchitectSchedules() *schema.Resource {
 				Optional:    true,
 			},
 			"start": {
-				Description:      "Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. Cannot be a Saturday or Sunday.",
+				Description:      "Date time is represented as an ISO-8601 string without a timezone. For example: 2006-01-02T15:04:05.000000. The start date should be applicable to the schedule's recurrence rule.",
 				Type:             schema.TypeString,
 				Required:         true,
 				ValidateDiagFunc: validators.ValidateLocalDateTimes,

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
 )
 
-const errorMessageToMatch = "schedule start date cannot be a Saturday or Sunday"
+const errorMessageToMatch = "invalid start date."
 
 func TestAccResourceArchitectSchedules(t *testing.T) {
 	var (
@@ -111,14 +111,14 @@ func TestAccResourceArchitectSchedules(t *testing.T) {
 	})
 }
 
-func TestAccResourceArchitectSchedulesCreateFailsWhenStartDateIsNotWeekday(t *testing.T) {
+func TestAccResourceArchitectSchedulesCreateFailsWhenStartDateNotInRRule(t *testing.T) {
 	var (
 		schedResourceLabel = "schedule"
 		name               = "CX as Code Schedule " + uuid.NewString()
 		description        = "Sample Schedule by CX as Code"
 		start              = "2021-08-07T22:00:00.000000" // Saturday
 		end                = "2021-08-08T23:00:00.000000"
-		rrule              = "FREQ=DAILY;INTERVAL=1"
+		rrule              = "FREQ=DAILY;INTERVAL=1;BYDAY=MO,TU,WE,THU,FR,SU"
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -143,12 +143,12 @@ func TestAccResourceArchitectSchedulesCreateFailsWhenStartDateIsNotWeekday(t *te
 	})
 }
 
-func TestAccResourceArchitectSchedulesUpdateFailsWhenStartDateIsNotWeekday(t *testing.T) {
+func TestAccResourceArchitectSchedulesUpdateFailsWhenStartDateNotInRRule(t *testing.T) {
 	var (
 		schedResourceLabel = "schedule"
 		name               = "CX as Code Schedule " + uuid.NewString()
 		description        = "Sample Schedule by CX as Code"
-		rrule              = "FREQ=DAILY;INTERVAL=1"
+		rrule              = "FREQ=DAILY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR"
 
 		validStart = "2021-08-06T22:00:00.000000" // Friday
 		validEnd   = "2021-08-06T23:00:00.000000"

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
@@ -2,6 +2,7 @@ package architect_schedules
 
 import (
 	"fmt"
+	"regexp"
 	authDivision "terraform-provider-genesyscloud/genesyscloud/auth_division"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
@@ -12,6 +13,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
 )
+
+const errorMessageToMatch = "schedule start date cannot be a Saturday or Sunday"
 
 func TestAccResourceArchitectSchedules(t *testing.T) {
 	var (
@@ -28,6 +31,9 @@ func TestAccResourceArchitectSchedules(t *testing.T) {
 
 		divResourceLabel = "test-division"
 		divName          = "terraform-" + uuid.NewString()
+
+		resourcePath1 = ResourceType + "." + schedResourceLabel1
+		resourcePath2 = ResourceType + "." + schedResourceLabel2
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -46,12 +52,12 @@ func TestAccResourceArchitectSchedules(t *testing.T) {
 					rrule,
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "name", name),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "description", description),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "start", start),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "end", end),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "rrule", rrule),
-					provider.TestDefaultHomeDivision("genesyscloud_architect_schedules."+schedResourceLabel1),
+					resource.TestCheckResourceAttr(resourcePath1, "name", name),
+					resource.TestCheckResourceAttr(resourcePath1, "description", description),
+					resource.TestCheckResourceAttr(resourcePath1, "start", start),
+					resource.TestCheckResourceAttr(resourcePath1, "end", end),
+					resource.TestCheckResourceAttr(resourcePath1, "rrule", rrule),
+					provider.TestDefaultHomeDivision(resourcePath1),
 				),
 			},
 			{
@@ -66,12 +72,12 @@ func TestAccResourceArchitectSchedules(t *testing.T) {
 					rrule,
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "name", name),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "description", description),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "start", start2),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "end", end),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel1, "rrule", rrule),
-					provider.TestDefaultHomeDivision("genesyscloud_architect_schedules."+schedResourceLabel1),
+					resource.TestCheckResourceAttr(resourcePath1, "name", name),
+					resource.TestCheckResourceAttr(resourcePath1, "description", description),
+					resource.TestCheckResourceAttr(resourcePath1, "start", start2),
+					resource.TestCheckResourceAttr(resourcePath1, "end", end),
+					resource.TestCheckResourceAttr(resourcePath1, "rrule", rrule),
+					provider.TestDefaultHomeDivision(resourcePath1),
 				),
 			},
 			{
@@ -86,19 +92,109 @@ func TestAccResourceArchitectSchedules(t *testing.T) {
 					rrule,
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel2, "name", name2),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel2, "description", description),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel2, "start", start),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel2, "end", end),
-					resource.TestCheckResourceAttr("genesyscloud_architect_schedules."+schedResourceLabel2, "rrule", rrule),
-					resource.TestCheckResourceAttrPair("genesyscloud_architect_schedules."+schedResourceLabel2, "division_id", "genesyscloud_auth_division."+divResourceLabel, "id"),
+					resource.TestCheckResourceAttr(resourcePath2, "name", name2),
+					resource.TestCheckResourceAttr(resourcePath2, "description", description),
+					resource.TestCheckResourceAttr(resourcePath2, "start", start),
+					resource.TestCheckResourceAttr(resourcePath2, "end", end),
+					resource.TestCheckResourceAttr(resourcePath2, "rrule", rrule),
+					resource.TestCheckResourceAttrPair(resourcePath2, "division_id", "genesyscloud_auth_division."+divResourceLabel, "id"),
 				),
 			},
 			{
 				// Import/Read
-				ResourceName:      "genesyscloud_architect_schedules." + schedResourceLabel2,
+				ResourceName:      resourcePath2,
 				ImportState:       true,
 				ImportStateVerify: true,
+			},
+		},
+		CheckDestroy: testVerifySchedulesDestroyed,
+	})
+}
+
+func TestAccResourceArchitectSchedulesCreateFailsWhenStartDateIsNotWeekday(t *testing.T) {
+	var (
+		schedResourceLabel = "schedule"
+		name               = "CX as Code Schedule " + uuid.NewString()
+		description        = "Sample Schedule by CX as Code"
+		start              = "2021-08-07T22:00:00.000000" // Saturday
+		end                = "2021-08-08T23:00:00.000000"
+		rrule              = "FREQ=DAILY;INTERVAL=1"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Create
+				Config: GenerateArchitectSchedulesResource(
+					schedResourceLabel,
+					name,
+					util.NullValue,
+					description,
+					start,
+					end,
+					rrule,
+				),
+				ExpectError: regexp.MustCompile(errorMessageToMatch),
+			},
+		},
+		CheckDestroy: testVerifySchedulesDestroyed,
+	})
+}
+
+func TestAccResourceArchitectSchedulesUpdateFailsWhenStartDateIsNotWeekday(t *testing.T) {
+	var (
+		schedResourceLabel = "schedule"
+		name               = "CX as Code Schedule " + uuid.NewString()
+		description        = "Sample Schedule by CX as Code"
+		rrule              = "FREQ=DAILY;INTERVAL=1"
+
+		validStart = "2021-08-06T22:00:00.000000" // Friday
+		validEnd   = "2021-08-06T23:00:00.000000"
+
+		startUpdate = "2021-08-08T22:00:00.000000" // Sunday
+		endUpdate   = "2021-08-09T22:00:00.000000"
+
+		resourcePath = ResourceType + "." + schedResourceLabel
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Create
+				Config: GenerateArchitectSchedulesResource(
+					schedResourceLabel,
+					name,
+					util.NullValue,
+					description,
+					validStart,
+					validEnd,
+					rrule,
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "name", name),
+					resource.TestCheckResourceAttr(resourcePath, "description", description),
+					resource.TestCheckResourceAttr(resourcePath, "start", validStart),
+					resource.TestCheckResourceAttr(resourcePath, "end", validEnd),
+					resource.TestCheckResourceAttr(resourcePath, "rrule", rrule),
+					provider.TestDefaultHomeDivision(resourcePath),
+				),
+			},
+			{
+				// Update
+				Config: GenerateArchitectSchedulesResource(
+					schedResourceLabel,
+					name,
+					util.NullValue,
+					description,
+					startUpdate,
+					endUpdate,
+					rrule,
+				),
+				ExpectError: regexp.MustCompile(errorMessageToMatch),
 			},
 		},
 		CheckDestroy: testVerifySchedulesDestroyed,
@@ -108,20 +204,19 @@ func TestAccResourceArchitectSchedules(t *testing.T) {
 func testVerifySchedulesDestroyed(state *terraform.State) error {
 	archAPI := platformclientv2.NewArchitectApi()
 	for _, rs := range state.RootModule().Resources {
-		if rs.Type != "genesyscloud_architect_schedules" {
+		if rs.Type != ResourceType {
 			continue
 		}
 
-		sched, resp, err := archAPI.GetArchitectSchedule(rs.Primary.ID)
-		if sched != nil {
-			return fmt.Errorf("Schedule (%s) still exists", rs.Primary.ID)
-		} else if util.IsStatus404(resp) {
-			// Schedule not found as expected
-			continue
-		} else {
-			// Unexpected error
-			return fmt.Errorf("Unexpected error: %s", err)
+		_, resp, err := archAPI.GetArchitectSchedule(rs.Primary.ID)
+		if err != nil {
+			if util.IsStatus404(resp) {
+				// Schedule not found as expected
+				continue
+			}
+			return fmt.Errorf("unexpected error: %s", err)
 		}
+		return fmt.Errorf("schedule (%s) still exists", rs.Primary.ID)
 	}
 	// Success. All schedules destroyed
 	return nil

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_unit_test.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_unit_test.go
@@ -1,0 +1,106 @@
+package architect_schedules
+
+import (
+	"terraform-provider-genesyscloud/genesyscloud/util/lists"
+	"testing"
+	"time"
+)
+
+func TestUnitGetByDaysFromRRule(t *testing.T) {
+	type inputAndResults struct {
+		input          string
+		expectedOutput []string
+	}
+
+	testCases := []inputAndResults{
+		{
+			input:          "",
+			expectedOutput: []string{},
+		},
+		{
+			input:          "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO",
+			expectedOutput: []string{time.Monday.String()},
+		},
+		{
+			input:          "FREQ=MONTHLY;INTERVAL=1;BYMONTHDAY=12;BYDAY=TH,FR",
+			expectedOutput: []string{time.Thursday.String(), time.Friday.String()},
+		},
+		{
+			input:          "FREQ=YEARLY;COUNT=3;INTERVAL=1;BYMONTH=11;BYMONTHDAY=1",
+			expectedOutput: []string{},
+		},
+		{
+			input: "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU",
+			expectedOutput: []string{
+				time.Monday.String(),
+				time.Tuesday.String(),
+				time.Wednesday.String(),
+				time.Thursday.String(),
+				time.Friday.String(),
+				time.Saturday.String(),
+				time.Sunday.String(),
+			},
+		},
+		{
+			input:          "FREQ=MONTHLY;BYDAY=MO,FR;INTERVAL=1;BYMONTHDAY=12;",
+			expectedOutput: []string{time.Monday.String(), time.Friday.String()},
+		},
+	}
+
+	for _, testCase := range testCases {
+		result := getDaysFromRRule(testCase.input)
+		if len(result) != len(testCase.expectedOutput) {
+			t.Errorf("getDaysFromRRule(%q) returned %d results, expected %d", testCase.input, len(result), len(testCase.expectedOutput))
+		}
+		if !lists.AreEquivalent(result, testCase.expectedOutput) {
+			t.Errorf("lists are not equivalent, expected %v, got %v", testCase.expectedOutput, result)
+		}
+	}
+}
+
+func TestUnitVerifyStartDateConformsToRRule(t *testing.T) {
+	const scheduleName = "example schedule"
+
+	type inputAndResults struct {
+		dateTime    string
+		rrule       string
+		expectError bool
+	}
+
+	testCases := []inputAndResults{
+		{
+			dateTime:    "2018-05-07T09:00:00.000000", // Monday
+			rrule:       "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO",
+			expectError: false,
+		},
+		{
+			dateTime:    "2018-11-16T09:43:00.000000", // Friday
+			rrule:       "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE,TH,FR,SA,SU",
+			expectError: false,
+		},
+		{
+			dateTime:    "2016-03-31T10:00:00.000000", // Thursday
+			rrule:       "FREQ=WEEKLY;INTERVAL=1;BYDAY=MO",
+			expectError: true,
+		},
+		{
+			dateTime:    "2020-11-16T07:31:00.000000", // Monday
+			rrule:       "FREQ=YEARLY;COUNT=3;INTERVAL=1;BYMONTH=11;BYMONTHDAY=1",
+			expectError: false,
+		},
+	}
+
+	for i, testCase := range testCases {
+		dt, err := time.Parse(timeFormat, testCase.dateTime)
+		if err != nil {
+			t.Errorf("failed to parse date time %q: %s", testCase.dateTime, err)
+		}
+		err = verifyStartDateConformsToRRule(dt, testCase.rrule, scheduleName)
+		if err != nil && !testCase.expectError {
+			t.Errorf("verifyStartDateConformsToRRule returned unexpected error on test case #%d: %s", i+1, err.Error())
+		}
+		if err == nil && testCase.expectError {
+			t.Errorf("Expected verifyStartDateConformsToRRule to return an error for test case #%d, got nil", i+1)
+		}
+	}
+}

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_utils.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_utils.go
@@ -1,18 +1,60 @@
 package architect_schedules
 
 import (
-	"errors"
 	"fmt"
+	"regexp"
+	"strings"
+	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 	"time"
 )
 
 const timeFormat = "2006-01-02T15:04:05.000000"
 
-func verifyDateTimeIsWeekday(dateTime time.Time) error {
-	if dateTime.Weekday() == time.Saturday || dateTime.Weekday() == time.Sunday {
-		return errors.New("schedule start date cannot be a Saturday or Sunday")
+func verifyStartDateConformsToRRule(dateTime time.Time, rrule string, scheduleName string) error {
+	scheduleDays := getDaysFromRRule(rrule)
+	if len(scheduleDays) == 0 {
+		return nil
+	}
+	if !lists.SubStringInSlice(dateTime.Weekday().String(), scheduleDays) {
+		return fmt.Errorf("invalid start date. %s is not specified in the rrule for schedule '%s'", dateTime.Weekday().String(), scheduleName)
 	}
 	return nil
+}
+
+// getDaysFromRRule parses the rrule to establish which weekdays are specified, if any.
+func getDaysFromRRule(rrule string) []string {
+	// Match BYDAY= followed by uppercase letters and commas
+	re := regexp.MustCompile(`BYDAY=([A-Z,]+)(?:;|$)`)
+
+	matches := re.FindStringSubmatch(rrule)
+	if len(matches) < 2 {
+		// No BYDAY parameter found
+		return []string{}
+	}
+
+	// Split the matched days on commas
+	days := strings.Split(matches[1], ",")
+
+	// Map the abbreviations to full day names
+	abbreviationMap := map[string]string{
+		"MO": time.Monday.String(),
+		"TU": time.Tuesday.String(),
+		"WE": time.Wednesday.String(),
+		"TH": time.Thursday.String(),
+		"FR": time.Friday.String(),
+		"SA": time.Saturday.String(),
+		"SU": time.Sunday.String(),
+	}
+
+	// Convert abbreviations to full day names
+	fullDays := make([]string, 0, len(days))
+	for _, day := range days {
+		if fullDay, ok := abbreviationMap[day]; ok {
+			fullDays = append(fullDays, fullDay)
+		}
+	}
+
+	return fullDays
 }
 
 func GenerateArchitectSchedulesResource(

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_utils.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_utils.go
@@ -10,6 +10,17 @@ import (
 
 const timeFormat = "2006-01-02T15:04:05.000000"
 
+// Mapping rrule day abbreviations to full day names
+var rruleDayMap = map[string]string{
+	"MO": time.Monday.String(),
+	"TU": time.Tuesday.String(),
+	"WE": time.Wednesday.String(),
+	"TH": time.Thursday.String(),
+	"FR": time.Friday.String(),
+	"SA": time.Saturday.String(),
+	"SU": time.Sunday.String(),
+}
+
 func verifyStartDateConformsToRRule(dateTime time.Time, rrule string, scheduleName string) error {
 	scheduleDays := getDaysFromRRule(rrule)
 	if len(scheduleDays) == 0 {
@@ -35,21 +46,10 @@ func getDaysFromRRule(rrule string) []string {
 	// Split the matched days on commas
 	days := strings.Split(matches[1], ",")
 
-	// Map the abbreviations to full day names
-	abbreviationMap := map[string]string{
-		"MO": time.Monday.String(),
-		"TU": time.Tuesday.String(),
-		"WE": time.Wednesday.String(),
-		"TH": time.Thursday.String(),
-		"FR": time.Friday.String(),
-		"SA": time.Saturday.String(),
-		"SU": time.Sunday.String(),
-	}
-
 	// Convert abbreviations to full day names
 	fullDays := make([]string, 0, len(days))
 	for _, day := range days {
-		if fullDay, ok := abbreviationMap[day]; ok {
+		if fullDay, ok := rruleDayMap[day]; ok {
 			fullDays = append(fullDays, fullDay)
 		}
 	}

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_utils.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_utils.go
@@ -1,0 +1,35 @@
+package architect_schedules
+
+import (
+	"errors"
+	"fmt"
+	"time"
+)
+
+const timeFormat = "2006-01-02T15:04:05.000000"
+
+func verifyDateTimeIsWeekday(dateTime time.Time) error {
+	if dateTime.Weekday() == time.Saturday || dateTime.Weekday() == time.Sunday {
+		return errors.New("schedule start date cannot be a Saturday or Sunday")
+	}
+	return nil
+}
+
+func GenerateArchitectSchedulesResource(
+	schedResourceLabel,
+	name,
+	divisionId,
+	description,
+	start,
+	end,
+	rrule string) string {
+	return fmt.Sprintf(`resource "%s" "%s" {
+		name = "%s"
+		division_id = %s
+		description = "%s"
+		start = "%s"
+		end = "%s"
+		rrule = "%s"
+	}
+	`, ResourceType, schedResourceLabel, name, divisionId, description, start, end, rrule)
+}

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
@@ -454,7 +454,9 @@ func SetupJourneyActionMap(t *testing.T, testCaseName string, sdkConfig *platfor
 	testCasePrefix := testrunner.TestObjectIdPrefix + testCaseName
 	cleanupJourneySegments(testCasePrefix, sdkConfig)
 	cleanupArchitectScheduleGroups(testCasePrefix)
-	cleanupArchitectSchedules(testCasePrefix)
+	if err := cleanupArchitectSchedules(testCasePrefix); err != nil {
+		t.Log(err)
+	}
 	cleanupFlows(testCasePrefix, sdkConfig)
 	cleanupJourneyActionMaps(testCasePrefix, sdkConfig)
 }
@@ -513,14 +515,14 @@ func cleanupArchitectScheduleGroups(idPrefix string) {
 	}
 }
 
-func cleanupArchitectSchedules(idPrefix string) {
+func cleanupArchitectSchedules(idPrefix string) error {
 	architectApi := platformclientv2.NewArchitectApi()
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
 		architectSchedules, _, getErr := architectApi.GetArchitectSchedules(pageNum, pageSize, "", "", "", nil)
 		if getErr != nil {
-			return
+			return getErr
 		}
 
 		if architectSchedules.Entities == nil || len(*architectSchedules.Entities) == 0 {
@@ -529,15 +531,15 @@ func cleanupArchitectSchedules(idPrefix string) {
 
 		for _, schedule := range *architectSchedules.Entities {
 			if schedule.Name != nil && strings.HasPrefix(*schedule.Name, idPrefix) {
-				resp, delErr := architectApi.DeleteArchitectSchedule(*schedule.Id)
+				_, delErr := architectApi.DeleteArchitectSchedule(*schedule.Id)
 				if delErr != nil {
-					util.BuildAPIDiagnosticError("genesyscloud_architect_schedules", fmt.Sprintf("failed to delete architect schedule %s (%s): %s", *schedule.Id, *schedule.Name, delErr), resp)
-					return
+					return fmt.Errorf("failed to delete architect schedule %s (%s): %s", *schedule.Id, *schedule.Name, delErr)
 				}
 				log.Printf("Deleted architect schedule %s (%s)", *schedule.Id, *schedule.Name)
 			}
 		}
 	}
+	return nil
 }
 
 func cleanupJourneySegments(idPrefix string, sdkConfig *platformclientv2.Configuration) {

--- a/genesyscloud/tfexporter/tf_exporter_resource_test.go
+++ b/genesyscloud/tfexporter/tf_exporter_resource_test.go
@@ -244,7 +244,7 @@ func (r *registerTestInstance) registerTestExporters() {
 	RegisterExporter("genesyscloud_architect_datatable_row", architect_datatable_row.ArchitectDatatableRowExporter())
 	RegisterExporter("genesyscloud_architect_emergencygroup", emergencyGroup.ArchitectEmergencyGroupExporter())
 	RegisterExporter("genesyscloud_architect_ivr", archIvr.ArchitectIvrExporter())
-	RegisterExporter("genesyscloud_architect_schedules", architectSchedules.ArchitectSchedulesExporter())
+	RegisterExporter(architectSchedules.ResourceType, architectSchedules.ArchitectSchedulesExporter())
 	RegisterExporter("genesyscloud_architect_schedulegroups", architectSchedulegroups.ArchitectSchedulegroupsExporter())
 	RegisterExporter("genesyscloud_architect_user_prompt", userPrompt.ArchitectUserPromptExporter())
 	RegisterExporter("genesyscloud_auth_division", authDivision.AuthDivisionExporter())


### PR DESCRIPTION
If an architect schedule defines its recurrence rule (`rrule`) as `"FREQ=WEEKLY;INTERVAL=1;BYDAY=MO,TU,WE"` , then the start date must be a Monday, Tuesday or Wednesday. If it is not, the API will automatically push the day back until it matches the rrule (in this case it will transform to the next Monday)  

This PR adds a check to the create and update context to establish the days specified in the rrule (if any), and then establish which day of the week the start date is. If the start date day is not in the rrule, fail. 

@carnellj-genesys After exporting all schedules in an org and applying them against another org, I found that there were schedules that did not conform to the rules (i.e. had start dates that were not in the rrule), so the deployment failed. I don't think this is an issue from a CX as Code perspective because there are three possibilities:

1. We leave the code as is and the consistency checker will retry for ages before outputting a vague error message:
    
<img width="958" alt="Screenshot 2024-12-13 at 10 27 47" src="https://github.com/user-attachments/assets/0144e417-0b59-4866-970b-2c5e2b73654d" />

2. The user bypasses the consistency checker which will get them around the error, but every `terraform apply/plan` will produce changes because of the inconsistency between the config and API.

3. We enforce this validation which will cause there deployment to fail quickly, providing an explanation:

<img width="1168" alt="Screenshot 2024-12-13 at 10 28 10" src="https://github.com/user-attachments/assets/61605989-95bd-4b3a-937f-68f16966890d" />

