### PR TITLE
JM-2290: require platform-client-sdk-go v150.1.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/leekchan/timeutil v0.0.0-20150802142658-28917288c48d
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/mozillazg/go-unidecode v0.2.0
-	github.com/mypurecloud/platform-client-sdk-go/v150 v150.0.0
+	github.com/mypurecloud/platform-client-sdk-go/v150 v150.1.0
 	github.com/nyaruka/phonenumbers v1.4.4
 	github.com/rjNemo/underscore v0.7.0
 	github.com/zclconf/go-cty v1.16.0

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwd
 github.com/mozillazg/go-unidecode v0.2.0 h1:vFGEzAH9KSwyWmXCOblazEWDh7fOkpmy/Z4ArmamSUc=
 github.com/mozillazg/go-unidecode v0.2.0/go.mod h1:zB48+/Z5toiRolOZy9ksLryJ976VIwmDmpQ2quyt1aA=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
-github.com/mypurecloud/platform-client-sdk-go/v150 v150.0.0 h1:KQChgHKvh3njkyscE7qBbjg4jxvR9055r6vjjiMO6x8=
-github.com/mypurecloud/platform-client-sdk-go/v150 v150.0.0/go.mod h1:MQ2dqMSmyug3a51RlHQU+WtGhSh9MuOntAUqY+IU3pU=
+github.com/mypurecloud/platform-client-sdk-go/v150 v150.1.0 h1:h/3thKv2jbdR+VLtM8MxNNolLoAkf3QmQfbryUiFpI8=
+github.com/mypurecloud/platform-client-sdk-go/v150 v150.1.0/go.mod h1:MQ2dqMSmyug3a51RlHQU+WtGhSh9MuOntAUqY+IU3pU=
 github.com/nyaruka/phonenumbers v1.4.4 h1:9yo9jLvXD7J4exe7GJATApgTlB+05snF0joMDL1p7nQ=
 github.com/nyaruka/phonenumbers v1.4.4/go.mod h1:gv+CtldaFz+G3vHHnasBSirAi3O2XLqZzVWz4V1pl2E=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=


### PR DESCRIPTION
Hi 

https://inindca.atlassian.net/browse/JM-2290 requires the version https://github.com/MyPureCloud/platform-client-sdk-go/tree/v150.1.0

About https://github.com/MyPureCloud/platform-client-sdk-go/blob/v150.1.0/platformclientv2/journeyviewelementfilter.go
Previously, 
`// NumberPredicates - numberPredicates
	NumberPredicates *[]Journeyviewelementfilternumberpredicate `json:"numberPredicates,omitempty"``

was not accessible