### PR TITLE
DEVTOOLING-1175 - Fix Unaligned Atomic Operations

### DIFF
--- a/genesyscloud/provider/sdk_client_pool.go
+++ b/genesyscloud/provider/sdk_client_pool.go
@@ -49,19 +49,19 @@ type SDKClientPool struct {
 }
 
 type SDKClientPoolConfig struct {
-	MaxClients     int
 	AcquireTimeout time.Duration
 	InitTimeout    time.Duration
+	MaxClients     int
 	DebugLogging   bool
 }
 
 type poolMetrics struct {
-	mu              sync.RWMutex
+	activeClients   int64
+	acquireTimeouts int64
 	totalAcquires   int64
 	totalReleases   int64
-	acquireTimeouts int64
 	lastAcquireTime time.Time
-	activeClients   int64
+	mu              sync.RWMutex
 }
 
 func (m *poolMetrics) recordAcquire() {


### PR DESCRIPTION
Fixes https://inindca.atlassian.net/browse/DEVTOOLING-1175
Reorder structs to ensure proper alignment, specifically for 32-bit systems. 

Some details from Amazon Q:

> On 32-bit systems, the struct fields need to be ordered carefully to ensure proper alignment for atomic operations. Go ensures proper alignment of the first field in a struct, and by putting the 64-bit fields first, we guarantee they'll be properly aligned for atomic operations. The Go compiler will ensure the struct starts at an 8-byte boundary, and since the 64-bit fields are first, they're guaranteed to maintain that alignment. This ensures atomic operations on these fields will work correctly.
> The key principles to apply:
> 1. Put 64-bit fields first
> 2. Group fields by size (64-bit, 32-bit, 16-bit, 8-bit)
> 3. Put complex types (like time.Time and sync.RWMutex) after the primitive types

