### PR TITLE
NOJIRA - Fix NPE

### DIFF
--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -272,7 +272,7 @@ func updateSite(ctx context.Context, d *schema.ResourceData, meta interface{}) d
 		log.Printf("Updating site %s", *site.Name)
 		site, resp, err = sp.updateSite(ctx, d.Id(), site)
 		if err != nil {
-			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update site %s error: %s", *site.Name, err), resp)
+			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update site %s error: %s", *currentSite.Name, err), resp)
 		}
 
 		return resp, nil


### PR DESCRIPTION
Happened across this NPE in Razorcrest

```
Stack trace from the terraform-provider-genesyscloud plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x45b0b30]

goroutine 213 [running]:
terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site.updateSite.func1()
	/Users/bgoad/genesys/git/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go:275 +0x490
terraform-provider-genesyscloud/genesyscloud/util.RetryWhen(0x4ff6200, 0xc000de6f40, {0x0, 0x0, 0x0})
	/Users/bgoad/genesys/git/terraform-provider-genesyscloud/genesyscloud/util/util_retries.go:63 +0xb4
terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site.updateSite({0x500bbe8, 0xc000852070}, 0xc0008c4300, {0x4c74f60, 0xc000f84440})
	/Users/bgoad/genesys/git/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go:264 +0x9a5
terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site.ResourceSite.UpdateWithPooledClient.runWithPooledClient.func5({0x500bbe8, 0xc000852070}, 0xc0008c4300, {0x4c74f60, 0xc00081c780})
	/Users/bgoad/genesys/git/terraform-provider-genesyscloud/genesyscloud/provider/sdk_client_pool.go:134 +0x191
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).update(0xc000173880, {0x500bb40, 0xc000797080}, 0xc0008c4300, {0x4c74f60, 0xc00081c780})
	/Users/bgoad/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.35.0/helper/schema/resource.go:840 +0x119
```

This PR fixes it