### PR TITLE
Fix DEVTOOLING-936 (update)

### DIFF
--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
@@ -152,7 +152,7 @@ func (p *SiteProxy) deleteSite(ctx context.Context, siteId string) (*platformcli
 }
 
 // getSiteByIdFunc returns a single Genesys Cloud Site by Id
-func (p *SiteProxy) getSiteById(ctx context.Context, siteId string) (site *platformclientv2.Site, resp *platformclientv2.APIResponse, err error) {
+func (p *SiteProxy) GetSiteById(ctx context.Context, siteId string) (site *platformclientv2.Site, resp *platformclientv2.APIResponse, err error) {
 	return p.getSiteByIdAttr(ctx, p, siteId)
 }
 

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -153,7 +153,7 @@ func readSite(ctx context.Context, d *schema.ResourceData, meta interface{}) dia
 
 	log.Printf("Reading site %s", d.Id())
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
-		currentSite, resp, err := sp.getSiteById(ctx, d.Id())
+		currentSite, resp, err := sp.GetSiteById(ctx, d.Id())
 		if err != nil {
 			if util.IsStatus404(resp) {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("failed to read site %s | error: %s", d.Id(), err), resp))
@@ -266,7 +266,7 @@ func updateSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 
 	diagErr := util.RetryWhen(util.IsVersionMismatch, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
 		// Get current site version
-		currentSite, resp, err := sp.getSiteById(ctx, d.Id())
+		currentSite, resp, err := sp.GetSiteById(ctx, d.Id())
 		if err != nil {
 			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to read site %s error: %s", d.Id(), err), resp)
 		}
@@ -335,7 +335,7 @@ func deleteSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 	}
 
 	return util.WithRetries(ctx, 30*time.Second, func() *retry.RetryError {
-		site, resp, err := sp.getSiteById(ctx, d.Id())
+		site, resp, err := sp.GetSiteById(ctx, d.Id())
 		if err != nil {
 			if util.IsStatus404(resp) {
 				// Site deleted

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
@@ -108,7 +108,7 @@ func updatePrimarySecondarySites(ctx context.Context, sp *SiteProxy, d *schema.R
 	primarySites := lists.InterfaceListToStrings(d.Get("primary_sites").([]interface{}))
 	secondarySites := lists.InterfaceListToStrings(d.Get("secondary_sites").([]interface{}))
 
-	site, resp, err := sp.getSiteById(ctx, siteId)
+	site, resp, err := sp.GetSiteById(ctx, siteId)
 	if resp.StatusCode != 200 {
 		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Unable to retrieve site record after site %s was created, but unable to update the primary or secondary site error: %s", siteId, err), resp)
 	}

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
@@ -70,16 +70,22 @@ func createSiteOutboundRoute(ctx context.Context, d *schema.ResourceData, meta i
 
 	siteId := d.Get("site_id").(string)
 
-	// Default Outbound Routes are created automatically when a site resource is created, so instead of trying to create
-	// a new outbound route, we will just update the existing one
 	if outboundRouteName, ok := d.GetOk("name"); ok {
 		if outboundRouteName.(string) == "Default Outbound Route" {
-			siteId, outboundRouteId, _, _, err := proxy.getSiteOutboundRouteByName(ctx, siteId, "Default Outbound Route")
+			site, resp, err := proxy.siteProxy.GetSiteById(ctx, siteId)
 			if err != nil {
-				return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get outbound route %s for site %s: %s", outboundRouteName, siteId, err), nil)
+				return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get site %s: %s", siteId, err), resp)
 			}
-			d.SetId(buildSiteAndOutboundRouteId(siteId, outboundRouteId))
-			return updateSiteOutboundRoute(ctx, d, meta)
+			// Default Outbound Routes are created automatically when a Cloud based site resource is created,
+			// so instead of trying to create a new outbound route, we will just update the existing one
+			if *site.MediaModel == "Cloud" {
+				siteId, outboundRouteId, _, _, err := proxy.getSiteOutboundRouteByName(ctx, siteId, "Default Outbound Route")
+				if err != nil {
+					return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get outbound route %s for site %s: %s", outboundRouteName, siteId, err), nil)
+				}
+				d.SetId(buildSiteAndOutboundRouteId(siteId, outboundRouteId))
+				return updateSiteOutboundRoute(ctx, d, meta)
+			}
 		}
 	}
 


### PR DESCRIPTION
Only update the Default Outbound Route if it's a Cloud based site (since the GC only auto creates the default outbound route for a cloud based site)