### PR TITLE
Fixes DEVTOOLING-988

### DIFF
--- a/genesyscloud/tfexporter/export_common.go
+++ b/genesyscloud/tfexporter/export_common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -322,4 +323,27 @@ func isDirEmpty(path string) (bool, diag.Diagnostics) {
 
 func createUnresolvedAttrKey(attr unresolvableAttributeInfo) string {
 	return fmt.Sprintf("%s_%s_%s", attr.ResourceType, attr.ResourceLabel, attr.Name)
+}
+
+func sortJSONMap(m map[string]interface{}) map[string]interface{} {
+	// Create new map to store sorted data
+	orderedMap := make(map[string]interface{})
+
+	// Get and sort the keys
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Add keys in sorted order and recursively sort nested maps
+	for _, k := range keys {
+		if nestedMap, isMap := m[k].(map[string]interface{}); isMap {
+			orderedMap[k] = sortJSONMap(nestedMap)
+		} else {
+			orderedMap[k] = m[k]
+		}
+	}
+
+	return orderedMap
 }

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
@@ -550,20 +550,11 @@ func TestUnitResolveValueToDataSource(t *testing.T) {
 		t.Errorf("expected data source name to be '%s', got '%s'", defaultOutboundScriptName, nameInDataSource)
 	}
 
-	hclBlocks, ok := g.resourceTypesHCLBlocks[scriptResourceType]
-	if !ok {
-		t.Errorf("expected resourceTypesHCLBlocks to contain key '%s'", scriptResourceType)
-	}
-	if len(hclBlocks) == 0 {
-		t.Errorf("expected length of resourceTypesHCLBlocks to not be zero")
-	}
-
 	// set up
 	resolverFunc = func(configMap map[string]any, value any, sdkConfig *platformclientv2.Configuration) (string, string, map[string]any, bool) {
 		return "", "", nil, false
 	}
 	g.dataSourceTypesMaps = make(map[string]resourceJSONMaps)
-	g.resourceTypesHCLBlocks = make(map[string]resourceHCLBlock)
 	attrCustomResolver["script_id"] = &resourceExporter.RefAttrCustomResolver{ResolveToDataSourceFunc: resolverFunc}
 	exporter = &resourceExporter.ResourceExporter{
 		CustomAttributeResolver: attrCustomResolver,
@@ -574,10 +565,6 @@ func TestUnitResolveValueToDataSource(t *testing.T) {
 
 	if _, ok := g.dataSourceTypesMaps[scriptResourceType]; ok {
 		t.Errorf("expected key '%s' to not exist in dataSourceTypesMaps", scriptResourceType)
-	}
-
-	if _, ok := g.resourceTypesHCLBlocks[scriptResourceType]; ok {
-		t.Errorf("expected key '%s' to not exist in resourceTypesHCLBlocks map", scriptResourceType)
 	}
 }
 
@@ -601,7 +588,6 @@ func setupGenesysCloudResourceExporter(t *testing.T) *GenesysCloudResourceExport
 		t.Errorf("%v", diagErr)
 	}
 	g.dataSourceTypesMaps = make(map[string]resourceJSONMaps)
-	g.resourceTypesHCLBlocks = make(map[string]resourceHCLBlock)
 	g.exportAsHCL = true
 	return g
 }

--- a/genesyscloud/tfexporter/hcl_exporter.go
+++ b/genesyscloud/tfexporter/hcl_exporter.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 
@@ -21,22 +22,24 @@ const resourceHCLFileExt = "tf"
 type resourceHCLBlock [][]byte
 
 type HCLExporter struct {
-	resourceTypesHCLBlocks map[string]resourceHCLBlock
-	unresolvedAttrs        []unresolvableAttributeInfo
-	providerSource         string
-	version                string
-	dirPath                string
-	splitFilesByResource   bool
+	resourceTypesJSONMaps map[string]resourceJSONMaps
+	dataSourceTypesMaps   map[string]resourceJSONMaps
+	unresolvedAttrs       []unresolvableAttributeInfo
+	providerSource        string
+	version               string
+	dirPath               string
+	splitFilesByResource  bool
 }
 
