### PR TITLE
No jira: Fix trunkbase setting data source test failure

### DIFF
--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -3,6 +3,7 @@ package telephony_provider_edges_trunkbasesettings
 import (
 	"context"
 	"fmt"
+	"github.com/mypurecloud/platform-client-sdk-go/v152/platformclientv2"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"time"
@@ -14,26 +15,43 @@ import (
 )
 
 func dataSourceTrunkBaseSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	sdkConfig := m.(*provider.ProviderMeta).ClientConfig
-	proxy := getTrunkBaseSettingProxy(sdkConfig)
+	var (
+		sdkConfig = m.(*provider.ProviderMeta).ClientConfig
+		proxy     = getTrunkBaseSettingProxy(sdkConfig)
 
-	name := d.Get("name").(string)
-	return util.WithRetries(ctx, 1*time.Second, func() *retry.RetryError {
+		name          = d.Get("name").(string)
+		notFoundError = fmt.Errorf("no trunkbase settings found with name '%s'", name)
+		response      *platformclientv2.APIResponse
+	)
+
+	retryErr := util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {
 		trunkBaseSettings, resp, getErr := proxy.GetAllTrunkBaseSettingWithName(ctx, name)
+		response = resp
 
 		if getErr != nil {
-			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("error requesting trunk base setting with name %s | error: %s", name, getErr), resp))
+			return retry.NonRetryableError(fmt.Errorf("error requesting trunk base setting with name '%s' | error: %s", name, getErr))
+		}
+
+		if trunkBaseSettings == nil || len(*trunkBaseSettings) == 0 {
+			return retry.RetryableError(notFoundError)
 		}
 
 		for _, trunkBaseSetting := range *trunkBaseSettings {
-			if trunkBaseSetting.Name != nil && *trunkBaseSetting.Name == name &&
-				trunkBaseSetting.State != nil && *trunkBaseSetting.State != "deleted" {
+			if trunkBaseSetting.Name == nil || *trunkBaseSetting.Name != name {
+				continue
+			}
+			if trunkBaseSetting.State != nil && *trunkBaseSetting.State != "deleted" {
 				d.SetId(*trunkBaseSetting.Id)
-
 				return nil
 			}
+			return retry.NonRetryableError(fmt.Errorf("found trunkbase setting with name '%s', but could not verify that state is not 'deleted'", name))
 		}
 
-		return nil
+		return retry.RetryableError(notFoundError)
 	})
+
+	if retryErr != nil {
+		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to read trunkbase setting with name '%s' | errror: %v", name, retryErr), response)
+	}
+	return nil
 }

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
@@ -2,13 +2,11 @@ package telephony_provider_edges_trunkbasesettings
 
 import (
 	"fmt"
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
-	"time"
-
-	"github.com/google/uuid"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
 func TestAccDataSourceTrunkBaseSettings(t *testing.T) {
@@ -32,19 +30,6 @@ func TestAccDataSourceTrunkBaseSettings(t *testing.T) {
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{
-				Config: GenerateTrunkBaseSettingsResourceWithCustomAttrs(
-					trunkBaseSettingsResourceLabel,
-					name,
-					description,
-					trunkMetaBaseId,
-					trunkType,
-					managed,
-				),
-			},
-			{
-				PreConfig: func() {
-					time.Sleep(1 * time.Second)
-				},
 				Config: GenerateTrunkBaseSettingsResourceWithCustomAttrs(
 					trunkBaseSettingsResourceLabel,
 					name,

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
@@ -5,6 +5,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/provider"
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -20,6 +21,9 @@ func TestAccDataSourceTrunkBaseSettings(t *testing.T) {
 		trunkMetaBaseId                    = "phone_connections_webrtc.json"
 		trunkType                          = "PHONE"
 		managed                            = false
+
+		dataResourcePath = "data." + ResourceType + "." + trunkBaseSettingsDataResourceLabel
+		resourcePath     = ResourceType + "." + trunkBaseSettingsResourceLabel
 	)
 
 	resource.Test(t, resource.TestCase{
@@ -35,12 +39,25 @@ func TestAccDataSourceTrunkBaseSettings(t *testing.T) {
 					trunkMetaBaseId,
 					trunkType,
 					managed,
+				),
+			},
+			{
+				PreConfig: func() {
+					time.Sleep(1 * time.Second)
+				},
+				Config: GenerateTrunkBaseSettingsResourceWithCustomAttrs(
+					trunkBaseSettingsResourceLabel,
+					name,
+					description,
+					trunkMetaBaseId,
+					trunkType,
+					managed,
 				) + generateTrunkBaseSettingsDataSource(
 					trunkBaseSettingsDataResourceLabel,
 					name,
-					"genesyscloud_telephony_providers_edges_trunkbasesettings."+trunkBaseSettingsResourceLabel),
+					resourcePath),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrPair("data.genesyscloud_telephony_providers_edges_trunkbasesettings."+trunkBaseSettingsDataResourceLabel, "id", "genesyscloud_telephony_providers_edges_trunkbasesettings."+trunkBaseSettingsResourceLabel, "id"),
+					resource.TestCheckResourceAttrPair(dataResourcePath, "id", resourcePath, "id"),
 				),
 			},
 		},

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -132,7 +132,7 @@ func updateTrunkBaseSettings(ctx context.Context, d *schema.ResourceData, meta i
 		trunkBase.Version = trunkBaseSettings.Version
 
 		log.Printf("Updating trunk base settings %s", name)
-		trunkBaseSettings, resp, err := proxy.UpdateTrunkBaseSetting(ctx, d.Id(), trunkBase)
+		_, resp, err := proxy.UpdateTrunkBaseSetting(ctx, d.Id(), trunkBase)
 		if err != nil {
 
 			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update trunk base settings %s error: %s", name, err), resp)

--- a/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony_provider_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -10,6 +10,7 @@ import (
 	"terraform-provider-genesyscloud/genesyscloud/util"
 	"terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"terraform-provider-genesyscloud/genesyscloud/util/lists"
+	"terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -174,61 +175,50 @@ func readTrunkBaseSettings(ctx context.Context, d *schema.ResourceData, meta int
 	proxy := getTrunkBaseSettingProxy(sdkConfig)
 
 	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceTrunkBaseSettings(), constants.ConsistencyChecks(), ResourceType)
+	var response *platformclientv2.APIResponse
 
 	log.Printf("Reading trunk base settings %s", d.Id())
-	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
+	readErr := util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
 		trunkBaseSettings, resp, getErr := proxy.GetTrunkBaseSettingById(ctx, d.Id())
+		response = resp
 
 		if getErr != nil {
 			if util.IsStatus404(resp) {
-				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read trunk base settings %s | error: %s", d.Id(), getErr), resp))
+				return retry.RetryableError(getErr)
 			}
-			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read trunk base settings %s | error: %s", d.Id(), getErr), resp))
+			return retry.NonRetryableError(getErr)
 		}
 
-		if trunkBaseSettings != nil && trunkBaseSettings.Name != nil {
-			d.Set("name", *trunkBaseSettings.Name)
+		if trunkBaseSettings == nil {
+			return retry.NonRetryableError(fmt.Errorf("succesfully read trunkbase setting '%s', but response body was nil", d.Id()))
 		}
 
-		if trunkBaseSettings != nil && trunkBaseSettings.State != nil {
-			d.Set("state", *trunkBaseSettings.State)
-		}
+		resourcedata.SetNillableValue(d, "name", trunkBaseSettings.Name)
+		resourcedata.SetNillableValue(d, "state", trunkBaseSettings.State)
+		resourcedata.SetNillableValue(d, "description", trunkBaseSettings.Description)
+		resourcedata.SetNillableValue(d, "managed", trunkBaseSettings.Managed)
+		resourcedata.SetNillableReference(d, "trunk_meta_base_id", trunkBaseSettings.TrunkMetabase)
+		resourcedata.SetNillableReference(d, "inbound_site_id", trunkBaseSettings.InboundSite)
+		resourcedata.SetNillableReference(d, "site_id", trunkBaseSettings.Site)
+		resourcedata.SetNillableValue(d, "trunk_type", trunkBaseSettings.TrunkType)
 
-		if trunkBaseSettings.Description != nil {
-			d.Set("description", *trunkBaseSettings.Description)
-		}
-		if trunkBaseSettings.Managed != nil {
-			d.Set("managed", *trunkBaseSettings.Managed)
-		}
-
-		// check if Id is null or not for both metabase and inboundsite
-		if trunkBaseSettings != nil && trunkBaseSettings.TrunkMetabase != nil && trunkBaseSettings.TrunkMetabase.Id != nil {
-			d.Set("trunk_meta_base_id", *trunkBaseSettings.TrunkMetabase.Id)
-		}
-
-		// check if Id is null or not for both metabase and inboundsite
-		if trunkBaseSettings != nil && trunkBaseSettings.InboundSite != nil {
-			d.Set("inbound_site_id", *trunkBaseSettings.InboundSite.Id)
-		}
-
-		if trunkBaseSettings != nil && trunkBaseSettings.Site != nil {
-			d.Set("site_id", *trunkBaseSettings.Site.Id)
-		}
-
-		if trunkBaseSettings != nil && trunkBaseSettings.TrunkType != nil {
-			d.Set("trunk_type", *trunkBaseSettings.TrunkType)
-		}
-		d.Set("properties", nil)
+		_ = d.Set("properties", nil)
 		if trunkBaseSettings.Properties != nil {
 			properties, err := util.FlattenTelephonyProperties(trunkBaseSettings.Properties)
 			if err != nil {
 				return retry.NonRetryableError(fmt.Errorf("%v", err))
 			}
-			d.Set("properties", properties)
+			_ = d.Set("properties", properties)
 		}
 
 		return cc.CheckState(d)
 	})
+
+	if readErr != nil {
+		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to read trunkbase setting '%s' | error: %v", d.Id(), readErr), response)
+	}
+
+	return nil
 }
 
 func deleteTrunkBaseSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {


### PR DESCRIPTION
The data source read function for trunkbase settings was only retrying for 1 second and there was no condition where it would return a retryable error 