### PR TITLE
[Devtooling-834] hasPeer Not exported

### DIFF
--- a/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
@@ -49,7 +49,7 @@ func hydrateRoutingQueueCacheFn(c *rc.DataSourceCache, ctx context.Context) erro
 
 	queues, resp, err := proxy.GetAllRoutingQueues(ctx, "", false)
 	if err != nil {
-		return fmt.Errorf("failed to get routing queues. Error: %s | API Response: %s", err.Error(), resp.String())
+		return fmt.Errorf("failed to get routing queues. Error: %s | API Response: %s", err.Error(), resp)
 	}
 
 	if queues != nil || len(*queues) != 0 {
@@ -58,10 +58,10 @@ func hydrateRoutingQueueCacheFn(c *rc.DataSourceCache, ctx context.Context) erro
 
 	trueQueues, resp, err := proxy.GetAllRoutingQueues(ctx, "", true)
 	if err != nil {
-		return fmt.Errorf("failed to get routing queues. Error: %s | API Response: %s", err.Error(), resp.String())
+		return fmt.Errorf("failed to get routing queues. Error: %s | API Response: %s", err.Error(), resp)
 	}
 
-	if trueQueues != nil || len(*trueQueues) != 0 {
+	if trueQueues != nil && len(*trueQueues) != 0 {
 		allQueues = append(allQueues, *trueQueues...)
 	}
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -30,20 +30,30 @@ var bullseyeExpansionTypeTimeout = "TIMEOUT_SECONDS"
 func getAllRoutingQueues(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := GetRoutingQueueProxy(clientConfig)
+	var allQueues []platformclientv2.Queue
 
 	// Newly created resources often aren't returned unless there's a delay
 	time.Sleep(5 * time.Second)
 
-	queues, resp, err := proxy.GetAllRoutingQueues(ctx, "")
+	queues, resp, err := proxy.GetAllRoutingQueues(ctx, "", false)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get routing queues: %s", err), resp)
 	}
 
-	if queues == nil || len(*queues) == 0 {
-		return resources, nil
+	if queues != nil || len(*queues) != 0 {
+		allQueues = append(allQueues, *queues...)
 	}
 
-	for _, queue := range *queues {
+	queues, resp, err = proxy.GetAllRoutingQueues(ctx, "", true)
+	if err != nil {
+		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get routing queues with Peer IDs: %s", err), resp)
+	}
+
+	if queues != nil || len(*queues) != 0 {
+		allQueues = append(allQueues, *queues...)
+	}
+
+	for _, queue := range allQueues {
 		resources[*queue.Id] = &resourceExporter.ResourceMeta{BlockLabel: *queue.Name}
 	}
 

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
@@ -32,7 +32,7 @@ func getAllAuthRoutingQueueConditionalGroup(ctx context.Context, clientConfig *p
 		return nil, nil
 	}
 
-	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "")
+	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get conditional group routing rules: %s", err), resp)
 	}

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
@@ -32,7 +32,7 @@ func getAllAuthRoutingQueueOutboundEmailAddress(ctx context.Context, clientConfi
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := getRoutingQueueOutboundEmailAddressProxy(clientConfig)
 
-	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "")
+	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, "failed to get outbound email addresses for routing queues", resp)
 	}


### PR DESCRIPTION
This PR changes the export for queues to account for queues with peer_id, using the hasPeer flag in the API call