### PR TITLE
returning response so IsVersionMismatch function can work

### DIFF
--- a/genesyscloud/user/resource_genesyscloud_user_utils.go
+++ b/genesyscloud/user/resource_genesyscloud_user_utils.go
@@ -383,7 +383,7 @@ func restoreDeletedUser(ctx context.Context, d *schema.ResourceData, meta interf
 		})
 
 		if patchErr != nil {
-			return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Faild to restored deleted user %s | Error: %s.", email, patchErr), proxyPatchResponse)
+			return proxyPatchResponse, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Faild to restored deleted user %s | Error: %s.", email, patchErr), proxyPatchResponse)
 		}
 
 		return nil, updateUser(ctx, d, meta)


### PR DESCRIPTION
When the users resource was refactored to the package structure in v1.45.0 , we stopped returning this APIResponse object when the patch operation fails. This means that the *retry when version is mismatch* logic that the operation is wrapped in cannot work. 

The restore deleted user logic after 1.45.0: https://github.com/MyPureCloud/terraform-provider-genesyscloud/blob/v1.45.0/genesyscloud/user/resource_genesyscloud_user_utils.go

And before (1.44.0): https://github.com/MyPureCloud/terraform-provider-genesyscloud/blob/v1.44.0/genesyscloud/resource_genesyscloud_user.go#L721