### PR TITLE
Feat/gpe 14858 update segment contract

### DIFF
--- a/docs/resources/journey_segment.md
+++ b/docs/resources/journey_segment.md
@@ -64,6 +64,7 @@ resource "genesyscloud_journey_segment" "example_journey_segment_resource" {
 
 ### Optional
 
+- `assignment_expiration_days` (Number) Time, in days, from when the segment is assigned until it is automatically unassigned.
 - `context` (Block Set, Max: 1) The context of the segment. (see [below for nested schema](#nestedblock--context))
 - `description` (String) A description of the segment.
 - `is_active` (Boolean) Whether or not the segment is active. Defaults to `true`.

--- a/docs/resources/journey_segment.md
+++ b/docs/resources/journey_segment.md
@@ -60,7 +60,7 @@ resource "genesyscloud_journey_segment" "example_journey_segment_resource" {
 
 - `color` (String) The hexadecimal color value of the segment.
 - `display_name` (String) The display name of the segment.
-- `scope` (String) The target entity that a segment applies to. Valid values: Session
+- `scope` (String, Deprecated) The target entity that a segment applies to. Valid values: Session
 
 ### Optional
 

--- a/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_schema.go
+++ b/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_schema.go
@@ -72,7 +72,7 @@ var (
 			MaxItems:    1,
 			Elem:        journeyResource,
 		},
-		"assignmentExpirationDays": {
+		"assignment_expiration_days": {
 			Description:  "Time, in days, from when the segment is assigned until it is automatically unassigned.",
 			Type:         schema.TypeInt,
 			Optional:     true,

--- a/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_schema.go
+++ b/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_schema.go
@@ -52,6 +52,7 @@ var (
 			Required:     true,
 			ForceNew:     true, // scope can be only set during creation
 			ValidateFunc: validation.StringInSlice([]string{"Session"}, false),
+			Deprecated:   "The scope field is redundant and will be removed in a future release.",
 		},
 		"should_display_to_agent": {
 			Description: "Whether or not the segment should be displayed to agent/supervisor users.",

--- a/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_schema.go
+++ b/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_schema.go
@@ -72,6 +72,12 @@ var (
 			MaxItems:    1,
 			Elem:        journeyResource,
 		},
+		"assignmentExpirationDays": {
+			Description:  "Time, in days, from when the segment is assigned until it is automatically unassigned.",
+			Type:         schema.TypeInt,
+			Optional:     true,
+			ValidateFunc: validation.IntAtLeast(0),
+		},
 	}
 
 	contextResource = &schema.Resource{

--- a/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_utils.go
+++ b/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_utils.go
@@ -18,6 +18,7 @@ func flattenJourneySegment(d *schema.ResourceData, journeySegment *platformclien
 	resourcedata.SetNillableValue(d, "should_display_to_agent", journeySegment.ShouldDisplayToAgent)
 	resourcedata.SetNillableValue(d, "context", lists.FlattenAsList(journeySegment.Context, flattenContext))
 	resourcedata.SetNillableValue(d, "journey", lists.FlattenAsList(journeySegment.Journey, flattenJourney))
+	resourcedata.SetNillableValue(d, "assignment_expiration_days", journeySegment.AssignmentExpirationDays)
 }
 
 func buildSdkJourneySegment(journeySegment *schema.ResourceData) *platformclientv2.Journeysegmentrequest {
@@ -29,16 +30,18 @@ func buildSdkJourneySegment(journeySegment *schema.ResourceData) *platformclient
 	shouldDisplayToAgent := resourcedata.GetNillableBool(journeySegment, "should_display_to_agent")
 	sdkContext := resourcedata.BuildSdkListFirstElement(journeySegment, "context", buildSdkRequestContext, false)
 	journey := resourcedata.BuildSdkListFirstElement(journeySegment, "journey", buildSdkRequestJourney, false)
+	assignmentExpirationDays := resourcedata.GetNillableValue[int](journeySegment, "assignment_expiration_days")
 
 	return &platformclientv2.Journeysegmentrequest{
-		IsActive:             &isActive,
-		DisplayName:          &displayName,
-		Description:          description,
-		Color:                &color,
-		Scope:                &scope,
-		ShouldDisplayToAgent: shouldDisplayToAgent,
-		Context:              sdkContext,
-		Journey:              journey,
+		IsActive:                 &isActive,
+		DisplayName:              &displayName,
+		Description:              description,
+		Color:                    &color,
+		Scope:                    &scope,
+		ShouldDisplayToAgent:     shouldDisplayToAgent,
+		Context:                  sdkContext,
+		Journey:                  journey,
+		AssignmentExpirationDays: assignmentExpirationDays,
 	}
 }
 
@@ -50,6 +53,7 @@ func buildSdkPatchSegment(journeySegment *schema.ResourceData) *platformclientv2
 	shouldDisplayToAgent := resourcedata.GetNillableBool(journeySegment, "should_display_to_agent")
 	sdkContext := resourcedata.BuildSdkListFirstElement(journeySegment, "context", buildSdkPatchContext, false)
 	journey := resourcedata.BuildSdkListFirstElement(journeySegment, "journey", buildSdkPatchJourney, false)
+	assignmentExpirationDays := resourcedata.GetNillableValue[int](journeySegment, "assignment_expiration_days")
 
 	sdkPatchSegment := platformclientv2.Patchsegment{}
 	sdkPatchSegment.SetField("IsActive", &isActive)
@@ -59,6 +63,7 @@ func buildSdkPatchSegment(journeySegment *schema.ResourceData) *platformclientv2
 	sdkPatchSegment.SetField("ShouldDisplayToAgent", shouldDisplayToAgent)
 	sdkPatchSegment.SetField("Context", sdkContext)
 	sdkPatchSegment.SetField("Journey", journey)
+	sdkPatchSegment.SetField("AssignmentExpirationDays", assignmentExpirationDays)
 	return &sdkPatchSegment
 }
 

--- a/test/data/data_source/genesyscloud_journey_segment/find_by_name/01_find_by_name.tf
+++ b/test/data/data_source/genesyscloud_journey_segment/find_by_name/01_find_by_name.tf
@@ -22,4 +22,5 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
 }

--- a/test/data/resource/genesyscloud_journey_segment/basic_attributes/01_basic_resource.tf
+++ b/test/data/resource/genesyscloud_journey_segment/basic_attributes/01_basic_resource.tf
@@ -27,4 +27,5 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
 }

--- a/test/data/resource/genesyscloud_journey_segment/basic_attributes/02_update_attributes.tf
+++ b/test/data/resource/genesyscloud_journey_segment/basic_attributes/02_update_attributes.tf
@@ -28,4 +28,5 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 2
 }

--- a/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/01_create_context_only.tf
+++ b/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/01_create_context_only.tf
@@ -14,4 +14,5 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       }
     }
   }
