### PR TITLE
Fixed the reference to Canned Response Libraries in the RoutingQueueExporter function

### DIFF
--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -627,7 +627,7 @@ func RoutingQueueExporter() *resourceExporter.ResourceExporter {
 			"groups":                                   {RefType: group.ResourceType},
 			"conditional_group_routing_rules.queue_id": {RefType: ResourceType},
 			"direct_routing.backup_queue_id":           {RefType: ResourceType},
-			"canned_response_libraries.library_ids.*":  {RefType: responseManagementLibrary.ResourceType},
+			"canned_response_libraries.library_ids":    {RefType: responseManagementLibrary.ResourceType},
 		},
 		RemoveIfMissing: map[string][]string{
 			"outbound_email_address": {"route_id"},


### PR DESCRIPTION
Provider 1.61.0

Queue canned response libraries currently get exported with hard-coded IDs instead of references to terraform resource "genesyscloud_responsemanagement_library"

### **Current export data:**
resource "genesyscloud_routing_queue" "NL_C_DEFAULT_Q1" {
  canned_response_libraries {
    **library_ids = ["abab5121-4b40-4e25-86e0-814d3b7a8f58", "a6cacb4f-ac6f-40a0-b1a2-272cc35fe7b0", "e1e57682-e75e-472a-be5b-a340b1b7ce25"]**
    mode        = "SelectedOnly"
  }

### **After the fix:**
resource "genesyscloud_routing_queue" "NL_C_DEFAULT_Q1" {
  canned_response_libraries {
    **library_ids = ["${genesyscloud_responsemanagement_library.ESI_NL_Jaarwissel.id}", "${genesyscloud_responsemanagement_library.ESI_NL_English.id}", "${genesyscloud_responsemanagement_library.ESI_NL_Nederlands.id}"]**
    mode        = "SelectedOnly"
  }