### PR TITLE
Architect IVR dnis computed issue

### DIFF
--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_schema.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_schema.go
@@ -65,7 +65,7 @@ func ResourceArchitectIvrConfig() *schema.Resource {
 				Description: fmt.Sprintf("The phone number(s) to contact the IVR by. Each phone number in the array must be in an E.164 number format. (Note: An array with a length greater than %v will be broken into chunks and uploaded in subsequent PUT requests.)", maxDnisPerRequest),
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Computed:    true,
+				Computed:    false,
 				Elem:        &schema.Schema{Type: schema.TypeString, ValidateDiagFunc: validators.ValidatePhoneNumber},
 			},
 			"open_hours_flow_id": {


### PR DESCRIPTION
Provider 1.61.0

The issue is related to resource "genesyscloud_architect_ivr" field "dnis" being set as "Computed = true". When not available in the Terraform configuration, this field retrieves its value from the state. This prevents phone numbers from being transferred between IVRs as the dnis must be unique and not in use by another resource.

**Error:**

Failed to create IVR config IVR_PROD error: error performing create inside function uploadArchitectIvrWithChunkingLogic: API Error: 400 - PhoneNumber with text '+33173290933' already exists.

**Scenario:**

- Org A has IVR_DEV configured with dnis "+33173290933"

- Org B has IVR_DEV configured with dnis "+33173290933"

- GC admin manually removes the dnis "+33173290933" from IVR_DEV on Org A, and configures the same dnis for IVR_PROD on Org_A

- Current Configurations: Org A IVR_DEV configured with no dnis, Org A IVR_PROD configured with dnis "+33173290933" and org B IVR_DEV configured with dnis "+33173290933"

- GC admin now applies Org A's configuration to Org B using the provider

- Even though the terraform resource for IVR_DEV from Org A does not have any DNIS set, the PUT api call contains the dnis, as it pulls the information from the state file of Org B (DNIS being a computed field). This results in IVR_DEV on org B still having the dnis value even though it doesn't exist on IVR_DEV from org A anymore.

- Once IVR_PROD resource is applied to the destination org B, it fails to create the resource because that number already exists on resource IVR_DEV.

**Resources applied:**

resource "genesyscloud_architect_ivr" "**IVR_DEV**" {
  division_id        = "${genesyscloud_auth_division.ESI_FR_TEST.id}"
  name               = "IVR_DEV"
  open_hours_flow_id = "50c807a4-7aa6-4c51-a161-bd07f0924a28"
}
resource "genesyscloud_architect_ivr" "**IVR_PROD**" {
  division_id        = "${genesyscloud_auth_division.ESI_FR.id}"
  dnis               = ["+33173290933"]
  name               = "IVR_PROD"
  open_hours_flow_id = "268f0f88-6743-4a2e-9311-9f15a01e8866"


See below API call; we can see the DNIS is provided in the payload, even though that DNIS doesn't exist on the Terraform resource "IVR_DEV" above:

URL: https://api.mypurecloud.ie/api/v2/architect/ivrs/e6c7abef-b0b2-4647-b99d-f0c19d646efb
Method: PUT
Body: {"name":"**IVR_DEV**","division":{"id":"3f81301e-f38c-4bec-b296-2356c279da42"},"version":1,"**dnis":["+33173290933"]**,"openHoursFlow":{"id":"50c807a4-7aa6-4c51-a161-bd07f0924a28"}}

**Fix:**

Changing dnis Computed to False, so it doesn't retrieve its value from the state when not specified in the configuration. 

SDK log after switching it to False

The request for IVR_DEV now does not contain any dnis: 

URL: https://api.mypurecloud.ie/api/v2/architect/ivrs/e6c7abef-b0b2-4647-b99d-f0c19d646efb
Method: PUT
Body: {"name":"**IVR_DEV**","division":{"id":"3f81301e-f38c-4bec-b296-2356c279da42"},"version":1,"openHoursFlow":{"id":"50c807a4-7aa6-4c51-a161-bd07f0924a28"}}

The request for IVR_PROD contains the dnis and the IVR can be created successfully as the dnis is no longer in use by IVR_DEV:

URL: https://api.mypurecloud.ie/api/v2/architect/ivrs
Method: POST
Body: {"name":"IVR_PROD","division":{"id":"a03b1a29-3e69-4f99-90ef-58cf55f78654"},**"dnis":["+33173290933"]**,"openHoursFlow":{"id":"268f0f88-6743-4a2e-9311-9f15a01e8866"}}