+  assignment_expiration_days = 1
 }

--- a/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/02_update_to_journey_only.tf
+++ b/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/02_update_to_journey_only.tf
@@ -16,4 +16,5 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
 }

--- a/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/03_update_add_criteria.tf
+++ b/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/03_update_add_criteria.tf
@@ -22,4 +22,5 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
 }

--- a/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/04_update_add_pattern.tf
+++ b/test/data/resource/genesyscloud_journey_segment/context_only_to_journey_only/04_update_add_pattern.tf
@@ -33,4 +33,5 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
 }

--- a/test/data/resource/genesyscloud_journey_segment/optional_attributes/01_create.tf
+++ b/test/data/resource/genesyscloud_journey_segment/optional_attributes/01_create.tf
@@ -17,6 +17,7 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
   # optional
   description                = "Test description"
 }

--- a/test/data/resource/genesyscloud_journey_segment/optional_attributes/02_update_all_optional_changed.tf
+++ b/test/data/resource/genesyscloud_journey_segment/optional_attributes/02_update_all_optional_changed.tf
@@ -17,6 +17,7 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
   # optional
   description                = "Test description updated"
 }

--- a/test/data/resource/genesyscloud_journey_segment/optional_attributes/03_update_remove_description.tf
+++ b/test/data/resource/genesyscloud_journey_segment/optional_attributes/03_update_remove_description.tf
@@ -17,5 +17,6 @@ resource "genesyscloud_journey_segment" "terraform_test_-TEST-CASE-" {
       session_type = "web"
     }
   }
+  assignment_expiration_days = 1
   # optional
 }


### PR DESCRIPTION
As part of the in-progress Customer Segmentation feature, Journey Segments can be directly assigned to an external contact (representing the end user), rather than the user's session. This allows Segments to live beyond the lifetime of the session. A new field is being added to the Segment, for admins to configure how long these Segment assignments to a contact should last. This PR adds this new field to the CX as Code repo.