-func NewHClExporter(resourceTypesHCLBlocks map[string]resourceHCLBlock, unresolvedAttrs []unresolvableAttributeInfo, providerSource string, version string, dirPath string, splitFilesByResource bool) *HCLExporter {
+func NewHClExporter(resourceTypesJSONMaps map[string]resourceJSONMaps, dataSourceTypesMaps map[string]resourceJSONMaps, unresolvedAttrs []unresolvableAttributeInfo, providerSource string, version string, dirPath string, splitFilesByResource bool) *HCLExporter {
 	hclExporter := &HCLExporter{
-		resourceTypesHCLBlocks: resourceTypesHCLBlocks,
-		unresolvedAttrs:        unresolvedAttrs,
-		providerSource:         providerSource,
-		version:                version,
-		dirPath:                dirPath,
-		splitFilesByResource:   splitFilesByResource,
+		resourceTypesJSONMaps: resourceTypesJSONMaps,
+		dataSourceTypesMaps:   dataSourceTypesMaps,
+		unresolvedAttrs:       unresolvedAttrs,
+		providerSource:        providerSource,
+		version:               version,
+		dirPath:               dirPath,
+		splitFilesByResource:  splitFilesByResource,
 	}
 	return hclExporter
 }
@@ -44,6 +47,40 @@ func NewHClExporter(resourceTypesHCLBlocks map[string]resourceHCLBlock, unresolv
 func (h *HCLExporter) exportHCLConfig() diag.Diagnostics {
 	providerBlock := createHCLProviderBlock(h.providerSource, h.version)
 	variablesBlock := createHCLVariablesBlock(h.unresolvedAttrs)
+
+	hclBlocks := make(map[string][][]byte, 0)
+
+	// Data resources
+	for resDataType, dataJSONMap := range h.dataSourceTypesMaps {
+
+		// Output the data resources in a sorted fashion
+		blockLabels := make([]string, 0)
+		for resDataLabel, _ := range dataJSONMap {
+			blockLabels = append(blockLabels, resDataLabel)
+		}
+		sort.Strings(blockLabels)
+		for _, blockLabel := range blockLabels {
+			resDataJson := dataJSONMap[blockLabel]
+			hclBlock := instanceStateToHCLBlock(resDataType, blockLabel, resDataJson, true)
+			hclBlocks[resDataType] = append(hclBlocks[resDataType], hclBlock)
+		}
+	}
+
+	// Resources
+	for resType, resJSONMap := range h.resourceTypesJSONMaps {
+
+		// Output the resources in a sorted fashion
+		blockLabels := make([]string, 0)
+		for resLabel, _ := range resJSONMap {
+			blockLabels = append(blockLabels, resLabel)
+		}
+		sort.Strings(blockLabels)
+		for _, resLabel := range blockLabels {
+			resJson := resJSONMap[resLabel]
+			hclBlock := instanceStateToHCLBlock(resType, resLabel, resJson, false)
+			hclBlocks[resType] = append(hclBlocks[resType], hclBlock)
+		}
+	}
 
 	if h.splitFilesByResource {
 		// Provider file
@@ -64,24 +101,33 @@ func (h *HCLExporter) exportHCLConfig() diag.Diagnostics {
 			return diagErr
 		}
 
-		// Resource files
-		for resType, resBlock := range h.resourceTypesHCLBlocks {
+		// Resources files
+		for resType, hclContent := range hclBlocks {
 			resourceHCLFilePath := filepath.Join(h.dirPath, fmt.Sprintf("%s.%s", resType, resourceHCLFileExt))
 			if resourceHCLFilePath == "" {
 				return diag.Errorf("Failed to create file path %s", resourceHCLFilePath)
 			}
-			if diagErr := writeHCLToFile(resBlock, resourceHCLFilePath); diagErr != nil {
+			if diagErr := writeHCLToFile(hclContent, resourceHCLFilePath); diagErr != nil {
 				return diagErr
 			}
 		}
+
 	} else {
 		// Single file export
 		allBlockSlice := make([][]byte, 0)
 		allBlockSlice = append(allBlockSlice, providerBlock)
 
-		for _, resBlock := range h.resourceTypesHCLBlocks {
-			allBlockSlice = append(allBlockSlice, resBlock...)
+		// Sort resource types
+		resourceTypes := make([]string, 0)
+		for resType, _ := range hclBlocks {
+			resourceTypes = append(resourceTypes, resType)
 		}
+		sort.Strings(resourceTypes)
+		for _, resType := range resourceTypes {
+			hclContent := hclBlocks[resType]
+			allBlockSlice = append(allBlockSlice, hclContent...)
+		}
+
 		allBlockSlice = append(allBlockSlice, variablesBlock)
 
 		hclFilePath := filepath.Join(h.dirPath, defaultTfHCLFile)
@@ -140,6 +186,11 @@ func createHCLProviderBlock(providerSource string, version string) []byte {
 func createHCLVariablesBlock(unresolvedAttrs []unresolvableAttributeInfo) []byte {
 	mFile := hclwrite.NewEmptyFile()
 	keys := make(map[string]string)
+	sort.Slice(unresolvedAttrs, func(i, j int) bool {
+		return unresolvedAttrs[i].ResourceType < unresolvedAttrs[j].ResourceType ||
+			(unresolvedAttrs[i].ResourceType == unresolvedAttrs[j].ResourceType &&
+				unresolvedAttrs[i].ResourceLabel < unresolvedAttrs[j].ResourceLabel)
+	})
 	for _, attr := range unresolvedAttrs {
 		mBody := mFile.Body()
 		key := createUnresolvedAttrKey(attr)
@@ -211,7 +262,8 @@ func instanceStateToHCLBlock(resType, resLabel string, json util.JsonMap, isData
 
 	body := block.Body()
 
-	addBody(body, json)
+	sortedJson := sortJSONMap(json)
+	addBody(body, sortedJson)
 
 	newCopy := strings.Replace(string(f.Bytes()), "$${", "${", -1)
 	return []byte(newCopy)

--- a/genesyscloud/tfexporter/hcl_exporter.go
+++ b/genesyscloud/tfexporter/hcl_exporter.go
@@ -19,8 +19,6 @@ import (
 
 const resourceHCLFileExt = "tf"
 
-type resourceHCLBlock [][]byte
-
 type HCLExporter struct {
 	resourceTypesJSONMaps map[string]resourceJSONMaps
 	dataSourceTypesMaps   map[string]resourceJSONMaps

--- a/genesyscloud/tfexporter/json_exporter.go
+++ b/genesyscloud/tfexporter/json_exporter.go
@@ -277,7 +277,8 @@ func determineVarType(s *schema.Schema) string {
 }
 
 func writeConfig(jsonMap map[string]interface{}, path string) diag.Diagnostics {
-	dataJSONBytes, err := json.MarshalIndent(jsonMap, "", "  ")
+	sortedJsonMap := sortJSONMap(jsonMap)
+	dataJSONBytes, err := json.MarshalIndent(sortedJsonMap, "", "  ")
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/genesyscloud/util/lists/util_lists.go
+++ b/genesyscloud/util/lists/util_lists.go
@@ -26,6 +26,15 @@ func RemoveStringFromSlice(value string, slice []string) []string {
 	return s
 }
 
+func StringInSlice(a string, slice []string) bool {
+	for _, b := range slice {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 func SubStringInSlice(a string, list []string) bool {
 	for _, b := range list {
 		if strings.Contains(b, a) {


### PR DESCRIPTION
Addresses an issue where the state for duplicated resources was not getting updated due to the separate handling of HCL and JSON maps, when we really should just handle the resource/data maps as one object that the HCL/JSON exporter iterates over and exports in the proper format. Also, as an added bonus, I added sorting of the output to make things more consistent on outputs. I have seen this as a request from both internal and customers