### PR TITLE
NOJIRA - Fix/outbound route cache

### DIFF
--- a/docs/resources/telephony_providers_edges_site_outbound_route.md
+++ b/docs/resources/telephony_providers_edges_site_outbound_route.md
@@ -31,7 +31,7 @@ When exporting this resource, please be aware of the following behavior:
 
 If the associated Genesys Cloud Telephony Site is configured as a `managed` resource:
 
-- This resource will be exported as a data object
+- This resource will be exported as a data resource
 - Updates and modifications to this resource and its child dependencies will not be allowed through through this provider or the Genesys Cloud API
 - This limitation is enforced by the Genesys Cloud API itself
 

--- a/examples/resources/genesyscloud_telephony_providers_edges_site_outbound_route/apis.md
+++ b/examples/resources/genesyscloud_telephony_providers_edges_site_outbound_route/apis.md
@@ -18,7 +18,7 @@ When exporting this resource, please be aware of the following behavior:
 
 If the associated Genesys Cloud Telephony Site is configured as a `managed` resource:
 
-- This resource will be exported as a data object
+- This resource will be exported as a data resource
 - Updates and modifications to this resource and its child dependencies will not be allowed through through this provider or the Genesys Cloud API
 - This limitation is enforced by the Genesys Cloud API itself
 


### PR DESCRIPTION
This is to fix a bug where the output of the outbound routes would return the same outbound routes as the previous site if the same number of routes was returned. This was discovered while testing telephony support for the BCP Wizard.

This caching logic was obviously copied over from the site resource, where it should remain. But it is not appropriate for this resource.

Also fixes an issue where a cache collision could occur (unlikely but important to address)