### PR TITLE
No JIRA: Slight change to commands in release build to prevent race condition.

### DIFF
--- a/jenkins/release/Jenkinsfile
+++ b/jenkins/release/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 
       steps {
          withCredentials([file(credentialsId: 'TERRAFORM_GPG', variable: 'terraform_gpg_private_key')]) {
-                    sh "cp \$terraform_gpg_private_key /tmp/terraform_gpg_secret.asc & chmod 755 /tmp/terraform_gpg_secret.asc"
+                    sh "cp \$terraform_gpg_private_key /tmp/terraform_gpg_secret.asc && chmod 755 /tmp/terraform_gpg_secret.asc"
                     sh "./addCredToConfig.sh"
                     sh "rm -f secret.asc"
         }


### PR DESCRIPTION
Sometimes the build fails because the `chmod` command is executed before the `cp`. This is because `&` means runs the first command in the background and move right onto the second. Changing to `&&` will fix the problem as it means only run the second command if the first is successful. 