### PR TITLE
Feat/cobrowse 2635 add enable draw to cobrowse

### DIFF
--- a/docs/resources/webdeployments_configuration.md
+++ b/docs/resources/webdeployments_configuration.md
@@ -97,6 +97,7 @@ resource "genesyscloud_webdeployments_configuration" "exampleConfiguration" {
     enabled                = true
     allow_agent_control    = true
     allow_agent_navigation = true
+    allow_draw             = true
     channels               = ["Webmessaging", "Voice"]
     mask_selectors         = [".my-class", "#my-id"]
     readonly_selectors     = [".my-class", "#my-id"]
@@ -214,6 +215,7 @@ Optional:
 
 - `allow_agent_control` (Boolean) Whether agent can take control over customer's screen or not
 - `allow_agent_navigation` (Boolean) Whether agent can use navigation feature over customer's screen or not
+- `allow_draw` (Boolean) Whether drawing is enabled or not
 - `channels` (List of String) List of channels through which cobrowse is available (for now only Webmessaging and Voice)
 - `enabled` (Boolean) Whether or not cobrowse is enabled
 - `mask_selectors` (List of String) List of CSS selectors which should be masked when screen sharing is active

--- a/examples/resources/genesyscloud_webdeployments_configuration/resource.tf
+++ b/examples/resources/genesyscloud_webdeployments_configuration/resource.tf
@@ -72,6 +72,7 @@ resource "genesyscloud_webdeployments_configuration" "exampleConfiguration" {
     enabled                = true
     allow_agent_control    = true
     allow_agent_navigation = true
+    allow_draw             = true
     channels               = ["Webmessaging", "Voice"]
     mask_selectors         = [".my-class", "#my-id"]
     readonly_selectors     = [".my-class", "#my-id"]

--- a/genesyscloud/architect_datatable/data_source_genesyscloud_architect_datatable.go
+++ b/genesyscloud/architect_datatable/data_source_genesyscloud_architect_datatable.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func DataSourceArchitectDatatableRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type Datatableproperty struct {

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_proxy.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_proxy.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_test.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceArchitectDatatable(t *testing.T) {

--- a/genesyscloud/architect_datatable_row/genesyscloud_architect_datatable_row_utils.go
+++ b/genesyscloud/architect_datatable_row/genesyscloud_architect_datatable_row_utils.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // Row IDs structured as {table-id}/{key-value}

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type Datatableproperty struct {

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_proxy.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_proxy.go
@@ -9,7 +9,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // Type definitions for each func on our proxy so we can easily mock them out later

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_test.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceArchitectDatatableRow(t *testing.T) {

--- a/genesyscloud/architect_emergencygroup/genesyscloud_architect_emergencygroup_proxy.go
+++ b/genesyscloud/architect_emergencygroup/genesyscloud_architect_emergencygroup_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *architectEmergencyGroupProxy

--- a/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup.go
+++ b/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllEmergencyGroups(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_test.go
+++ b/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceArchitectEmergencyGroups(t *testing.T) {

--- a/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_utils.go
+++ b/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_utils.go
@@ -2,7 +2,7 @@ package architect_emergencygroup
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildSdkEmergencyGroupCallFlows(d *schema.ResourceData) *[]platformclientv2.Emergencycallflow {

--- a/genesyscloud/architect_flow/data_source_genesyscloud_flow.go
+++ b/genesyscloud/architect_flow/data_source_genesyscloud_flow.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_proxy.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *architectFlowProxy

--- a/genesyscloud/architect_flow/resource_genesyscloud_flow.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_flow.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllFlows(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/architect_flow/resource_genesyscloud_flow_test.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_flow_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // lockFlow will search for a specific flow and then lock it.  This is to specifically test the force_unlock flag where I want to create a flow,  simulate some one locking it and then attempt to

--- a/genesyscloud/architect_grammar/genesyscloud_architect_grammar_proxy.go
+++ b/genesyscloud/architect_grammar/genesyscloud_architect_grammar_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar.go
+++ b/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar_test.go
+++ b/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceArchitectGrammar(t *testing.T) {

--- a/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_proxy.go
+++ b/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_proxy.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/files"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type FileType int

--- a/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language.go
+++ b/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_test.go
+++ b/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceArchitectGrammarLanguage(t *testing.T) {

--- a/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_utils.go
+++ b/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_utils.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_ivr/data_source_genesyscloud_architect_ivr_test.go
+++ b/genesyscloud/architect_ivr/data_source_genesyscloud_architect_ivr_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/google/uuid"

--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy.go
@@ -7,7 +7,7 @@ import (
 	utillists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestUnitUploadIvrDnisChunksSuccess(t *testing.T) {

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // getAllIvrConfigs retrieves all architect IVRs and is used for the exporter

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_test.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIvrConfigBasic(t *testing.T) {

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_unit_test.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_unit_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_utils.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_utils.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type IvrConfigStruct struct {

--- a/genesyscloud/architect_schedulegroups/genesyscloud_architect_schedulegroups_proxy.go
+++ b/genesyscloud/architect_schedulegroups/genesyscloud_architect_schedulegroups_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups.go
+++ b/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups_test.go
+++ b/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceArchitectScheduleGroups(t *testing.T) {

--- a/genesyscloud/architect_schedules/genesyscloud_architect_schedules_proxy.go
+++ b/genesyscloud/architect_schedules/genesyscloud_architect_schedules_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
@@ -19,7 +19,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 const timeFormat = "2006-01-02T15:04:05.000000"

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceArchitectSchedules(t *testing.T) {

--- a/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
+++ b/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllUserPrompts(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_test.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceUserPromptBasic(t *testing.T) {

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_utils.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_utils.go
@@ -15,7 +15,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/testrunner"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type PromptAudioData struct {

--- a/genesyscloud/auth_division/genesyscloud_auth_division_proxy.go
+++ b/genesyscloud/auth_division/genesyscloud_auth_division_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *authDivisionProxy

--- a/genesyscloud/auth_division/resource_genesyscloud_auth_division.go
+++ b/genesyscloud/auth_division/resource_genesyscloud_auth_division.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllAuthDivisions(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/auth_division/resource_genesyscloud_auth_division_test.go
+++ b/genesyscloud/auth_division/resource_genesyscloud_auth_division_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/auth_role/data_source_genesyscloud_auth_role.go
+++ b/genesyscloud/auth_role/data_source_genesyscloud_auth_role.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/auth_role/genesyscloud_auth_role_proxy.go
+++ b/genesyscloud/auth_role/genesyscloud_auth_role_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/auth_role/resource_genesyscloud_auth_role.go
+++ b/genesyscloud/auth_role/resource_genesyscloud_auth_role.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/auth_role/resource_genesyscloud_auth_role_test.go
+++ b/genesyscloud/auth_role/resource_genesyscloud_auth_role_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceAuthRoleDefault(t *testing.T) {

--- a/genesyscloud/auth_role/resource_genesyscloud_auth_role_utils.go
+++ b/genesyscloud/auth_role/resource_genesyscloud_auth_role_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func validatePermissionPolicy(proxy *authRoleProxy, policy platformclientv2.Domainpermissionpolicy) (*platformclientv2.APIResponse, error) {

--- a/genesyscloud/authorization_product/data_source_genesyscloud_authorization_product_test.go
+++ b/genesyscloud/authorization_product/data_source_genesyscloud_authorization_product_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 

--- a/genesyscloud/authorization_product/genesyscloud_authorization_product_proxy.go
+++ b/genesyscloud/authorization_product/genesyscloud_authorization_product_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_instagram/genesyscloud_conversations_messaging_integrations_instagram_proxy.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/genesyscloud_conversations_messaging_integrations_instagram_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_test.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_unit_test.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_utils.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_open/genesyscloud_conversations_messaging_integrations_open_proxy.go
+++ b/genesyscloud/conversations_messaging_integrations_open/genesyscloud_conversations_messaging_integrations_open_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open.go
+++ b/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_test.go
+++ b/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_utils.go
+++ b/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_utils.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_proxy.go
+++ b/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *conversationsMessagingSettingsProxy

--- a/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings.go
+++ b/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllAuthConversationsMessagingSettings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_test.go
+++ b/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_test.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_utils.go
+++ b/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getConversationsMessagingSettingsFromResourceData(d *schema.ResourceData) platformclientv2.Messagingsettingrequest {

--- a/genesyscloud/conversations_messaging_settings_default/genesyscloud_conversations_messaging_settings_default_proxy.go
+++ b/genesyscloud/conversations_messaging_settings_default/genesyscloud_conversations_messaging_settings_default_proxy.go
@@ -3,7 +3,7 @@ package conversations_messaging_settings_default
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_settings_default/resource_genesyscloud_conversations_messaging_settings_default.go
+++ b/genesyscloud/conversations_messaging_settings_default/resource_genesyscloud_conversations_messaging_settings_default.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func createConversationsMessagingSettingsDefault(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_proxy.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_test.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_utils.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_supportedcontent_default/genesyscloud_conversations_messaging_supportedcontent_default_proxy.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/genesyscloud_conversations_messaging_supportedcontent_default_proxy.go
@@ -3,7 +3,7 @@ package conversations_messaging_supportedcontent_default
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/data_source_genesyscloud_auth_division_home.go
+++ b/genesyscloud/data_source_genesyscloud_auth_division_home.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func DataSourceAuthDivisionHome() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_journey_outcome.go
+++ b/genesyscloud/data_source_genesyscloud_journey_outcome.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceJourneyOutcome() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_journey_segment.go
+++ b/genesyscloud/data_source_genesyscloud_journey_segment.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceJourneySegment() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/data_source_genesyscloud_knowledge_knowledgebase.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceKnowledgeKnowledgebase() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_organizations_me.go
+++ b/genesyscloud/data_source_genesyscloud_organizations_me.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func DataSourceOrganizationsMe() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_quality_forms_evaluation.go
+++ b/genesyscloud/data_source_genesyscloud_quality_forms_evaluation.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type EvaluationFormQuestionGroupStruct struct {

--- a/genesyscloud/data_source_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/data_source_genesyscloud_quality_forms_survey.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceQualityFormsSurvey() *schema.Resource {

--- a/genesyscloud/data_source_genesyscloud_widget_deployment.go
+++ b/genesyscloud/data_source_genesyscloud_widget_deployment.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceWidgetDeployments() *schema.Resource {

--- a/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy.go
+++ b/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy.go
@@ -11,7 +11,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/stringmap"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type DependentConsumerProxy struct {

--- a/genesyscloud/employeeperformance_externalmetrics_definitions/genesyscloud_employeeperformance_externalmetrics_definitions_proxy.go
+++ b/genesyscloud/employeeperformance_externalmetrics_definitions/genesyscloud_employeeperformance_externalmetrics_definitions_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions.go
+++ b/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 

--- a/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions_test.go
+++ b/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceEmployeePerformanceExternalMetricsDefintions(t *testing.T) {

--- a/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
+++ b/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_test.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/external_contacts_organization/genesyscloud_externalcontacts_organization_proxy.go
+++ b/genesyscloud/external_contacts_organization/genesyscloud_externalcontacts_organization_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization.go
+++ b/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_test.go
+++ b/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceExternalContacts(t *testing.T) {

--- a/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_utils.go
+++ b/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_utils.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/flow_loglevel/genesyscloud_flow_loglevel_proxy.go
+++ b/genesyscloud/flow_loglevel/genesyscloud_flow_loglevel_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel.go
+++ b/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel_test.go
+++ b/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceFlowLogLevel(t *testing.T) {

--- a/genesyscloud/flow_milestone/genesyscloud_flow_milestone_proxy.go
+++ b/genesyscloud/flow_milestone/genesyscloud_flow_milestone_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone.go
+++ b/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_test.go
+++ b/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceFlowMilestone(t *testing.T) {

--- a/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_utils.go
+++ b/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_utils.go
@@ -2,7 +2,7 @@ package flow_milestone
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_outcome/genesyscloud_flow_outcome_proxy.go
+++ b/genesyscloud/flow_outcome/genesyscloud_flow_outcome_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome.go
+++ b/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome_utils.go
+++ b/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome_utils.go
@@ -2,7 +2,7 @@ package flow_outcome
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/group/data_source_genesyscloud_group_test.go
+++ b/genesyscloud/group/data_source_genesyscloud_group_test.go
@@ -11,7 +11,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"

--- a/genesyscloud/group/genesyscloud_group_proxy.go
+++ b/genesyscloud/group/genesyscloud_group_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type createGroupFunc func(ctx context.Context, p *groupProxy, group *platformclientv2.Groupcreate) (*platformclientv2.Group, *platformclientv2.APIResponse, error)

--- a/genesyscloud/group/resource_genesyscloud_group.go
+++ b/genesyscloud/group/resource_genesyscloud_group.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllGroups(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/group/resource_genesyscloud_group_test.go
+++ b/genesyscloud/group/resource_genesyscloud_group_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceGroupBasic(t *testing.T) {

--- a/genesyscloud/group/resource_genesyscloud_group_utils.go
+++ b/genesyscloud/group/resource_genesyscloud_group_utils.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // 'number' and 'extension' conflict with eachother. However, one must be set.

--- a/genesyscloud/group_roles/genesyscloud_group_roles_proxy.go
+++ b/genesyscloud/group_roles/genesyscloud_group_roles_proxy.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *groupRolesProxy

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles_schema.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles_schema.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles_test.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles_test.go
@@ -14,7 +14,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	authDivision "terraform-provider-genesyscloud/genesyscloud/auth_division"
 	authRole "terraform-provider-genesyscloud/genesyscloud/auth_role"

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles_utils.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles_utils.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func flattenSubjectRoles(d *schema.ResourceData, p *groupRolesProxy) (*schema.Set, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/idp_adfs/genesyscloud_idp_adfs_proxy.go
+++ b/genesyscloud/idp_adfs/genesyscloud_idp_adfs_proxy.go
@@ -3,7 +3,7 @@ package idp_adfs
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_test.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIdpAdfs(t *testing.T) {

--- a/genesyscloud/idp_generic/genesyscloud_idp_generic_proxy.go
+++ b/genesyscloud/idp_generic/genesyscloud_idp_generic_proxy.go
@@ -3,7 +3,7 @@ package idp_generic
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_test.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIdpGeneric(t *testing.T) {

--- a/genesyscloud/idp_gsuite/genesyscloud_idp_gsuite_proxy.go
+++ b/genesyscloud/idp_gsuite/genesyscloud_idp_gsuite_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_test.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIdpGsuite(t *testing.T) {

--- a/genesyscloud/idp_okta/genesyscloud_idp_okta_proxy.go
+++ b/genesyscloud/idp_okta/genesyscloud_idp_okta_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_test.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIdpOkta(t *testing.T) {

--- a/genesyscloud/idp_onelogin/genesyscloud_idp_onelogin_proxy.go
+++ b/genesyscloud/idp_onelogin/genesyscloud_idp_onelogin_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_test.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIdpOnelogin(t *testing.T) {

--- a/genesyscloud/idp_ping/genesyscloud_idp_ping_proxy.go
+++ b/genesyscloud/idp_ping/genesyscloud_idp_ping_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_test.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIdpPing(t *testing.T) {

--- a/genesyscloud/idp_salesforce/genesyscloud_idp_salesforce_proxy.go
+++ b/genesyscloud/idp_salesforce/genesyscloud_idp_salesforce_proxy.go
@@ -3,7 +3,7 @@ package idp_salesforce
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_test.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceIdpSalesforce(t *testing.T) {

--- a/genesyscloud/integration/genesyscloud_integration_proxy.go
+++ b/genesyscloud/integration/genesyscloud_integration_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration/resource_genesyscloud_integration_test.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/integration/resource_genesyscloud_integration_utils.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_utils.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_action/genesyscloud_integration_action_proxy.go
+++ b/genesyscloud/integration_action/genesyscloud_integration_action_proxy.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_test.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 )

--- a/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
+++ b/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_test.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_custom_auth_action/genesyscloud_integration_custom_auth_action_proxy.go
+++ b/genesyscloud/integration_custom_auth_action/genesyscloud_integration_custom_auth_action_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_test.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type customAuthActionResource struct {

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_utils.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_utils.go
@@ -6,7 +6,7 @@ import (
 	integrationAction "terraform-provider-genesyscloud/genesyscloud/integration_action"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_facebook/genesyscloud_integration_facebook_proxy.go
+++ b/genesyscloud/integration_facebook/genesyscloud_integration_facebook_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_test.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_unit_test.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_unit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_utils.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map.go
+++ b/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceJourneyActionMapRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/journey_action_map/genesyscloud_journey_action_map_init_test.go
+++ b/genesyscloud/journey_action_map/genesyscloud_journey_action_map_init_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/journey_action_map/genesyscloud_journey_action_map_proxy.go
+++ b/genesyscloud/journey_action_map/genesyscloud_journey_action_map_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllJourneyActionMaps(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_test.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceJourneyActionMapActionMediaTypes(t *testing.T) {

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func flattenActionMap(d *schema.ResourceData, actionMap *platformclientv2.Actionmap) {

--- a/genesyscloud/journey_action_template/data_source_genesyscloud_journey_action_template.go
+++ b/genesyscloud/journey_action_template/data_source_genesyscloud_journey_action_template.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceJourneyActionTemplateRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/journey_action_template/genesyscloud_journey_action_template_init_test.go
+++ b/genesyscloud/journey_action_template/genesyscloud_journey_action_template_init_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/journey_action_template/genesyscloud_journey_action_template_proxy.go
+++ b/genesyscloud/journey_action_template/genesyscloud_journey_action_template_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllJourneyActionTemplates(_ context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_test.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceJourneyActionTemplate(t *testing.T) {

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_utils.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_utils.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/typeconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // All buildSdkPatch*  functions are helper method which maps Create operation of journeyApi's Actiontemplates

--- a/genesyscloud/journey_outcome_predictor/genesyscloud_journey_outcome_predictor_proxy.go
+++ b/genesyscloud/journey_outcome_predictor/genesyscloud_journey_outcome_predictor_proxy.go
@@ -3,7 +3,7 @@ package journey_outcome_predictor
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor.go
+++ b/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor_test.go
+++ b/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceJourneyOutcomePredictor(t *testing.T) {

--- a/genesyscloud/journey_views/genesyscloud_journey_views_proxy.go
+++ b/genesyscloud/journey_views/genesyscloud_journey_views_proxy.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *journeyViewsProxy

--- a/genesyscloud/journey_views/resource_genesyscloud_journey_views.go
+++ b/genesyscloud/journey_views/resource_genesyscloud_journey_views.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllJourneyViews(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/journey_views/resource_genesyscloud_journey_views_test.go
+++ b/genesyscloud/journey_views/resource_genesyscloud_journey_views_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceJourneyViewsBasic(t *testing.T) {

--- a/genesyscloud/journey_views/resource_genesyscloud_journey_views_utils.go
+++ b/genesyscloud/journey_views/resource_genesyscloud_journey_views_utils.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildElements(d *schema.ResourceData) (*[]platformclientv2.Journeyviewelement, error) {

--- a/genesyscloud/knowledge/resource_genesyscloud_knowledge_document_variation_test.go
+++ b/genesyscloud/knowledge/resource_genesyscloud_knowledge_document_variation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceKnowledgeDocumentVariationBasic(t *testing.T) {
@@ -382,12 +382,12 @@ func testVerifyKnowledgeDocumentVariationDestroyed(state *terraform.State) error
 		knowledgeDocumentVariationId := id[0]
 		knowledgeBaseId := id[1]
 		knowledgeDocumentId := id[2]
-		publishedKnowledgeDocumentVariation, publishedResp, publishedErr := knowledgeAPI.GetKnowledgeKnowledgebaseDocumentVariation(knowledgeDocumentVariationId, knowledgeDocumentId, knowledgeBaseId, "Published")
+		publishedKnowledgeDocumentVariation, publishedResp, publishedErr := knowledgeAPI.GetKnowledgeKnowledgebaseDocumentVariation(knowledgeDocumentVariationId, knowledgeDocumentId, knowledgeBaseId, "Published", nil)
 		// check both published and draft variations
 		if publishedKnowledgeDocumentVariation != nil {
 			return fmt.Errorf("Knowledge document variation (%s) still exists", knowledgeDocumentVariationId)
 		} else if util.IsStatus404(publishedResp) || util.IsStatus400(publishedResp) {
-			draftKnowledgeDocumentVariation, draftResp, draftErr := knowledgeAPI.GetKnowledgeKnowledgebaseDocumentVariation(knowledgeDocumentVariationId, knowledgeDocumentId, knowledgeBaseId, "Draft")
+			draftKnowledgeDocumentVariation, draftResp, draftErr := knowledgeAPI.GetKnowledgeKnowledgebaseDocumentVariation(knowledgeDocumentVariationId, knowledgeDocumentId, knowledgeBaseId, "Draft", nil)
 
 			if draftKnowledgeDocumentVariation != nil {
 				return fmt.Errorf("Knowledge document variation (%s) still exists", knowledgeDocumentVariationId)

--- a/genesyscloud/knowledge_category/genesyscloud_knowledge_category_proxy.go
+++ b/genesyscloud/knowledge_category/genesyscloud_knowledge_category_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *knowledgeCategoryProxy

--- a/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category.go
+++ b/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllKnowledgeCategories(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_test.go
+++ b/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceKnowledgeCategoryBasic(t *testing.T) {

--- a/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_utils.go
+++ b/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_utils.go
@@ -3,7 +3,7 @@ package knowledge_category
 import (
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildKnowledgeCategoryUpdate(categoryIn map[string]interface{}) *platformclientv2.Categoryupdaterequest {

--- a/genesyscloud/knowledge_document/genesyscloud_knowledge_document_proxy.go
+++ b/genesyscloud/knowledge_document/genesyscloud_knowledge_document_proxy.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"net/url"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	resourceExporter "terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *knowledgeDocumentProxy

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllKnowledgeDocuments(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_test.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceKnowledgeDocumentBasic(t *testing.T) {

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_utils.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_utils.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildDocumentAlternatives(requestIn map[string]interface{}) *[]platformclientv2.Knowledgedocumentalternative {

--- a/genesyscloud/knowledge_label/data_source_genesyscloud_knowledge_label.go
+++ b/genesyscloud/knowledge_label/data_source_genesyscloud_knowledge_label.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceKnowledgeLabelRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/knowledge_label/genesyscloud_knowledge_label_proxy.go
+++ b/genesyscloud/knowledge_label/genesyscloud_knowledge_label_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *knowledgeLabelProxy

--- a/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label.go
+++ b/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllKnowledgeLabels(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_test.go
+++ b/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceKnowledgeLabelBasic(t *testing.T) {

--- a/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_utils.go
+++ b/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_utils.go
@@ -1,7 +1,7 @@
 package knowledge_label
 
 import (
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildKnowledgeLabel(labelIn map[string]interface{}) platformclientv2.Labelcreaterequest {

--- a/genesyscloud/location/data_source_genesyscloud_location.go
+++ b/genesyscloud/location/data_source_genesyscloud_location.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceLocationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/location/genesyscloud_location_proxy.go
+++ b/genesyscloud/location/genesyscloud_location_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *locationProxy

--- a/genesyscloud/location/resource_genesyscloud_location.go
+++ b/genesyscloud/location/resource_genesyscloud_location.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllLocations(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/location/resource_genesyscloud_location_test.go
+++ b/genesyscloud/location/resource_genesyscloud_location_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceLocationBasic(t *testing.T) {

--- a/genesyscloud/location/resource_genesyscloud_location_utils.go
+++ b/genesyscloud/location/resource_genesyscloud_location_utils.go
@@ -7,7 +7,7 @@ import (
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllOAuthClients(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_proxy.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_proxy.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *oauthClientProxy

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_utils.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_utils.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildOAuthRedirectURIs(d *schema.ResourceData) *[]string {

--- a/genesyscloud/oauth_client/resource_genesyscloude_oauth_client_unit_test.go
+++ b/genesyscloud/oauth_client/resource_genesyscloude_oauth_client_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/organization_authentication_settings/genesyscloud_organization_authentication_settings_proxy.go
+++ b/genesyscloud/organization_authentication_settings/genesyscloud_organization_authentication_settings_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_utils.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_utils.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/orgauthorization_pairing/genesyscloud_orgauthorization_pairing_proxy.go
+++ b/genesyscloud/orgauthorization_pairing/genesyscloud_orgauthorization_pairing_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *orgauthorizationPairingProxy

--- a/genesyscloud/orgauthorization_pairing/resource_genesyscloud_orgauthorization_pairing.go
+++ b/genesyscloud/orgauthorization_pairing/resource_genesyscloud_orgauthorization_pairing.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func createOrgauthorizationPairing(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/outbound/data_source_genesyscloud_outbound_messagingcampaign.go
+++ b/genesyscloud/outbound/data_source_genesyscloud_outbound_messagingcampaign.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceOutboundMessagingcampaignRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/outbound/data_source_genesyscloud_outbound_messagingcampaign_test.go
+++ b/genesyscloud/outbound/data_source_genesyscloud_outbound_messagingcampaign_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound/genesyscloud_outbound_messagingcampaign_unit_test.go
+++ b/genesyscloud/outbound/genesyscloud_outbound_messagingcampaign_unit_test.go
@@ -2,11 +2,12 @@ package outbound
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
-	"github.com/stretchr/testify/assert"
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestUnitFlattenEmailConfig(t *testing.T) {

--- a/genesyscloud/outbound/genesyscloud_outbound_messagingcampaign_utils.go
+++ b/genesyscloud/outbound/genesyscloud_outbound_messagingcampaign_utils.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func gatherExtraErrorMessagesFromResponseBody(resp *platformclientv2.APIResponse) (string, error) {

--- a/genesyscloud/outbound/resource_genesyscloud_outbound_messagingcampaign.go
+++ b/genesyscloud/outbound/resource_genesyscloud_outbound_messagingcampaign.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllOutboundMessagingcampaign(_ context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound/resource_genesyscloud_outbound_messagingcampaign_test.go
+++ b/genesyscloud/outbound/resource_genesyscloud_outbound_messagingcampaign_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	obCallableTimeset "terraform-provider-genesyscloud/genesyscloud/outbound_callabletimeset"
 	obContactList "terraform-provider-genesyscloud/genesyscloud/outbound_contact_list"

--- a/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func DataSourceOutboundAttemptLimit() *schema.Resource {

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 const (

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // func init() {

--- a/genesyscloud/outbound_callabletimeset/genesyscloud_outbound_callabletimeset_proxy.go
+++ b/genesyscloud/outbound_callabletimeset/genesyscloud_outbound_callabletimeset_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_test.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundCallabletimeset(t *testing.T) {

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_utils.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callanalysisresponseset/genesyscloud_outbound_callanalysisresponseset_proxy.go
+++ b/genesyscloud/outbound_callanalysisresponseset/genesyscloud_outbound_callanalysisresponseset_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_test.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundCallAnalysisResponseSet(t *testing.T) {

--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_utils.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getResponseSetFromResourceData(d *schema.ResourceData) platformclientv2.Responseset {

--- a/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
+++ b/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
@@ -19,7 +19,7 @@ import (
 	telephonyProvidersEdgesSite "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_proxy.go
+++ b/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_proxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_test.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // Add a special generator DEVENGAGE-1646.  Basically, the API makes it look like you need a full phone_columns field here.  However, the API ignores the type because the devs reused the phone_columns object.  However,

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaignrule/data_source_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/outbound_campaignrule/data_source_genesyscloud_outbound_campaignrule.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceOutboundCampaignruleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/outbound_campaignrule/genesyscloud_outbound_campaignrule_proxy.go
+++ b/genesyscloud/outbound_campaignrule/genesyscloud_outbound_campaignrule_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllAuthCampaignRules(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_test.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundCampaignRuleBasic(t *testing.T) {

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_utils.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_utils.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getCampaignruleFromResourceData(d *schema.ResourceData) platformclientv2.Campaignrule {

--- a/genesyscloud/outbound_contact_list/genesyscloud_outbound_contact_list_proxy.go
+++ b/genesyscloud/outbound_contact_list/genesyscloud_outbound_contact_list_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllOutboundContactLists(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_test.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundContactListBasic(t *testing.T) {

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildSdkOutboundContactListContactPhoneNumberColumnSlice(contactPhoneNumberColumn *schema.Set) *[]platformclientv2.Contactphonenumbercolumn {

--- a/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
+++ b/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var contactCache = rc.NewResourceCache[platformclientv2.Dialercontact]()

--- a/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
+++ b/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllContacts(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact_utils.go
+++ b/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact_utils.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // buildWritableContactFromResourceData used to build the request body for contact creation

--- a/genesyscloud/outbound_contact_list_template/genesyscloud_outbound_contact_list_template_proxy.go
+++ b/genesyscloud/outbound_contact_list_template/genesyscloud_outbound_contact_list_template_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllOutboundContactListTemplates(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_test.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundContactListTemplateBasic(t *testing.T) {

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_utils.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildSdkOutboundContactListTemplateContactPhoneNumberColumnSlice(contactPhoneNumberColumn *schema.Set) *[]platformclientv2.Contactphonenumbercolumn {

--- a/genesyscloud/outbound_contactlistfilter/genesyscloud_outbound_contactlistfilter_proxy.go
+++ b/genesyscloud/outbound_contactlistfilter/genesyscloud_outbound_contactlistfilter_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter.go
+++ b/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_test.go
+++ b/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundContactListFilter(t *testing.T) {

--- a/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_utils.go
+++ b/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_utils.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getContactlistfilterFromResourceData(d *schema.ResourceData) platformclientv2.Contactlistfilter {

--- a/genesyscloud/outbound_digitalruleset/genesyscloud_outbound_digitalruleset_proxy.go
+++ b/genesyscloud/outbound_digitalruleset/genesyscloud_outbound_digitalruleset_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_test.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_utils.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_utils.go
@@ -10,7 +10,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_dnclist/genesyscloud_outbound_dnclist_proxy.go
+++ b/genesyscloud/outbound_dnclist/genesyscloud_outbound_dnclist_proxy.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *outboundDnclistProxy

--- a/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist.go
+++ b/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllOutboundDncLists(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_test.go
+++ b/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundDncListRdsListType(t *testing.T) {

--- a/genesyscloud/outbound_filespecificationtemplate/genesyscloud_outbound_filespecificationtemplate_proxy.go
+++ b/genesyscloud/outbound_filespecificationtemplate/genesyscloud_outbound_filespecificationtemplate_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate.go
+++ b/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllFileSpecificationTemplates(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_test.go
+++ b/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundFileSpecificationTemplate(t *testing.T) {

--- a/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_utils.go
+++ b/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_utils.go
@@ -4,7 +4,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getFilespecificationtemplateFromResourceData(d *schema.ResourceData) platformclientv2.Filespecificationtemplate {

--- a/genesyscloud/outbound_ruleset/genesyscloud_outbound_ruleset_proxy.go
+++ b/genesyscloud/outbound_ruleset/genesyscloud_outbound_ruleset_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_test.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	obContactList "terraform-provider-genesyscloud/genesyscloud/outbound_contact_list"
 )

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_unit_test.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_unit_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestUnitDoesRuleConditionsRefDeletedSkill(t *testing.T) {

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_utils.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_utils.go
@@ -10,7 +10,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_init_test.go
+++ b/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_init_test.go
@@ -16,7 +16,7 @@ import (
 
 	authDivision "terraform-provider-genesyscloud/genesyscloud/auth_division"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_proxy.go
+++ b/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_test.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceOutboundSequence(t *testing.T) {

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_utils.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_settings/genesyscloud_outbound_settings_proxy.go
+++ b/genesyscloud/outbound_settings/genesyscloud_outbound_settings_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_utils.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildOutboundSettingsAutomaticTimeZoneMapping(d *schema.ResourceData) *platformclientv2.Automatictimezonemappingsettings {

--- a/genesyscloud/outbound_wrapupcode_mappings/genesyscloud_wrapupcode_mappings_proxy.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/genesyscloud_wrapupcode_mappings_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *outboundWrapupCodeMappingsProxy

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcode_mappings_utils.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcode_mappings_utils.go
@@ -4,7 +4,7 @@ import (
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // flattenOutboundWrapupCodeMappings maps a Genesys Cloud Wrapupcodemapping to a schema.Set

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // getOutboundWrapupCodeMappings is used by the exporter to return all wrapupcode mappings

--- a/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type ProcessAutomationTriggers struct {

--- a/genesyscloud/process_automation_trigger/process_automation_triggers_proxy.go
+++ b/genesyscloud/process_automation_trigger/process_automation_triggers_proxy.go
@@ -11,7 +11,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func postProcessAutomationTrigger(pat *ProcessAutomationTrigger, api *platformclientv2.IntegrationsApi) (*ProcessAutomationTrigger, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
+++ b/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
@@ -3,7 +3,7 @@ package process_automation_trigger
 import (
 	"encoding/json"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type ProcessAutomationTrigger struct {

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -13,7 +13,7 @@ import (
 
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceProcessAutomationTrigger(t *testing.T) {

--- a/genesyscloud/provider/division.go
+++ b/genesyscloud/provider/division.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type JsonMap map[string]interface{}

--- a/genesyscloud/provider/provider.go
+++ b/genesyscloud/provider/provider.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var orgDefaultCountryCode string

--- a/genesyscloud/provider/sdk_client_pool.go
+++ b/genesyscloud/provider/sdk_client_pool.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // SDKClientPool holds a Pool of client configs for the Genesys Cloud SDK. One should be

--- a/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_init_test.go
+++ b/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_init_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_proxy.go
+++ b/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_proxy.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_test.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_utils.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_utils.go
@@ -10,7 +10,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/resource_cache/datasource_cache.go
+++ b/genesyscloud/resource_cache/datasource_cache.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // Cache for Data Sources

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 

--- a/genesyscloud/resource_exporter/resource_exporter_custom.go
+++ b/genesyscloud/resource_exporter/resource_exporter_custom.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/resource_genesyscloud_init_test.go
+++ b/genesyscloud/resource_genesyscloud_init_test.go
@@ -25,7 +25,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_journey_outcome.go
+++ b/genesyscloud/resource_genesyscloud_journey_outcome.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_journey_outcome_test.go
+++ b/genesyscloud/resource_genesyscloud_journey_outcome_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceJourneyOutcome(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_journey_segment.go
+++ b/genesyscloud/resource_genesyscloud_journey_segment.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_journey_segment_test.go
+++ b/genesyscloud/resource_genesyscloud_journey_segment_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceJourneySegment(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_knowledgebase.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllKnowledgeKnowledgebases(_ context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/resource_genesyscloud_knowledge_knowledgebase_test.go
+++ b/genesyscloud/resource_genesyscloud_knowledge_knowledgebase_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceKnowledgeKnowledgebaseBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_evaluation.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/resource_genesyscloud_quality_forms_evaluation_test.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_evaluation_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceEvaluationFormBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_survey.go
@@ -18,7 +18,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type SurveyFormStruct struct {

--- a/genesyscloud/resource_genesyscloud_quality_forms_survey_test.go
+++ b/genesyscloud/resource_genesyscloud_quality_forms_survey_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceSurveyFormBasic(t *testing.T) {

--- a/genesyscloud/resource_genesyscloud_widget_deployment.go
+++ b/genesyscloud/resource_genesyscloud_widget_deployment.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 const (

--- a/genesyscloud/resource_genesyscloud_widget_deployment_test.go
+++ b/genesyscloud/resource_genesyscloud_widget_deployment_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type widgetDeploymentConfig struct {

--- a/genesyscloud/responsemanagement_library/genesyscloud_responsemanagement_library_proxy.go
+++ b/genesyscloud/responsemanagement_library/genesyscloud_responsemanagement_library_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library.go
+++ b/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library_test.go
+++ b/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceResponseManagementLibrary(t *testing.T) {

--- a/genesyscloud/responsemanagement_response/genesyscloud_responsemanagement_response_proxy.go
+++ b/genesyscloud/responsemanagement_response/genesyscloud_responsemanagement_response_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_test.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceResponseManagementResponseFooterField(t *testing.T) {

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_utils.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getResponseFromResourceData(d *schema.ResourceData) platformclientv2.Response {

--- a/genesyscloud/responsemanagement_responseasset/genesyscloud_responsemanagement_responseasset_proxy.go
+++ b/genesyscloud/responsemanagement_responseasset/genesyscloud_responsemanagement_responseasset_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_test.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceResponseManagementResponseAsset(t *testing.T) {

--- a/genesyscloud/routing_email_domain/data_source_genesyscloud_routing_email_domain_test.go
+++ b/genesyscloud/routing_email_domain/data_source_genesyscloud_routing_email_domain_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccDataSourceRoutingEmailDomain(t *testing.T) {

--- a/genesyscloud/routing_email_domain/genesyscloud_routing_email_domain_proxy.go
+++ b/genesyscloud/routing_email_domain/genesyscloud_routing_email_domain_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *routingEmailDomainProxy

--- a/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain.go
+++ b/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllRoutingEmailDomains(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain_test.go
+++ b/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingEmailDomainSub(t *testing.T) {

--- a/genesyscloud/routing_email_route/genesyscloud_routing_email_route_proxy.go
+++ b/genesyscloud/routing_email_route/genesyscloud_routing_email_route_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingEmailRoute(t *testing.T) {

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_language/genesyscloud_routing_language_proxy.go
+++ b/genesyscloud/routing_language/genesyscloud_routing_language_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *routingLanguageProxy

--- a/genesyscloud/routing_language/resource_genesyscloud_routing_language.go
+++ b/genesyscloud/routing_language/resource_genesyscloud_routing_language.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllRoutingLanguages(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_language/resource_genesyscloud_routing_language_test.go
+++ b/genesyscloud/routing_language/resource_genesyscloud_routing_language_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingLanguageBasic(t *testing.T) {

--- a/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
+++ b/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var bullseyeExpansionTypeTimeout = "TIMEOUT_SECONDS"

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_members.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_members.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var ctx = context.Background()

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // Build Functions

--- a/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_proxy.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	routingQueue "terraform-provider-genesyscloud/genesyscloud/routing_queue"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_test.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_queue_outbound_email_address/genesyscloud_routing_queue_outbound_email_address_proxy.go
+++ b/genesyscloud/routing_queue_outbound_email_address/genesyscloud_routing_queue_outbound_email_address_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	routingQueue "terraform-provider-genesyscloud/genesyscloud/routing_queue"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_test.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingQueueOutboundEmailAddress(t *testing.T) {

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_unit_test.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils.go
@@ -1,6 +1,6 @@
 package routing_queue_outbound_email_address
 
-import "github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+import "github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 func isQueueEmailAddressEmpty(qea *platformclientv2.Queueemailaddress) bool {
 	if qea == nil {

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils_unit_test.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils_unit_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_settings/genesyscloud_routing_settings_proxy.go
+++ b/genesyscloud/routing_settings/genesyscloud_routing_settings_proxy.go
@@ -3,7 +3,7 @@ package routing_settings
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *routingSettingsProxy

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllRoutingSettings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_skill/genesyscloud_routing_skill_proxy.go
+++ b/genesyscloud/routing_skill/genesyscloud_routing_skill_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type getAllRoutingSkillsFunc func(ctx context.Context, p *routingSkillProxy, name string) (*[]platformclientv2.Routingskill, *platformclientv2.APIResponse, error)

--- a/genesyscloud/routing_skill/resource_genesyscloud_routing_skill.go
+++ b/genesyscloud/routing_skill/resource_genesyscloud_routing_skill.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func GetAllRoutingSkills(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_skill/resource_genesyscloud_routing_skill_test.go
+++ b/genesyscloud/routing_skill/resource_genesyscloud_routing_skill_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingSkillBasic(t *testing.T) {

--- a/genesyscloud/routing_skill_group/genesyscloud_routing_skill_group_proxy.go
+++ b/genesyscloud/routing_skill_group/genesyscloud_routing_skill_group_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *routingSkillGroupsProxy

--- a/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group.go
+++ b/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllRoutingSkillGroups(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group_test.go
+++ b/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func testAccCheckSkillConditions(resourcePath string, targetSkillConditionJson string) resource.TestCheckFunc {

--- a/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_proxy.go
+++ b/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // Type definitions for each func on our proxy so we can easily mock them out later

--- a/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
+++ b/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 const ResourceType = "genesyscloud_routing_sms_address"

--- a/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses_test.go
+++ b/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingSmsAddresses(t *testing.T) {

--- a/genesyscloud/routing_utilization/genesyscloud_routing_utilization_proxy.go
+++ b/genesyscloud/routing_utilization/genesyscloud_routing_utilization_proxy.go
@@ -3,7 +3,7 @@ package routing_utilization
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *routingUtilizationProxy

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllRoutingUtilization(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingUtilizationBasic(t *testing.T) {

--- a/genesyscloud/routing_utilization/resource_routing_utilization_utils.go
+++ b/genesyscloud/routing_utilization/resource_routing_utilization_utils.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func BuildSdkMediaUtilizations(d *schema.ResourceData) *map[string]platformclientv2.Mediautilization {

--- a/genesyscloud/routing_utilization_label/data_source_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/routing_utilization_label/data_source_genesyscloud_routing_utilization_label_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccDataSourceRoutingUtilizationLabel(t *testing.T) {

--- a/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_init_test.go
+++ b/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_init_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_proxy.go
+++ b/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *routingUtilizationLabelProxy

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllRoutingUtilizationLabels(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingUtilizationLabelBasic(t *testing.T) {

--- a/genesyscloud/routing_wrapupcode/genesyscloud_routing_wrapupcode_proxy.go
+++ b/genesyscloud/routing_wrapupcode/genesyscloud_routing_wrapupcode_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode.go
+++ b/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllRoutingWrapupCodes(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode_test.go
+++ b/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceRoutingWrapupcode(t *testing.T) {

--- a/genesyscloud/scripts/genesyscloud_scripts_proxy.go
+++ b/genesyscloud/scripts/genesyscloud_scripts_proxy.go
@@ -14,7 +14,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/files"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/scripts/resource_genesyscloud_script.go
+++ b/genesyscloud/scripts/resource_genesyscloud_script.go
@@ -12,7 +12,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/genesyscloud/scripts/resource_genesyscloud_script_test.go
+++ b/genesyscloud/scripts/resource_genesyscloud_script_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/station/genesyscloud_station_init_test.go
+++ b/genesyscloud/station/genesyscloud_station_init_test.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 	edgePhone "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_phone"

--- a/genesyscloud/station/genesyscloud_station_proxy.go
+++ b/genesyscloud/station/genesyscloud_station_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
+++ b/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin.go
+++ b/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin_test.go
+++ b/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin_test.go
@@ -12,7 +12,7 @@ import (
 	authDivision "terraform-provider-genesyscloud/genesyscloud/auth_division"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem/genesyscloud_task_management_workitem_proxy.go
+++ b/genesyscloud/task_management_workitem/genesyscloud_task_management_workitem_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_test.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_test.go
@@ -29,7 +29,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_unit_test.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_unit_test.go
@@ -16,7 +16,7 @@ import (
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_utils.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_utils.go
@@ -11,7 +11,7 @@ import (
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem_schema/genesyscloud_task_management_workitem_schema_proxy.go
+++ b/genesyscloud/task_management_workitem_schema/genesyscloud_task_management_workitem_schema_proxy.go
@@ -10,7 +10,7 @@ import (
 
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_test.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_test.go
@@ -15,7 +15,7 @@ import (
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_unit_test.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_unit_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_utils.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 const (

--- a/genesyscloud/task_management_worktype/genesyscloud_task_management_worktype_proxy.go
+++ b/genesyscloud/task_management_worktype/genesyscloud_task_management_worktype_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_test.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_test.go
@@ -17,7 +17,7 @@ import (
 	workitemSchema "terraform-provider-genesyscloud/genesyscloud/task_management_workitem_schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_utils.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_utils.go
@@ -6,7 +6,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_status/genesyscloud_task_management_worktype_status_proxy.go
+++ b/genesyscloud/task_management_worktype_status/genesyscloud_task_management_worktype_status_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	taskManagementWorktype "terraform-provider-genesyscloud/genesyscloud/task_management_worktype"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status.go
+++ b/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_test.go
+++ b/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 

--- a/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_util.go
+++ b/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_util.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // ModifyStatusIdStateValue will change the statusId before it is saved in the state file.

--- a/genesyscloud/team/genesyscloud_team_proxy.go
+++ b/genesyscloud/team/genesyscloud_team_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/team/resource_genesyscloud_team.go
+++ b/genesyscloud/team/resource_genesyscloud_team.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 

--- a/genesyscloud/team/resource_genesyscloud_team_test.go
+++ b/genesyscloud/team/resource_genesyscloud_team_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	authDivision "terraform-provider-genesyscloud/genesyscloud/auth_division"
 

--- a/genesyscloud/team/resource_genesyscloud_team_unit_test.go
+++ b/genesyscloud/team/resource_genesyscloud_team_unit_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/team/resource_genesyscloud_team_utils.go
+++ b/genesyscloud/team/resource_genesyscloud_team_utils.go
@@ -12,7 +12,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/chunks"
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // getTeamFromResourceData maps data from schema ResourceData object to a platformclientv2.Team

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/genesyscloud_telephony_providers_trunkbasesettings_proxy.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/genesyscloud_telephony_providers_trunkbasesettings_proxy.go
@@ -12,7 +12,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *trunkbaseSettingProxy

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func createTrunkBaseSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceTrunkBaseSettings(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 // getAllDidPools retrieves all DID pools and is used for the exporter

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_test.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceDidPoolBasic(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_utils.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_utils.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type DidPoolStruct struct {

--- a/genesyscloud/telephony_providers_edges_edge_group/genesyscloud_telephony_providers_edges_edge_group_proxy.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/genesyscloud_telephony_providers_edges_edge_group_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *edgeGroupProxy

--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func createEdgeGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_test.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceEdgeGroup(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_utils.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_utils.go
@@ -6,7 +6,7 @@ import (
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildSdkTrunkBases(d *schema.ResourceData) *[]platformclientv2.Trunkbase {

--- a/genesyscloud/telephony_providers_edges_extension_pool/genesyscloud_telephony_providers_edges_extension_pool_proxy.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/genesyscloud_telephony_providers_edges_extension_pool_proxy.go
@@ -3,7 +3,7 @@ package telephony_providers_edges_extension_pool
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *extensionPoolProxy

--- a/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllExtensionPools(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_test.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceExtensionPoolBasic(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_utils.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_utils.go
@@ -5,7 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type ExtensionPoolStruct struct {

--- a/genesyscloud/telephony_providers_edges_linebasesettings/data_source_genesyscloud_telephony_providers_edges_linebasesettings.go
+++ b/genesyscloud/telephony_providers_edges_linebasesettings/data_source_genesyscloud_telephony_providers_edges_linebasesettings.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceLineBaseSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
@@ -12,7 +12,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/user"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_proxy.go
+++ b/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_proxy.go
@@ -8,7 +8,7 @@ import (
 
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllPhones(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourcePhoneBasic(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type PhoneConfig struct {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/data_source_genesyscloud_telephony_providers_edges_phonebasesettings.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/data_source_genesyscloud_telephony_providers_edges_phonebasesettings.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourcePhoneBaseSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/genesyscloud_telephony_providers_edges_phonebasesettings_proxy.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/genesyscloud_telephony_providers_edges_phonebasesettings_proxy.go
@@ -3,7 +3,7 @@ package telephony_providers_edges_phonebasesettings
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *phoneBaseProxy

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func createPhoneBaseSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_test.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourcePhoneBaseSettings(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_unit_test.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_unit_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_utils.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_utils.go
@@ -9,7 +9,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func generatePhoneBaseSettingsDataSource(

--- a/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site_test.go
@@ -8,7 +8,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceSite(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/leekchan/timeutil"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
@@ -10,7 +10,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_init_test.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_init_test.go
@@ -12,7 +12,7 @@ import (
 	gcloud "terraform-provider-genesyscloud/genesyscloud"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	telephonyProvidersEdgesSite "terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllSitesAndOutboundRoutes(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_utils.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildOutboundRoutes(d *schema.ResourceData) *platformclientv2.Outboundroutebase {

--- a/genesyscloud/telephony_providers_edges_trunk/data_source_genesyscloud_telephony_providers_edges_trunk.go
+++ b/genesyscloud/telephony_providers_edges_trunk/data_source_genesyscloud_telephony_providers_edges_trunk.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func dataSourceTrunkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_trunk/genesyscloud_telephony_providers_edges_trunk_proxy.go
+++ b/genesyscloud/telephony_providers_edges_trunk/genesyscloud_telephony_providers_edges_trunk_proxy.go
@@ -3,7 +3,7 @@ package telephony_providers_edges_trunk
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 //generate a proxy for telephony_providers_edges_trunk

--- a/genesyscloud/telephony_providers_edges_trunk/resource_genesyscloud_telephony_providers_edges_trunk.go
+++ b/genesyscloud/telephony_providers_edges_trunk/resource_genesyscloud_telephony_providers_edges_trunk.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func createTrunk(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -33,7 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/mohae/deepcopy"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
@@ -9,7 +9,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -29,7 +29,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 
 	"terraform-provider-genesyscloud/genesyscloud/util/testrunner"
 

--- a/genesyscloud/user/data_source_genesyscloud_user.go
+++ b/genesyscloud/user/data_source_genesyscloud_user.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var (

--- a/genesyscloud/user/genesyscloud_user_proxy.go
+++ b/genesyscloud/user/genesyscloud_user_proxy.go
@@ -8,7 +8,7 @@ import (
 	rc "terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 /*

--- a/genesyscloud/user/resource_genesyscloud_user.go
+++ b/genesyscloud/user/resource_genesyscloud_user.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type agentUtilizationWithLabels struct {

--- a/genesyscloud/user/resource_genesyscloud_user_test.go
+++ b/genesyscloud/user/resource_genesyscloud_user_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceUserBasic(t *testing.T) {

--- a/genesyscloud/user/resource_genesyscloud_user_utils.go
+++ b/genesyscloud/user/resource_genesyscloud_user_utils.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/user_roles/genesyscloud_user_roles_proxy.go
+++ b/genesyscloud/user_roles/genesyscloud_user_roles_proxy.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *userRolesProxy

--- a/genesyscloud/user_roles/resource_genesyscloud_user_roles_utils.go
+++ b/genesyscloud/user_roles/resource_genesyscloud_user_roles_utils.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func flattenSubjectRoles(d *schema.ResourceData, p *userRolesProxy) (*schema.Set, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/util/resourcedata/resourcedata.go
+++ b/genesyscloud/util/resourcedata/resourcedata.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/leekchan/timeutil"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 const (

--- a/genesyscloud/util/util_basesetting_properties.go
+++ b/genesyscloud/util/util_basesetting_properties.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func BuildTelephonyProperties(d *schema.ResourceData) *map[string]interface{} {

--- a/genesyscloud/util/util_diagnostic_unit_test.go
+++ b/genesyscloud/util/util_diagnostic_unit_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/util/util_diagnostics.go
+++ b/genesyscloud/util/util_diagnostics.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type detailedDiagnosticInfo struct {

--- a/genesyscloud/util/util_divisions.go
+++ b/genesyscloud/util/util_divisions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type JsonMap map[string]interface{}

--- a/genesyscloud/util/util_domainentities.go
+++ b/genesyscloud/util/util_domainentities.go
@@ -4,7 +4,7 @@ import (
 	lists "terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func BuildSdkDomainEntityRef(d *schema.ResourceData, idAttr string) *platformclientv2.Domainentityref {

--- a/genesyscloud/util/util_retries.go
+++ b/genesyscloud/util/util_retries.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func WithRetries(ctx context.Context, timeout time.Duration, method func() *retry.RetryError) diag.Diagnostics {

--- a/genesyscloud/webdeployments_configuration/genesyscloud_webdeployments_configuration_proxy.go
+++ b/genesyscloud/webdeployments_configuration/genesyscloud_webdeployments_configuration_proxy.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *webDeploymentsConfigurationProxy

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllWebDeploymentConfigurations(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
@@ -335,6 +335,12 @@ var (
 				Optional:    true,
 				Computed:    true,
 			},
+			"allow_draw": {
+				Description: "Whether drawing is enabled or not",
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Computed:    true,
+			},
 			"channels": {
 				Description: "List of channels through which cobrowse is available (for now only Webmessaging and Voice)",
 				Type:        schema.TypeList,

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
@@ -184,6 +184,7 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 						util.TrueValue,
 						util.TrueValue,
 						util.TrueValue,
+						util.TrueValue,
 						channels,
 						[]string{strconv.Quote("selector-one")},
 						[]string{strconv.Quote("selector-one")},
@@ -253,6 +254,7 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.enabled", util.TrueValue),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.allow_agent_control", util.TrueValue),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.allow_agent_navigation", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.allow_draw", util.TrueValue),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.channels.#", "1"),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.channels.0", "Webmessaging"),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.mask_selectors.#", "1"),
@@ -316,6 +318,7 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 						util.FalseValue,
 						util.FalseValue,
 						util.FalseValue,
+						util.FalseValue,
 						channelsUpdate,
 						[]string{strconv.Quote("selector-one"), strconv.Quote("selector-two")},
 						[]string{strconv.Quote("selector-one"), strconv.Quote("selector-two")},
@@ -345,6 +348,7 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.enabled", util.FalseValue),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.allow_agent_control", util.FalseValue),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.allow_agent_navigation", util.FalseValue),
+					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.allow_draw", util.FalseValue),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.channels.#", "2"),
 					util.ValidateStringInArray(resourcePath, "cobrowse.0.channels", "Webmessaging"),
 					util.ValidateStringInArray(resourcePath, "cobrowse.0.channels", "Voice"),
@@ -1048,19 +1052,20 @@ func complexConfigurationResource(name, description, kbId string, nestedBlocks .
 	`, name, description, kbId, strings.Join(nestedBlocks, "\n"))
 }
 
-func generateWebDeploymentConfigCobrowseSettings(cbEnabled, cbAllowAgentControl string, cbAllowAgentNavigation string, cbChannels []string, cbMaskSelectors []string, cbReadonlySelectors []string, pauseCriteriaBlocks ...string) string {
+func generateWebDeploymentConfigCobrowseSettings(cbEnabled, cbAllowAgentControl string, cbAllowAgentNavigation string, cbAllowDraw string, cbChannels []string, cbMaskSelectors []string, cbReadonlySelectors []string, pauseCriteriaBlocks ...string) string {
 
 	return fmt.Sprintf(`
 	cobrowse {
 		enabled = %s
 		allow_agent_control = %s
 		allow_agent_navigation = %s
+		allow_draw = %s
 		channels = [ %s ]
 		mask_selectors = [ %s ]
 		readonly_selectors = [ %s ]
 		%s
 	}
-`, cbEnabled, cbAllowAgentControl, cbAllowAgentNavigation, strings.Join(cbChannels, ", "), strings.Join(cbMaskSelectors, ", "), strings.Join(cbReadonlySelectors, ", "), strings.Join(pauseCriteriaBlocks, "\n"))
+`, cbEnabled, cbAllowAgentControl, cbAllowAgentNavigation, cbAllowDraw, strings.Join(cbChannels, ", "), strings.Join(cbMaskSelectors, ", "), strings.Join(cbReadonlySelectors, ", "), strings.Join(pauseCriteriaBlocks, "\n"))
 }
 
 func generatePauseCriteria(urlFragment, condition string) string {

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 type scCustomMessageConfig struct {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_journey.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_journey.go
@@ -4,7 +4,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildSelectorEventTriggers(triggers []interface{}) *[]platformclientv2.Selectoreventtrigger {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_messenger.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_messenger.go
@@ -4,7 +4,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildAppConversations(conversations []interface{}) *platformclientv2.Conversationappsettings {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_support_center.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_support_center.go
@@ -4,7 +4,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildSupportCenterHeroStyle(styles []interface{}) *platformclientv2.Supportcenterherostyle {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
@@ -26,6 +26,7 @@ func buildCobrowseSettings(d *schema.ResourceData) *platformclientv2.Cobrowseset
 	enabled, _ := cfg["enabled"].(bool)
 	allowAgentControl, _ := cfg["allow_agent_control"].(bool)
 	allowAgentNavigation, _ := cfg["allow_agent_navigation"].(bool)
+	allowDraw, _ := cfg["allow_draw"].(bool)
 	channels := lists.InterfaceListToStrings(cfg["channels"].([]interface{}))
 	maskSelectors := lists.InterfaceListToStrings(cfg["mask_selectors"].([]interface{}))
 	readonlySelectors := lists.InterfaceListToStrings(cfg["readonly_selectors"].([]interface{}))
@@ -47,6 +48,7 @@ func buildCobrowseSettings(d *schema.ResourceData) *platformclientv2.Cobrowseset
 		Enabled:              &enabled,
 		AllowAgentControl:    &allowAgentControl,
 		AllowAgentNavigation: &allowAgentNavigation,
+		AllowDraw:            &allowDraw,
 		Channels:             &channels,
 		MaskSelectors:        &maskSelectors,
 		ReadonlySelectors:    &readonlySelectors,
@@ -175,6 +177,7 @@ func FlattenCobrowseSettings(cobrowseSettings *platformclientv2.Cobrowsesettings
 		"enabled":                cobrowseSettings.Enabled,
 		"allow_agent_control":    cobrowseSettings.AllowAgentControl,
 		"allow_agent_navigation": cobrowseSettings.AllowAgentNavigation,
+		"allow_draw":             cobrowseSettings.AllowDraw,
 		"channels":               cobrowseSettings.Channels,
 		"mask_selectors":         cobrowseSettings.MaskSelectors,
 		"readonly_selectors":     cobrowseSettings.ReadonlySelectors,

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
@@ -7,7 +7,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func buildCobrowseSettings(d *schema.ResourceData) *platformclientv2.Cobrowsesettings {

--- a/genesyscloud/webdeployments_deployment/genesyscloud_webdeployments_deployment_proxy.go
+++ b/genesyscloud/webdeployments_deployment/genesyscloud_webdeployments_deployment_proxy.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 var internalProxy *webDeploymentsProxy

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func getAllWebDeployments(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func TestAccResourceWebDeploymentsDeployment(t *testing.T) {

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_utils.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_utils.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v146/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v149/platformclientv2"
 )
 
 func alwaysDifferent(k, old, new string, d *schema.ResourceData) bool {

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/leekchan/timeutil v0.0.0-20150802142658-28917288c48d
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/mozillazg/go-unidecode v0.2.0
-	github.com/mypurecloud/platform-client-sdk-go/v146 v146.0.0
+	github.com/mypurecloud/platform-client-sdk-go/v149 v149.0.0
 	github.com/nyaruka/phonenumbers v1.4.3
 	github.com/rjNemo/underscore v0.7.0
 	github.com/zclconf/go-cty v1.15.1
@@ -29,7 +29,6 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
-	github.com/mypurecloud/platform-client-sdk-go/v149 v149.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/hashicorp/cli v1.1.6 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mypurecloud/platform-client-sdk-go/v149 v149.0.0 // indirect
 	github.com/pelletier/go-toml/v2 v2.2.3 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/sagikazarmark/locafero v0.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -278,6 +278,8 @@ github.com/mozillazg/go-unidecode v0.2.0/go.mod h1:zB48+/Z5toiRolOZy9ksLryJ976VI
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mypurecloud/platform-client-sdk-go/v146 v146.0.0 h1:3ww0KjTVF35pyba/QL/JKFvnCtQHgD7GbnFcl7aMs1s=
 github.com/mypurecloud/platform-client-sdk-go/v146 v146.0.0/go.mod h1:ehOEmTtb5KCtfgUq5gBp08ntPOVX/Sqamgavv8Ewuyk=
+github.com/mypurecloud/platform-client-sdk-go/v149 v149.0.0 h1:df413CVT6G4gnSbeAuqLo4DWXZndsADdXzIaw6LB5/4=
+github.com/mypurecloud/platform-client-sdk-go/v149 v149.0.0/go.mod h1:afV1nQPB7luHoRCoLTh0b92Qvep0K0+zBA1IljTtwJ4=
 github.com/nyaruka/phonenumbers v1.4.3 h1:tR71UJ+DZu7TSkxoG8JI8HzHJkPD/m4KNiUX34Fvmlo=
 github.com/nyaruka/phonenumbers v1.4.3/go.mod h1:gv+CtldaFz+G3vHHnasBSirAi3O2XLqZzVWz4V1pl2E=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,6 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwd
 github.com/mozillazg/go-unidecode v0.2.0 h1:vFGEzAH9KSwyWmXCOblazEWDh7fOkpmy/Z4ArmamSUc=
 github.com/mozillazg/go-unidecode v0.2.0/go.mod h1:zB48+/Z5toiRolOZy9ksLryJ976VIwmDmpQ2quyt1aA=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/mypurecloud/platform-client-sdk-go/v146 v146.0.0 h1:3ww0KjTVF35pyba/QL/JKFvnCtQHgD7GbnFcl7aMs1s=
-github.com/mypurecloud/platform-client-sdk-go/v146 v146.0.0/go.mod h1:ehOEmTtb5KCtfgUq5gBp08ntPOVX/Sqamgavv8Ewuyk=
 github.com/mypurecloud/platform-client-sdk-go/v149 v149.0.0 h1:df413CVT6G4gnSbeAuqLo4DWXZndsADdXzIaw6LB5/4=
 github.com/mypurecloud/platform-client-sdk-go/v149 v149.0.0/go.mod h1:afV1nQPB7luHoRCoLTh0b92Qvep0K0+zBA1IljTtwJ4=
 github.com/nyaruka/phonenumbers v1.4.3 h1:tR71UJ+DZu7TSkxoG8JI8HzHJkPD/m4KNiUX34Fvmlo=


### PR DESCRIPTION
Added `allow_draw` to co-browse related configuration in webmessenger config. 
It's a new property we introduced recently in co-browse.
Also updated platformclient to the newest version `(149)` containing that property.