### PR TITLE
[Devtooling-960] outbound_contact_list exporting incorrectly

### DIFF
--- a/docs/resources/outbound_contact_list.md
+++ b/docs/resources/outbound_contact_list.md
@@ -65,12 +65,12 @@ resource "genesyscloud_outbound_contact_list" "contact-list" {
 Required:
 
 - `column_name` (String) The column name of a column selected for dynamic queueing.
-- `max_length` (Number) The maximum length of the text column selected for dynamic queueing.
 
 Optional:
 
 - `column_data_type` (String) The data type of the column selected for dynamic queueing (TEXT, NUMERIC or TIMESTAMP)
 - `max` (Number) The maximum length of the numeric column selected for dynamic queueing.
+- `max_length` (Number) The maximum length of the text column selected for dynamic queueing.
 - `min` (Number) The minimum length of the numeric column selected for dynamic queueing.
 
 

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_schema.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_schema.go
@@ -83,7 +83,7 @@ var (
 			},
 			`max_length`: {
 				Description: `The maximum length of the text column selected for dynamic queueing.`,
-				Required:    true,
+				Optional:    true,
 				Type:        schema.TypeInt,
 			},
 		},


### PR DESCRIPTION
In the ticket for this [960], I think the problem is caused by a difference with the terraform schema and the api requirements. The 'max_length' field is required in terraform, but when calling the API its only required when 'TEXT' is set as the data type. For 'NUMERIC' types, it is 'max' and 'min' that are required. Since terraform requires 'max_length', exporting a NUMERIC type will cause an error as 'max_length' might not have been set. Setting 'max_length' to optional fixes the issue, but the other option is some validation logic when creating and reading to reflect the API.