### PR TITLE
DEVTOOLING-929: Converting groups in CGR rules.groups from TypeList to TypeSet

### DIFF
--- a/docs/resources/routing_queue_conditional_group_routing.md
+++ b/docs/resources/routing_queue_conditional_group_routing.md
@@ -64,7 +64,7 @@ resource "genesyscloud_routing_queue_conditional_group_routing" "example-name" {
 Required:
 
 - `condition_value` (Number) The limit value, beyond which a rule evaluates as true.
-- `groups` (Block List, Min: 1) The group(s) to activate if the rule evaluates as true. (see [below for nested schema](#nestedblock--rules--groups))
+- `groups` (Block Set, Min: 1) The group(s) to activate if the rule evaluates as true. (see [below for nested schema](#nestedblock--rules--groups))
 - `operator` (String) The operator that compares the actual value against the condition value. Valid values: GreaterThan, GreaterThanOrEqualTo, LessThan, LessThanOrEqualTo.
 
 Optional:

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -270,7 +270,7 @@ func buildSdkConditionalGroupRouting(d *schema.ResourceData) (*platformclientv2.
 		}
 
 		if memberGroupSet, ok := ruleSettings["groups"].(*schema.Set); ok {
-			sdkCGRRule.Groups = buildCGRGroups(memberGroupSet)
+			sdkCGRRule.Groups = BuildCGRGroups(memberGroupSet)
 		}
 		sdkCGRRules = append(sdkCGRRules, sdkCGRRule)
 	}
@@ -278,7 +278,7 @@ func buildSdkConditionalGroupRouting(d *schema.ResourceData) (*platformclientv2.
 	return &platformclientv2.Conditionalgrouprouting{Rules: &sdkCGRRules}, nil
 }
 
-func buildCGRGroups(groups *schema.Set) *[]platformclientv2.Membergroup {
+func BuildCGRGroups(groups *schema.Set) *[]platformclientv2.Membergroup {
 	groupList := groups.List()
 	if len(groupList) == 0 {
 		return nil
@@ -591,7 +591,7 @@ func flattenConditionalGroupRoutingRules(queue *platformclientv2.Queue) []interf
 		}
 
 		if rule.Groups != nil {
-			ruleSettings["groups"] = flattenCGRGroups(*rule.Groups)
+			ruleSettings["groups"] = FlattenCGRGroups(*rule.Groups)
 		}
 
 		rules[i] = ruleSettings
@@ -600,7 +600,7 @@ func flattenConditionalGroupRoutingRules(queue *platformclientv2.Queue) []interf
 	return rules
 }
 
-func flattenCGRGroups(sdkGroups []platformclientv2.Membergroup) *schema.Set {
+func FlattenCGRGroups(sdkGroups []platformclientv2.Membergroup) *schema.Set {
 	groupSet := schema.NewSet(schema.HashResource(memberGroupResource), []interface{}{})
 	for _, sdkGroup := range sdkGroups {
 		groupMap := make(map[string]interface{})

--- a/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_utils.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_utils.go
@@ -1,0 +1,67 @@
+package routing_queue_conditional_group_routing
+
+import (
+	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v150/platformclientv2"
+	routingQueue "terraform-provider-genesyscloud/genesyscloud/routing_queue"
+	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
+)
+
+func buildConditionalGroupRouting(rules []interface{}) ([]platformclientv2.Conditionalgrouproutingrule, error) {
+	var sdkRules []platformclientv2.Conditionalgrouproutingrule
+	for i, rule := range rules {
+		configRule := rule.(map[string]interface{})
+		sdkRule := platformclientv2.Conditionalgrouproutingrule{
+			Operator:       platformclientv2.String(configRule["operator"].(string)),
+			ConditionValue: platformclientv2.Float64(configRule["condition_value"].(float64)),
+		}
+
+		if evaluatedQueue, ok := configRule["evaluated_queue_id"].(string); ok && evaluatedQueue != "" {
+			if i == 0 {
+				return nil, fmt.Errorf("for rule 1, the current queue is used so evaluated_queue_id should not be specified")
+			}
+			sdkRule.Queue = &platformclientv2.Domainentityref{Id: &evaluatedQueue}
+		}
+
+		resourcedata.BuildSDKStringValueIfNotNil(&sdkRule.Metric, configRule, "metric")
+		if waitSeconds, ok := configRule["wait_seconds"].(int); ok {
+			sdkRule.WaitSeconds = &waitSeconds
+		}
+
+		if memberGroupSet, ok := configRule["groups"].(*schema.Set); ok {
+			sdkRule.Groups = routingQueue.BuildCGRGroups(memberGroupSet)
+		}
+
+		sdkRules = append(sdkRules, sdkRule)
+	}
+
+	return sdkRules, nil
+}
+
+func flattenConditionalGroupRouting(sdkRules *[]platformclientv2.Conditionalgrouproutingrule) []interface{} {
+	if sdkRules == nil {
+		return nil
+	}
+
+	var rules []interface{}
+	for i, sdkRule := range *sdkRules {
+		rule := make(map[string]interface{})
+
+		// The first rule is assumed to apply to this queue, so evaluated_queue_id should be omitted
+		if i > 0 {
+			resourcedata.SetMapReferenceValueIfNotNil(rule, "evaluated_queue_id", sdkRule.Queue)
+		}
+		resourcedata.SetMapValueIfNotNil(rule, "wait_seconds", sdkRule.WaitSeconds)
+		resourcedata.SetMapValueIfNotNil(rule, "operator", sdkRule.Operator)
+		resourcedata.SetMapValueIfNotNil(rule, "condition_value", sdkRule.ConditionValue)
+		resourcedata.SetMapValueIfNotNil(rule, "metric", sdkRule.Metric)
+
+		if sdkRule.Groups != nil {
+			rule["groups"] = routingQueue.FlattenCGRGroups(*sdkRule.Groups)
+		}
+
+		rules = append(rules, rule)
+	}
+	return rules
+}

--- a/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_utils.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_utils.go
@@ -11,10 +11,18 @@ import (
 func buildConditionalGroupRouting(rules []interface{}) ([]platformclientv2.Conditionalgrouproutingrule, error) {
 	var sdkRules []platformclientv2.Conditionalgrouproutingrule
 	for i, rule := range rules {
-		configRule := rule.(map[string]interface{})
-		sdkRule := platformclientv2.Conditionalgrouproutingrule{
-			Operator:       platformclientv2.String(configRule["operator"].(string)),
-			ConditionValue: platformclientv2.Float64(configRule["condition_value"].(float64)),
+		configRule, ok := rule.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		var sdkRule platformclientv2.Conditionalgrouproutingrule
+
+		if operator, ok := configRule["operator"].(string); ok {
+			sdkRule.Operator = &operator
+		}
+
+		if conditionValue, ok := configRule["condition_value"].(float64); ok {
+			sdkRule.ConditionValue = &conditionValue
 		}
 
 		if evaluatedQueue, ok := configRule["evaluated_queue_id"].(string); ok && evaluatedQueue != "" {

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
@@ -3,6 +3,10 @@ package routing_queue_conditional_group_routing
 import (
 	"context"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v150/platformclientv2"
 	"log"
 	"strings"
 	consistencyChecker "terraform-provider-genesyscloud/genesyscloud/consistency_checker"
@@ -11,12 +15,6 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
-	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v150/platformclientv2"
 )
 
 /*
@@ -148,84 +146,4 @@ func deleteRoutingQueueConditionalRoutingGroup(ctx context.Context, d *schema.Re
 
 	log.Printf("Successfully removed rules from queue %s", queueId)
 	return nil
-}
-
-func buildConditionalGroupRouting(rules []interface{}) ([]platformclientv2.Conditionalgrouproutingrule, error) {
-	var sdkRules []platformclientv2.Conditionalgrouproutingrule
-	for i, rule := range rules {
-		configRule := rule.(map[string]interface{})
-		sdkRule := platformclientv2.Conditionalgrouproutingrule{
-			Operator:       platformclientv2.String(configRule["operator"].(string)),
-			ConditionValue: platformclientv2.Float64(configRule["condition_value"].(float64)),
-		}
-
-		if evaluatedQueue, ok := configRule["evaluated_queue_id"].(string); ok && evaluatedQueue != "" {
-			if i == 0 {
-				return nil, fmt.Errorf("for rule 1, the current queue is used so evaluated_queue_id should not be specified")
-			}
-			sdkRule.Queue = &platformclientv2.Domainentityref{Id: &evaluatedQueue}
-		}
-
-		resourcedata.BuildSDKStringValueIfNotNil(&sdkRule.Metric, configRule, "metric")
-		if waitSeconds, ok := configRule["wait_seconds"].(int); ok {
-			sdkRule.WaitSeconds = &waitSeconds
-		}
-
-		if memberGroupList, ok := configRule["groups"].([]interface{}); ok {
-			var sdkMemberGroups []platformclientv2.Membergroup
-			for _, memberGroup := range memberGroupList {
-				memberGroupMap, ok := memberGroup.(map[string]interface{})
-				if !ok {
-					continue
-				}
-
-				sdkMemberGroup := platformclientv2.Membergroup{
-					Id:      platformclientv2.String(memberGroupMap["member_group_id"].(string)),
-					VarType: platformclientv2.String(memberGroupMap["member_group_type"].(string)),
-				}
-				sdkMemberGroups = append(sdkMemberGroups, sdkMemberGroup)
-			}
-			sdkRule.Groups = &sdkMemberGroups
-		}
-
-		sdkRules = append(sdkRules, sdkRule)
-	}
-
-	return sdkRules, nil
-}
-
-func flattenConditionalGroupRouting(sdkRules *[]platformclientv2.Conditionalgrouproutingrule) []interface{} {
-	if sdkRules == nil {
-		return nil
-	}
-
-	var rules []interface{}
-	for i, sdkRule := range *sdkRules {
-		rule := make(map[string]interface{})
-
-		// The first rule is assumed to apply to this queue, so evaluated_queue_id should be omitted
-		if i > 0 {
-			resourcedata.SetMapReferenceValueIfNotNil(rule, "evaluated_queue_id", sdkRule.Queue)
-		}
-		resourcedata.SetMapValueIfNotNil(rule, "wait_seconds", sdkRule.WaitSeconds)
-		resourcedata.SetMapValueIfNotNil(rule, "operator", sdkRule.Operator)
-		resourcedata.SetMapValueIfNotNil(rule, "condition_value", sdkRule.ConditionValue)
-		resourcedata.SetMapValueIfNotNil(rule, "metric", sdkRule.Metric)
-
-		if sdkRule.Groups != nil {
-			memberGroups := make([]interface{}, 0)
-			for _, group := range *sdkRule.Groups {
-				memberGroupMap := make(map[string]interface{})
-
-				resourcedata.SetMapValueIfNotNil(memberGroupMap, "member_group_id", group.Id)
-				resourcedata.SetMapValueIfNotNil(memberGroupMap, "member_group_type", group.VarType)
-
-				memberGroups = append(memberGroups, memberGroupMap)
-			}
-			rule["groups"] = memberGroups
-		}
-
-		rules = append(rules, rule)
-	}
-	return rules
 }

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_schema.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_schema.go
@@ -95,7 +95,7 @@ func ResourceRoutingQueueConditionalGroupRouting() *schema.Resource {
 							ValidateFunc: validation.IntBetween(0, 259200),
 						},
 						"groups": {
-							Type:        schema.TypeList,
+							Type:        schema.TypeSet,
 							Required:    true,
 							MinItems:    1,
 							Description: "The group(s) to activate if the rule evaluates as true.",

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
@@ -43,42 +43,42 @@ func TestUnitBuildConditionalGroupRouting(t *testing.T) {
 		t.Errorf("Error building conditional group routing: %v", err)
 	}
 	if cgrRules == nil {
-		t.Errorf("Expected conditional group routing, got nil")
+		t.Fatalf("Expected conditional group routing, got nil")
 	}
 	if len(cgrRules) != 1 {
 		t.Errorf("Expected 1 rule, got %d", len(cgrRules))
 	}
 	cgrRule := cgrRules[0]
 	if cgrRule.Metric == nil {
-		t.Errorf("Expected metric to not be nil")
+		t.Fatalf("Expected metric to not be nil")
 	}
 	if *cgrRule.Metric != metric {
 		t.Errorf("Expected metric to be '%s', got %s", metric, *cgrRule.Metric)
 	}
 
 	if cgrRule.Operator == nil {
-		t.Errorf("Expected operator to not be nil")
+		t.Fatalf("Expected operator to not be nil")
 	}
 	if *cgrRule.Operator != operator {
 		t.Errorf("Expected operator to be '%s', got %s", operator, *cgrRule.Operator)
 	}
 
 	if cgrRule.ConditionValue == nil {
-		t.Errorf("Expected condition_value to not be nil")
+		t.Fatalf("Expected condition_value to not be nil")
 	}
 	if *cgrRule.ConditionValue != conditionValue {
 		t.Errorf("Expected condition_value to be %f, got %f", conditionValue, *cgrRule.ConditionValue)
 	}
 
 	if cgrRule.WaitSeconds == nil {
-		t.Errorf("Expected WaitSeconds to not be nil")
+		t.Fatalf("Expected WaitSeconds to not be nil")
 	}
 	if *cgrRule.WaitSeconds != waitSeconds {
 		t.Errorf("Expected WaitSeconds to be %d, got %d", waitSeconds, *cgrRule.WaitSeconds)
 	}
 
 	if cgrRule.Groups == nil {
-		t.Errorf("Expected groups to not be nil")
+		t.Fatalf("Expected groups to not be nil")
 	}
 	if len(*cgrRule.Groups) != 3 {
 		t.Errorf("Expected 3 groups, got %d", len(*cgrRule.Groups))
@@ -102,12 +102,12 @@ func TestUnitFlattenConditionalGroupRouting(t *testing.T) {
 
 	cgrRule, ok := cgrRulesFlattened[0].(map[string]any)
 	if !ok {
-		t.Errorf("Expected map[string]any, got %T", cgrRulesFlattened[0])
+		t.Fatalf("Expected map[string]any, got %T", cgrRulesFlattened[0])
 	}
 
 	metricFlattened, ok := cgrRule["metric"].(string)
 	if !ok {
-		t.Errorf("Expected metric to be a string, got %T", cgrRule["metric"])
+		t.Fatalf("Expected metric to be a string, got %T", cgrRule["metric"])
 	}
 	if metricFlattened != metric {
 		t.Errorf("Expected metric to be 'test', got %s", cgrRule["metric"].(string))
@@ -115,7 +115,7 @@ func TestUnitFlattenConditionalGroupRouting(t *testing.T) {
 
 	operatorFlattened, ok := cgrRule["operator"].(string)
 	if !ok {
-		t.Errorf("Expected operator to be a string, got %T", cgrRule["operator"])
+		t.Fatalf("Expected operator to be a string, got %T", cgrRule["operator"])
 	}
 	if operatorFlattened != "GreaterThan" {
 		t.Errorf("Expected operator to be 'GreaterThan', got %s", operatorFlattened)
@@ -123,7 +123,7 @@ func TestUnitFlattenConditionalGroupRouting(t *testing.T) {
 
 	conditionValueFlattened, ok := cgrRule["condition_value"].(float64)
 	if !ok {
-		t.Errorf("Expected condition_value to be a float64, got %T", cgrRule["condition_value"])
+		t.Fatalf("Expected condition_value to be a float64, got %T", cgrRule["condition_value"])
 	}
 	if conditionValueFlattened != 2345 {
 		t.Errorf("Expected condition_value to be 2345, got %f", conditionValueFlattened)
@@ -131,7 +131,7 @@ func TestUnitFlattenConditionalGroupRouting(t *testing.T) {
 
 	groupsFlattened, ok := cgrRule["groups"].(*schema.Set)
 	if !ok {
-		t.Errorf("Expected *schema.Set, got %T", cgrRule["groups"])
+		t.Fatalf("Expected *schema.Set, got %T", cgrRule["groups"])
 	}
 	if len(groupsFlattened.List()) != 3 {
 		t.Errorf("Expected 3 groups, got %d", len(groupsFlattened.List()))

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
@@ -1,104 +1,144 @@
 package routing_queue_conditional_group_routing
 
 import (
-	"context"
-	"net/http"
-	"terraform-provider-genesyscloud/genesyscloud/provider"
-	featureToggles "terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
-	"testing"
-
-	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mypurecloud/platform-client-sdk-go/v150/platformclientv2"
-	"github.com/stretchr/testify/assert"
+	"testing"
 )
 
-func TestUnitResourceRoutingQueueConditionalGroupRoutingUpdate(t *testing.T) {
-	tQueueId := uuid.NewString()
-	tRules := generateRuleData()
-	tId := tQueueId + "/rules"
+func TestUnitBuildConditionalGroupRouting(t *testing.T) {
+	var (
+		metric                 = "test"
+		operator               = "GreaterThan"
+		conditionValue float64 = 2345
+		waitSeconds            = 5432
+	)
 
-	if !featureToggles.CSGToggleExists() {
-		t.Skipf("Skipping because %s env variable is not set", featureToggles.CSGToggleName())
+	var cgrRulesMap = make(map[string]any)
+	cgrRulesMap["metric"] = metric
+	cgrRulesMap["operator"] = operator
+	cgrRulesMap["condition_value"] = conditionValue
+	cgrRulesMap["wait_seconds"] = waitSeconds
+	cgrRulesMap["groups"] = schema.NewSet(schema.HashResource(memberGroupResource), []interface{}{
+		map[string]any{
+			"member_group_id":   "111",
+			"member_group_type": "222",
+		},
+		map[string]any{
+			"member_group_id":   "333",
+			"member_group_type": "444",
+		},
+		map[string]any{
+			"member_group_id":   "555",
+			"member_group_type": "666",
+		},
+	})
+
+	cgrRulesList := []interface{}{cgrRulesMap}
+
+	// testing buildConditionalGroupRouting function
+	cgrRules, err := buildConditionalGroupRouting(cgrRulesList)
+	if err != nil {
+		t.Errorf("Error building conditional group routing: %v", err)
+	}
+	if cgrRules == nil {
+		t.Errorf("Expected conditional group routing, got nil")
+	}
+	if len(cgrRules) != 1 {
+		t.Errorf("Expected 1 rule, got %d", len(cgrRules))
+	}
+	cgrRule := cgrRules[0]
+	if cgrRule.Metric == nil {
+		t.Errorf("Expected metric to not be nil")
+	}
+	if *cgrRule.Metric != metric {
+		t.Errorf("Expected metric to be '%s', got %s", metric, *cgrRule.Metric)
 	}
 
-	groupRoutingProxy := &routingQueueConditionalGroupRoutingProxy{}
-	groupRoutingProxy.updateRoutingQueueConditionRoutingAttr = func(ctx context.Context, p *routingQueueConditionalGroupRoutingProxy, queueId string, rules *[]platformclientv2.Conditionalgrouproutingrule) (*[]platformclientv2.Conditionalgrouproutingrule, *platformclientv2.APIResponse, error) {
-		equal := cmp.Equal(tRules, *rules)
-		assert.Equal(t, true, equal, "rules not equal to expected value in update: %s", cmp.Diff(tRules, *rules))
-
-		apiResponse := platformclientv2.APIResponse{StatusCode: http.StatusOK}
-		return rules, &apiResponse, nil
+	if cgrRule.Operator == nil {
+		t.Errorf("Expected operator to not be nil")
+	}
+	if *cgrRule.Operator != operator {
+		t.Errorf("Expected operator to be '%s', got %s", operator, *cgrRule.Operator)
 	}
 
-	groupRoutingProxy.getRoutingQueueConditionRoutingAttr = func(ctx context.Context, p *routingQueueConditionalGroupRoutingProxy, queueId string) (*[]platformclientv2.Conditionalgrouproutingrule, *platformclientv2.APIResponse, error) {
-		apiResponse := platformclientv2.APIResponse{StatusCode: http.StatusOK}
-		return &tRules, &apiResponse, nil
+	if cgrRule.ConditionValue == nil {
+		t.Errorf("Expected condition_value to not be nil")
+	}
+	if *cgrRule.ConditionValue != conditionValue {
+		t.Errorf("Expected condition_value to be %f, got %f", conditionValue, *cgrRule.ConditionValue)
 	}
 
-	internalProxy = groupRoutingProxy
-	defer func() { internalProxy = nil }()
+	if cgrRule.WaitSeconds == nil {
+		t.Errorf("Expected WaitSeconds to not be nil")
+	}
+	if *cgrRule.WaitSeconds != waitSeconds {
+		t.Errorf("Expected WaitSeconds to be %d, got %d", waitSeconds, *cgrRule.WaitSeconds)
+	}
 
-	ctx := context.Background()
-	gcloud := &provider.ProviderMeta{ClientConfig: &platformclientv2.Configuration{}}
-
-	//Grab our defined schema
-	resourceSchema := ResourceRoutingQueueConditionalGroupRouting().Schema
-
-	//Setup a map of values
-	resourceDataMap := buildConditionalGroupRoutingResourceMap(tQueueId, &tRules)
-
-	d := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
-	d.SetId(tId)
-
-	diag := updateRoutingQueueConditionalRoutingGroup(ctx, d, gcloud)
-	assert.Equal(t, false, diag.HasError(), diag)
-	assert.Equal(t, tId, d.Id())
+	if cgrRule.Groups == nil {
+		t.Errorf("Expected groups to not be nil")
+	}
+	if len(*cgrRule.Groups) != 3 {
+		t.Errorf("Expected 3 groups, got %d", len(*cgrRule.Groups))
+	}
 }
 
-func TestUnitResourceRoutingQueueConditionalGroupRoutingRead(t *testing.T) {
-	tQueueId := uuid.NewString()
-	tRules := generateRuleData()
-	tId := tQueueId + "/rules"
+func TestUnitFlattenConditionalGroupRouting(t *testing.T) {
+	var (
+		metric                 = "test"
+		operator               = "GreaterThan"
+		conditionValue float64 = 2345
+		waitSeconds            = 5432
+	)
+	cgrRules := generateRuleData(metric, operator, conditionValue, waitSeconds)
 
-	if !featureToggles.CSGToggleExists() {
-		t.Skipf("Skipping because %s env variable is not set", featureToggles.CSGToggleName())
+	// testing buildConditionalGroupRouting function
+	cgrRulesFlattened := flattenConditionalGroupRouting(&cgrRules)
+	if len(cgrRulesFlattened) != 1 {
+		t.Errorf("Expected 1 rule, got %d", len(cgrRulesFlattened))
 	}
 
-	groupRoutingProxy := &routingQueueConditionalGroupRoutingProxy{}
-
-	groupRoutingProxy.getRoutingQueueConditionRoutingAttr = func(ctx context.Context, p *routingQueueConditionalGroupRoutingProxy, queueId string) (*[]platformclientv2.Conditionalgrouproutingrule, *platformclientv2.APIResponse, error) {
-		apiResponse := platformclientv2.APIResponse{StatusCode: http.StatusOK}
-		return &tRules, &apiResponse, nil
+	cgrRule, ok := cgrRulesFlattened[0].(map[string]any)
+	if !ok {
+		t.Errorf("Expected map[string]any, got %T", cgrRulesFlattened[0])
 	}
 
-	internalProxy = groupRoutingProxy
-	defer func() { internalProxy = nil }()
+	metricFlattened, ok := cgrRule["metric"].(string)
+	if !ok {
+		t.Errorf("Expected metric to be a string, got %T", cgrRule["metric"])
+	}
+	if metricFlattened != metric {
+		t.Errorf("Expected metric to be 'test', got %s", cgrRule["metric"].(string))
+	}
 
-	ctx := context.Background()
-	gcloud := &provider.ProviderMeta{ClientConfig: &platformclientv2.Configuration{}}
+	operatorFlattened, ok := cgrRule["operator"].(string)
+	if !ok {
+		t.Errorf("Expected operator to be a string, got %T", cgrRule["operator"])
+	}
+	if operatorFlattened != "GreaterThan" {
+		t.Errorf("Expected operator to be 'GreaterThan', got %s", operatorFlattened)
+	}
 
-	//Grab our defined schema
-	resourceSchema := ResourceRoutingQueueConditionalGroupRouting().Schema
+	conditionValueFlattened, ok := cgrRule["condition_value"].(float64)
+	if !ok {
+		t.Errorf("Expected condition_value to be a float64, got %T", cgrRule["condition_value"])
+	}
+	if conditionValueFlattened != 2345 {
+		t.Errorf("Expected condition_value to be 2345, got %f", conditionValueFlattened)
+	}
 
-	//Setup a map of values
-	resourceDataMap := buildConditionalGroupRoutingResourceMap(tQueueId, &tRules)
-
-	d := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
-	d.SetId(tId)
-
-	diag := readRoutingQueueConditionalRoutingGroup(ctx, d, gcloud)
-	assert.Equal(t, false, diag.HasError(), diag)
-
-	assert.Equal(t, tId, d.Id())
-	rules, err := buildConditionalGroupRouting(d.Get("rules").([]interface{}))
-	assert.Equal(t, err, nil)
-	equal := cmp.Equal(tRules, rules)
-	assert.Equal(t, true, equal, "rules not equal to expected value in read: %s", cmp.Diff(tRules, rules))
+	groupsFlattened, ok := cgrRule["groups"].(*schema.Set)
+	if !ok {
+		t.Errorf("Expected *schema.Set, got %T", cgrRule["groups"])
+	}
+	if len(groupsFlattened.List()) != 3 {
+		t.Errorf("Expected 3 groups, got %d", len(groupsFlattened.List()))
+	}
 }
 
-func generateRuleData() []platformclientv2.Conditionalgrouproutingrule {
+func generateRuleData(metric, operator string, conditionValue float64, waitSeconds int) []platformclientv2.Conditionalgrouproutingrule {
 	groupMember1 := platformclientv2.Membergroup{
 		Id:      platformclientv2.String(uuid.NewString()),
 		VarType: platformclientv2.String("TEAM"),
@@ -114,23 +154,14 @@ func generateRuleData() []platformclientv2.Conditionalgrouproutingrule {
 	group1 := []platformclientv2.Membergroup{groupMember1, groupMember2, groupMember3}
 
 	rule1 := platformclientv2.Conditionalgrouproutingrule{
-		Metric:         platformclientv2.String("test"),
-		Operator:       platformclientv2.String("GreaterThan"),
-		ConditionValue: platformclientv2.Float64(2345),
+		Metric:         platformclientv2.String(metric),
+		Operator:       platformclientv2.String(operator),
+		ConditionValue: platformclientv2.Float64(conditionValue),
 		Groups:         &group1,
-		WaitSeconds:    platformclientv2.Int(5432),
+		WaitSeconds:    platformclientv2.Int(waitSeconds),
 	}
 
 	rules := []platformclientv2.Conditionalgrouproutingrule{rule1}
 
 	return rules
-}
-
-func buildConditionalGroupRoutingResourceMap(queueId string, rules *[]platformclientv2.Conditionalgrouproutingrule) map[string]interface{} {
-	resourceDataMap := map[string]interface{}{
-		"queue_id": queueId,
-		"rules":    flattenConditionalGroupRouting(rules),
-	}
-
-	return resourceDataMap
 }


### PR DESCRIPTION
After converting to TypeSet, the function `TestResourceDataRaw` in the schema package was failing and causing those unit tests to fail. In the end, I just scrapped them and wrote new unit tests for the build and flatten functions. 