### PR TITLE
Feature/devtooling 1183 - Add support to BCP Sanitizer for including a hash of unique fields in the block label

### DIFF
--- a/genesyscloud/architect_flow/resource_genesyscloud_flow.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_flow.go
@@ -33,17 +33,22 @@ func getAllFlows(ctx context.Context, clientConfig *platformclientv2.Configurati
 
 	for _, flow := range *flows {
 
+		blockHash, err := util.QuickHashFields(flow.VarType)
+		if err != nil {
+			return nil, diag.Errorf("failed to generate quick hash for flow %s: %v", *flow.Id, err)
+		}
+
 		//DEVTOOLING-393:  Putting this in here to deal with the situation where Cesar's BCP app is reliant on the naming structure
 		//This should be removed once the CX as Code architect export process is complete and will export files with the type in the name.
 		overrideBCPNaming := os.Getenv("OVERRIDE_BCP_NAMING")
 
 		if overrideBCPNaming != "" {
-			resources[*flow.Id] = &resourceExporter.ResourceMeta{BlockLabel: *flow.Name}
+			resources[*flow.Id] = &resourceExporter.ResourceMeta{BlockLabel: *flow.Name, BlockHash: blockHash}
 			continue
 		}
 
 		//This is our go forward naming standard for flows.
-		resources[*flow.Id] = &resourceExporter.ResourceMeta{BlockLabel: *flow.VarType + "_" + *flow.Name}
+		resources[*flow.Id] = &resourceExporter.ResourceMeta{BlockLabel: *flow.VarType + "_" + *flow.Name, BlockHash: blockHash}
 	}
 
 	return resources, nil

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -51,7 +51,7 @@ func getAllIntegrations(ctx context.Context, clientConfig *platformclientv2.Conf
 
 	for _, integration := range *integrations {
 		log.Printf("Dealing with integration id : %s, integration Name : %s", *integration.Id, *integration.Name)
-		blockHash, err := util.QuickHashFields(integration.IntegrationType.Id, integration.Notes)
+		blockHash, err := util.QuickHashFields(integration.IntegrationType.Id)
 		if err != nil {
 			return nil, diag.Errorf("failed to generate quick hash for integration %s: %v", *integration.Name, err)
 		}

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -51,7 +51,11 @@ func getAllIntegrations(ctx context.Context, clientConfig *platformclientv2.Conf
 
 	for _, integration := range *integrations {
 		log.Printf("Dealing with integration id : %s, integration Name : %s", *integration.Id, *integration.Name)
-		resources[*integration.Id] = &resourceExporter.ResourceMeta{BlockLabel: *integration.Name}
+		blockHash, err := util.QuickHashFields(integration.IntegrationType.Id, integration.Notes)
+		if err != nil {
+			return nil, diag.Errorf("failed to generate quick hash for integration %s: %v", *integration.Name, err)
+		}
+		resources[*integration.Id] = &resourceExporter.ResourceMeta{BlockLabel: *integration.Name, BlockHash: blockHash}
 	}
 	return resources, nil
 }

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -51,7 +51,7 @@ func getAllIntegrations(ctx context.Context, clientConfig *platformclientv2.Conf
 
 	for _, integration := range *integrations {
 		log.Printf("Dealing with integration id : %s, integration Name : %s", *integration.Id, *integration.Name)
-		blockHash, err := util.QuickHashFields(integration.IntegrationType.Id)
+		blockHash, err := util.QuickHashFields(integration.IntegrationType.Id) // .Id is not a GUID here. It is a human readable consistent value.
 		if err != nil {
 			return nil, diag.Errorf("failed to generate quick hash for integration %s: %v", *integration.Name, err)
 		}

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
@@ -57,7 +57,11 @@ func getAllIntegrationActions(ctx context.Context, clientConfig *platformclientv
 		if strings.HasPrefix(*action.Id, "static") {
 			continue
 		}
-		resources[*action.Id] = &resourceExporter.ResourceMeta{BlockLabel: *action.Name}
+		blockHash, err := util.QuickHashFields(action.Category)
+		if err != nil {
+			return nil, diag.Errorf("error hashing integration action %s: %s", *action.Name, err)
+		}
+		resources[*action.Id] = &resourceExporter.ResourceMeta{BlockLabel: *action.Name, BlockHash: blockHash}
 	}
 	return resources, nil
 }

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
@@ -49,8 +49,20 @@ func getAllKnowledgeDocuments(ctx context.Context, clientConfig *platformclientv
 			return nil, util.BuildAPIDiagnosticError(ResourceType, err.Error(), response)
 		}
 		for _, knowledgeDocument := range *partialEntities {
+			blockHash := ""
+			if knowledgeDocument.Category != nil && knowledgeDocument.Category.Id != nil {
+				category, _, err := proxy.getKnowledgeKnowledgebaseCategory(ctx, *knowledgeBase.Id, *knowledgeDocument.Category.Id)
+				if err != nil {
+					return nil, diag.Errorf("error reading knowledge document %s category %s: %s", *knowledgeDocument.Id, *knowledgeDocument.Category.Id, err)
+
+				}
+				blockHash, err = util.QuickHashFields(*category.Name)
+				if err != nil {
+					return nil, diag.Errorf("error hashing knowledge document %s: %s", *knowledgeDocument.Id, err)
+				}
+			}
 			id := BuildDocumentResourceDataID(*knowledgeDocument.Id, *knowledgeBase.Id)
-			resources[id] = &resourceExporter.ResourceMeta{BlockLabel: *knowledgeBase.Name + "_" + *knowledgeDocument.Title}
+			resources[id] = &resourceExporter.ResourceMeta{BlockLabel: *knowledgeBase.Name + "_" + *knowledgeDocument.Title, BlockHash: blockHash}
 		}
 
 	}

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -26,14 +26,17 @@ type ResourceMeta struct {
 	// Prefix to add to the ID when reading state
 	IdPrefix string
 
-	// BlockHash represents a unique identifier generated from the resource's distinguishing attributes.
+	// BlockHash represents a unique identifier generated from the resource's distinguishing attributes,
+	// explicitly excluding IDs and calculated fields to enable cross-org resource correlation.
 	// Important:
 	//   * Use util.QuickHashFields() to generate this hash
 	//   * Only include fields that uniquely identify the resource WITHOUT using its ID
+	//   * Only include fields that would match if the resource exists in another org
+	//   * DO NOT include fields that are likely to be updated or modified as the resource evolves
 	//   * Do NOT include fields that are calculated (i.e., createdDate)
 	//   * ID fields and calculated field must be excluded from the hash calculation because:
 	//       - IDs and calculated values prevent correlation of resources across different exports and
-	//         make it impossible to compare equivalent resources between environments
+	//         make it impossible to compare equivalent resources between orgs
 	BlockHash string
 
 	// Represents the unsanitized version of the BlockLabel

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -26,6 +26,17 @@ type ResourceMeta struct {
 	// Prefix to add to the ID when reading state
 	IdPrefix string
 
+	// BlockHash represents a unique identifier generated from the resource's distinguishing attributes.
+	// Important:
+	//   * Use util.QuickHashFields() to generate this hash
+	//   * Only include fields that uniquely identify the resource WITHOUT using its ID
+	//   * Do NOT include fields that are calculated (i.e., createdDate)
+	//   * ID fields and calculated field must be excluded from the hash calculation because:
+	//       - IDs and calculated values prevent correlation of resources across different exports and
+	//         make it impossible to compare equivalent resources between environments
+	BlockHash string
+
+	// Represents the unsanitized version of the BlockLabel
 	OriginalLabel string
 }
 

--- a/genesyscloud/resource_exporter/resource_name_sanitizer_test.go
+++ b/genesyscloud/resource_exporter/resource_name_sanitizer_test.go
@@ -294,7 +294,6 @@ func TestUnitSanitize(t *testing.T) {
 
 			},
 		},
-		// ADD TESTS HERE FOR BLOCK_HASH FIELD
 		{
 			name: "duplicates with block hash",
 			input: ResourceIDMetaMap{

--- a/genesyscloud/resource_exporter/resource_name_sanitizer_test.go
+++ b/genesyscloud/resource_exporter/resource_name_sanitizer_test.go
@@ -1,6 +1,7 @@
 package resource_exporter
 
 import (
+	"fmt"
 	"os"
 	"strings"
 	"terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
@@ -106,9 +107,9 @@ func TestUnitSanitize(t *testing.T) {
 	testCases := []struct {
 		name                 string
 		input                ResourceIDMetaMap
-		validateOriginal     func(t *testing.T, result ResourceIDMetaMap)
-		validateOptimized    func(t *testing.T, result ResourceIDMetaMap)
-		validateBCPOptimized func(t *testing.T, result ResourceIDMetaMap)
+		validateOriginal     func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal)
+		validateOptimized    func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized)
+		validateBCPOptimized func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized)
 	}{
 		{
 			name: "unique labels",
@@ -116,15 +117,15 @@ func TestUnitSanitize(t *testing.T) {
 				"id1": &ResourceMeta{BlockLabel: "test1"},
 				"id2": &ResourceMeta{BlockLabel: "test2"},
 			},
-			validateOriginal: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
 				assert.Equal(t, "test1", result["id1"].BlockLabel)
 				assert.Equal(t, "test2", result["id2"].BlockLabel)
 			},
-			validateOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
 				assert.Equal(t, "test1", result["id1"].BlockLabel)
 				assert.Equal(t, "test2", result["id2"].BlockLabel)
 			},
-			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
 				assert.True(t, strings.HasPrefix(result["id1"].BlockLabel, "test1_"))
 				assert.True(t, strings.HasPrefix(result["id2"].BlockLabel, "test2_"))
 				// Hash is always appended for BCP Optimized
@@ -145,7 +146,7 @@ func TestUnitSanitize(t *testing.T) {
 			// This can cause issues with mixing up the state file unfortunately, and require
 			// extra logic in the buildResourceConfigMap() function to check for this.
 			// See DEVTOOLING-1183 for ideas on improving this
-			validateOriginal: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
 				assert.Equal(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 				assert.Equal(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
 				assert.Equal(t, result["id2"].BlockLabel, result["id3"].BlockLabel)
@@ -160,7 +161,7 @@ func TestUnitSanitize(t *testing.T) {
 			// This can cause issues with mixing up the state file unfortunately, and require
 			// extra logic in the buildResourceConfigMap() function to check for this
 			// See DEVTOOLING-1183 for ideas on improving this
-			validateOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
 				assert.Equal(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 				assert.Equal(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
 				assert.Equal(t, result["id2"].BlockLabel, result["id3"].BlockLabel)
@@ -175,16 +176,22 @@ func TestUnitSanitize(t *testing.T) {
 			// is more consistent across runs and between export comparisons across orgs.
 			// A _DUPLICATE_INSTANCE_# value is appended to alert on this rare edge case
 			// See DEVTOOLING-1183 for ideas on improving this
-			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
 				assert.NotEqual(t, result["id2"].BlockLabel, result["id3"].BlockLabel)
 				assert.True(t, strings.HasPrefix(result["id1"].BlockLabel, "testfoo_"))
 				assert.True(t, strings.HasPrefix(result["id2"].BlockLabel, "testfoo_"))
 				assert.True(t, strings.HasPrefix(result["id3"].BlockLabel, "testfoo_"))
-				assert.True(t, len(result["id1"].BlockLabel) > 8)                                  // Hash appended
-				assert.True(t, len(result["id2"].BlockLabel) > 8)                                  // Hash appended
-				assert.True(t, len(result["id3"].BlockLabel) > 8)                                  // Hash appended
+				assert.True(t, len(result["id1"].BlockLabel) > 8) // Hash appended
+				assert.True(t, len(result["id2"].BlockLabel) > 8) // Hash appended
+				assert.True(t, len(result["id3"].BlockLabel) > 8) // Hash appended
+				id1Hash := sanitizer.SanitizeResourceHash(*result["id1"])
+				id2Hash := sanitizer.SanitizeResourceHash(*result["id2"])
+				id3Hash := sanitizer.SanitizeResourceHash(*result["id3"])
+				assert.True(t, strings.Contains(result["id1"].BlockLabel, id1Hash))                // Hash included
+				assert.True(t, strings.Contains(result["id2"].BlockLabel, id2Hash))                // Hash included
+				assert.True(t, strings.Contains(result["id3"].BlockLabel, id3Hash))                // Hash included
 				assert.True(t, strings.Contains(result["id1"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate appended
 				assert.True(t, strings.Contains(result["id2"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate appended
 				assert.True(t, strings.Contains(result["id3"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate appended
@@ -195,13 +202,13 @@ func TestUnitSanitize(t *testing.T) {
 			// across the sanitizers
 			name: "duplicate sanitized labels",
 			input: ResourceIDMetaMap{
-				"id2": &ResourceMeta{BlockLabel: "test_user@foo.com"},
 				"id1": &ResourceMeta{BlockLabel: "test.user@foo.com"},
+				"id2": &ResourceMeta{BlockLabel: "test_user@foo.com"},
 				"id3": &ResourceMeta{BlockLabel: "test+user@foo.com"},
 				"id4": &ResourceMeta{BlockLabel: "test&user@foo.com"},
 			},
 			// Always appends a hash to all of the labels that match each other
-			validateOriginal: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id4"].BlockLabel)
@@ -216,11 +223,19 @@ func TestUnitSanitize(t *testing.T) {
 				assert.True(t, len(result["id2"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
 				assert.True(t, len(result["id4"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
 				assert.True(t, len(result["id4"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				id1Hash := sanitizer.SanitizeResourceHash(result["id1"].OriginalLabel)
+				id2Hash := sanitizer.SanitizeResourceHash(result["id2"].OriginalLabel)
+				id3Hash := sanitizer.SanitizeResourceHash(result["id3"].OriginalLabel)
+				id4Hash := sanitizer.SanitizeResourceHash(result["id4"].OriginalLabel)
+				assert.True(t, strings.Contains(result["id1"].BlockLabel, id1Hash)) // Hash included
+				assert.True(t, strings.Contains(result["id2"].BlockLabel, id2Hash)) // Hash included
+				assert.True(t, strings.Contains(result["id3"].BlockLabel, id3Hash)) // Hash included
+				assert.True(t, strings.Contains(result["id4"].BlockLabel, id4Hash)) // Hash included
 			},
 			// Appends a hash to every other label other than the first label that is processed
 			// Unfortunately this is not consistent across exports, as the first label is never the same
 			// from export to export. This is probably fine for any regular exports. See DEVTOOLING-1182
-			validateOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id4"].BlockLabel)
@@ -240,13 +255,16 @@ func TestUnitSanitize(t *testing.T) {
 				for _, meta := range result {
 					if len(meta.BlockLabel) == len("test_user_foo_com") {
 						lengthOfBlockLabelCount++
+					} else {
+						idHash := sanitizer.SanitizeResourceHash(meta.OriginalLabel)
+						assert.True(t, strings.Contains(meta.BlockLabel, idHash))
 					}
 				}
 				assert.Equal(t, 1, lengthOfBlockLabelCount, "Exactly one Block Label should have no hash appended")
 			},
 			// Appends a hash to every label processed to ensures consistency so that output
 			// is more consistent across runs and between export comparisons across orgs. See DEVTOOLING-1182
-			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id4"].BlockLabel)
@@ -257,14 +275,201 @@ func TestUnitSanitize(t *testing.T) {
 				assert.True(t, strings.HasPrefix(result["id2"].BlockLabel, "test_user_foo_com_"))
 				assert.True(t, strings.HasPrefix(result["id3"].BlockLabel, "test_user_foo_com_"))
 				assert.True(t, strings.HasPrefix(result["id4"].BlockLabel, "test_user_foo_com_"))
-				assert.True(t, len(result["id1"].BlockLabel) > len("test_user_foo_com_"))           // Hash appended
-				assert.True(t, len(result["id2"].BlockLabel) > len("test_user_foo_com_"))           // Hash appended
-				assert.True(t, len(result["id3"].BlockLabel) > len("test_user_foo_com_"))           // Hash appended
-				assert.True(t, len(result["id4"].BlockLabel) > len("test_user_foo_com_"))           // Hash appended
+				assert.True(t, len(result["id1"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				assert.True(t, len(result["id2"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				assert.True(t, len(result["id3"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				assert.True(t, len(result["id4"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				id1Hash := sanitizer.SanitizeResourceHash(*result["id1"])
+				id2Hash := sanitizer.SanitizeResourceHash(*result["id2"])
+				id3Hash := sanitizer.SanitizeResourceHash(*result["id3"])
+				id4Hash := sanitizer.SanitizeResourceHash(*result["id4"])
+				assert.True(t, strings.Contains(result["id1"].BlockLabel, id1Hash))                 // Hash included
+				assert.True(t, strings.Contains(result["id2"].BlockLabel, id2Hash))                 // Hash included
+				assert.True(t, strings.Contains(result["id3"].BlockLabel, id3Hash))                 // Hash included
+				assert.True(t, strings.Contains(result["id4"].BlockLabel, id4Hash))                 // Hash included
 				assert.False(t, strings.Contains(result["id1"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
 				assert.False(t, strings.Contains(result["id2"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
 				assert.False(t, strings.Contains(result["id3"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
 				assert.False(t, strings.Contains(result["id4"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
+
+			},
+		},
+		// ADD TESTS HERE FOR BLOCK_HASH FIELD
+		{
+			name: "duplicates with block hash",
+			input: ResourceIDMetaMap{
+				"id1": &ResourceMeta{BlockLabel: "test_distinct_user@foo.com", BlockHash: "abc1234"}, // Distinct block label, distinct block hash
+				"id2": &ResourceMeta{BlockLabel: "test_distinct_user2@foo.com"},                      // Distinct block label, no block hash
+				"id3": &ResourceMeta{BlockLabel: "test_user@foo.com", BlockHash: "abc1234"},          // Same sanitized block label as next, distinct block hash
+				"id4": &ResourceMeta{BlockLabel: "test.user@foo.com", BlockHash: "bcd5678"},          // Same block label as next, distinct block hash
+				"id5": &ResourceMeta{BlockLabel: "test.user@foo.com", BlockHash: "cde9001"},          // Same block label as prev, distinct block hash
+				"id6": &ResourceMeta{BlockLabel: "test+user@foo.com", BlockHash: "def2342"},          // Same block label as next, same block hash
+				"id7": &ResourceMeta{BlockLabel: "test+user@foo.com", BlockHash: "def2342"},          // Same block label as prev, same block hash
+			},
+			// Ignores the BlockHash (for now). This may change in the future.
+			// Never append a hash to original labels that distinct or are the same as another.
+			// Always appends a hash to all of the labels that were different but match each other directly after being sanitized.
+			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id3"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id7"].BlockLabel)
+				assert.Equal(t, result["id4"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id4"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id4"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id5"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id5"].BlockLabel, result["id7"].BlockLabel)
+				assert.Equal(t, result["id6"].BlockLabel, result["id7"].BlockLabel)
+				assert.Equal(t, result["id1"].BlockLabel, "test_distinct_user_foo_com")
+				assert.Equal(t, result["id2"].BlockLabel, "test_distinct_user2_foo_com")
+				assert.True(t, strings.HasPrefix(result["id3"].BlockLabel, "test_user_foo_com_"))
+				assert.True(t, strings.HasPrefix(result["id4"].BlockLabel, "test_user_foo_com_"))
+				assert.True(t, strings.HasPrefix(result["id5"].BlockLabel, "test_user_foo_com_"))
+				assert.True(t, strings.HasPrefix(result["id6"].BlockLabel, "test_user_foo_com_"))
+				assert.True(t, strings.HasPrefix(result["id7"].BlockLabel, "test_user_foo_com_"))
+				assert.True(t, len(result["id3"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				assert.True(t, len(result["id4"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				assert.True(t, len(result["id5"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				assert.True(t, len(result["id6"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				assert.True(t, len(result["id7"].BlockLabel) > len("test_user_foo_com_")) // Hash appended
+				id3Hash := sanitizer.SanitizeResourceHash(result["id3"].OriginalLabel)
+				id4Hash := sanitizer.SanitizeResourceHash(result["id4"].OriginalLabel)
+				id5Hash := sanitizer.SanitizeResourceHash(result["id5"].OriginalLabel)
+				id6Hash := sanitizer.SanitizeResourceHash(result["id6"].OriginalLabel)
+				id7Hash := sanitizer.SanitizeResourceHash(result["id7"].OriginalLabel)
+				assert.True(t, strings.HasSuffix(result["id3"].BlockLabel, id3Hash)) // Hash included
+				assert.True(t, strings.HasSuffix(result["id4"].BlockLabel, id4Hash)) // Hash included
+				assert.True(t, strings.HasSuffix(result["id5"].BlockLabel, id5Hash)) // Hash included
+				assert.True(t, strings.HasSuffix(result["id6"].BlockLabel, id6Hash)) // Hash included
+				assert.True(t, strings.HasSuffix(result["id7"].BlockLabel, id7Hash)) // Hash included
+			},
+			// Ignores the BlockHash (for now). This may change in the future.
+			// Appends a hash to every other label other than the first label that is processed
+			// Unfortunately this is not consistent across exports, as the first label is never the same
+			// from export to export. This is probably fine for any regular exports. See DEVTOOLING-1182
+			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id3"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id7"].BlockLabel)
+				// Intentionally commented out, as this could be equal (same hash) or
+				// not equal (one without the hash). Retained for consistency purposes.
+				// assert.NotEqual(t, result["id4"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id4"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id4"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id5"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id5"].BlockLabel, result["id7"].BlockLabel)
+				// Intentionally commented out, as this could be equal (same hash) or
+				// not equal (one without the hash). Retained for consistency purposes.
+				// assert.NotEqual(t, result["id6"].BlockLabel, result["id7"].BlockLabel)
+				assert.Equal(t, result["id1"].BlockLabel, "test_distinct_user_foo_com")
+				assert.Equal(t, result["id2"].BlockLabel, "test_distinct_user2_foo_com")
+				assert.True(t, strings.HasPrefix(result["id3"].BlockLabel, "test_user_foo_com"))
+				assert.True(t, strings.HasPrefix(result["id4"].BlockLabel, "test_user_foo_com"))
+				assert.True(t, strings.HasPrefix(result["id5"].BlockLabel, "test_user_foo_com"))
+				assert.True(t, strings.HasPrefix(result["id6"].BlockLabel, "test_user_foo_com"))
+				assert.True(t, strings.HasPrefix(result["id7"].BlockLabel, "test_user_foo_com"))
+				assert.True(t, len(result["id3"].BlockLabel) >= len("test_user_foo_com")) // Hash maybe appended
+				assert.True(t, len(result["id4"].BlockLabel) >= len("test_user_foo_com")) // Hash maybe appended
+				assert.True(t, len(result["id5"].BlockLabel) >= len("test_user_foo_com")) // Hash maybe appended
+				assert.True(t, len(result["id6"].BlockLabel) >= len("test_user_foo_com")) // Hash maybe appended
+				assert.True(t, len(result["id7"].BlockLabel) >= len("test_user_foo_com")) // Hash maybe appended
+				// Remove distinct results since we've already validated them
+				delete(result, "id1")
+				delete(result, "id2")
+				// Loop over the rest of matching results asserting only one has no hash appended
+				lengthOfBlockLabelCount := 0
+				for _, meta := range result {
+					if len(meta.BlockLabel) == len("test_user_foo_com") {
+						lengthOfBlockLabelCount++
+					} else {
+						hash := sanitizer.SanitizeResourceHash(meta.OriginalLabel)
+						assert.True(t, strings.HasSuffix(meta.BlockLabel, hash))
+					}
+				}
+				assert.Equal(t, 1, lengthOfBlockLabelCount, "Exactly one Block Label should have no hash appended")
+			},
+			// Checks for a BlockHash and appends the hash content to the label to create distinct labels
+			// Also includes a hash of the original BlockLabel to every label processed to ensures consistency so that output
+			// is more consistent across runs and between export comparisons across orgs. See DEVTOOLING-1182 and DEVTOOLING-1183
+			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id3"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id1"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id3"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id2"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id4"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id3"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id4"].BlockLabel, result["id5"].BlockLabel)
+				assert.NotEqual(t, result["id4"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id4"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id5"].BlockLabel, result["id6"].BlockLabel)
+				assert.NotEqual(t, result["id5"].BlockLabel, result["id7"].BlockLabel)
+				assert.NotEqual(t, result["id6"].BlockLabel, result["id7"].BlockLabel)
+				id1Hash := sanitizer.SanitizeResourceHash(*result["id1"])
+				id2Hash := sanitizer.SanitizeResourceHash(*result["id2"])
+				id3Hash := sanitizer.SanitizeResourceHash(*result["id3"])
+				id4Hash := sanitizer.SanitizeResourceHash(*result["id4"])
+				id5Hash := sanitizer.SanitizeResourceHash(*result["id5"])
+				id6Hash := sanitizer.SanitizeResourceHash(*result["id6"])
+				id7Hash := sanitizer.SanitizeResourceHash(*result["id7"])
+
+				assert.NotEqual(t, id3Hash, id4Hash)
+				assert.NotEqual(t, id3Hash, id5Hash)
+				assert.NotEqual(t, id3Hash, id6Hash)
+				assert.NotEqual(t, id3Hash, id7Hash)
+				assert.NotEqual(t, id4Hash, id5Hash)
+				assert.NotEqual(t, id4Hash, id6Hash)
+				assert.NotEqual(t, id4Hash, id7Hash)
+				assert.NotEqual(t, id5Hash, id6Hash)
+				assert.NotEqual(t, id5Hash, id7Hash)
+				assert.Equal(t, id6Hash, id7Hash)
+
+				assert.Equal(t, result["id1"].BlockLabel, fmt.Sprintf("test_distinct_user_foo_com__%s", id1Hash))
+				assert.Equal(t, result["id2"].BlockLabel, fmt.Sprintf("test_distinct_user2_foo_com__%s", id2Hash))
+				assert.Equal(t, result["id3"].BlockLabel, fmt.Sprintf("test_user_foo_com__%s", id3Hash))
+				assert.Equal(t, result["id4"].BlockLabel, fmt.Sprintf("test_user_foo_com__%s", id4Hash))
+				assert.Equal(t, result["id5"].BlockLabel, fmt.Sprintf("test_user_foo_com__%s", id5Hash))
+				assert.True(t, strings.HasPrefix(result["id6"].BlockLabel, fmt.Sprintf("test_user_foo_com__%s", id6Hash)))
+				assert.True(t, strings.HasPrefix(result["id7"].BlockLabel, fmt.Sprintf("test_user_foo_com__%s", id6Hash)))
+				assert.False(t, strings.Contains(result["id1"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
+				assert.False(t, strings.Contains(result["id2"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
+				assert.False(t, strings.Contains(result["id3"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
+				assert.False(t, strings.Contains(result["id4"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
+				assert.False(t, strings.Contains(result["id5"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
+				assert.True(t, strings.Contains(result["id6"].BlockLabel, "_DUPLICATE_INSTANCE_"))  // Duplicate IS appended
+				assert.True(t, strings.Contains(result["id7"].BlockLabel, "_DUPLICATE_INSTANCE_"))  // Duplicate IS appended
+
 			},
 		},
 		{
@@ -273,17 +478,17 @@ func TestUnitSanitize(t *testing.T) {
 				"id1": &ResourceMeta{BlockLabel: "テスト1"},
 				"id2": &ResourceMeta{BlockLabel: "テスト2"},
 			},
-			validateOriginal: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
 				assert.Contains(t, result["id1"].BlockLabel, "___1")
 				assert.Contains(t, result["id2"].BlockLabel, "___2")
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 			},
-			validateOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
 				assert.Contains(t, result["id1"].BlockLabel, "tesuto1")
 				assert.Contains(t, result["id2"].BlockLabel, "tesuto2")
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 			},
-			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
 				assert.Contains(t, result["id1"].BlockLabel, "tesuto1")
 				assert.Contains(t, result["id2"].BlockLabel, "tesuto2")
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
@@ -295,15 +500,15 @@ func TestUnitSanitize(t *testing.T) {
 				"id1": &ResourceMeta{BlockLabel: "123@test"},
 				"id2": &ResourceMeta{BlockLabel: "456#test"},
 			},
-			validateOriginal: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
 				assert.Equal(t, result["id1"].BlockLabel, "_123_test")
 				assert.Equal(t, result["id2"].BlockLabel, "_456_test")
 			},
-			validateOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
 				assert.Equal(t, result["id1"].BlockLabel, "_123_test")
 				assert.Equal(t, result["id2"].BlockLabel, "_456_test")
 			},
-			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
 				assert.True(t, strings.HasPrefix(result["id1"].BlockLabel, "_123_test_"))
 				assert.True(t, strings.HasPrefix(result["id2"].BlockLabel, "_456_test_"))
 			},
@@ -314,17 +519,17 @@ func TestUnitSanitize(t *testing.T) {
 				"id1": &ResourceMeta{BlockLabel: "Test@Label_123"},
 				"id2": &ResourceMeta{BlockLabel: "Test#Label_456"},
 			},
-			validateOriginal: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
 				assert.Equal(t, result["id1"].BlockLabel, "Test_Label_123")
 				assert.Equal(t, result["id2"].BlockLabel, "Test_Label_456")
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 			},
-			validateOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
 				assert.Equal(t, result["id1"].BlockLabel, "Test_Label_123")
 				assert.Equal(t, result["id2"].BlockLabel, "Test_Label_456")
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 			},
-			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap) {
+			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
 				assert.True(t, strings.HasPrefix(result["id1"].BlockLabel, "Test_Label_123"))
 				assert.True(t, strings.HasPrefix(result["id2"].BlockLabel, "Test_Label_456"))
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
@@ -339,7 +544,7 @@ func TestUnitSanitize(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				inputCopy := makeInputCopy(tc.input)
 				sanitizer.Sanitize(inputCopy)
-				tc.validateOriginal(t, inputCopy)
+				tc.validateOriginal(t, inputCopy, *sanitizer)
 			})
 		}
 	})
@@ -350,7 +555,7 @@ func TestUnitSanitize(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				inputCopy := makeInputCopy(tc.input)
 				sanitizer.Sanitize(inputCopy)
-				tc.validateOptimized(t, inputCopy)
+				tc.validateOptimized(t, inputCopy, *sanitizer)
 			})
 		}
 	})
@@ -361,7 +566,7 @@ func TestUnitSanitize(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				inputCopy := makeInputCopy(tc.input)
 				sanitizer.Sanitize(inputCopy)
-				tc.validateBCPOptimized(t, inputCopy)
+				tc.validateBCPOptimized(t, inputCopy, *sanitizer)
 			})
 		}
 	})
@@ -374,6 +579,7 @@ func makeInputCopy(input ResourceIDMetaMap) ResourceIDMetaMap {
 		inputCopy[k] = &ResourceMeta{
 			BlockLabel:    v.BlockLabel,
 			OriginalLabel: v.OriginalLabel,
+			BlockHash:     v.BlockHash,
 		}
 	}
 	return inputCopy

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
@@ -33,7 +33,11 @@ func getAllAuthResponsemanagementResponses(ctx context.Context, clientConfig *pl
 	}
 
 	for _, response := range *responseManagementResponses {
-		hashedUniqueFields, err := util.QuickHashFields(*response.Libraries, *response.Texts)
+		libraryNames := []string{}
+		for _, library := range *response.Libraries {
+			libraryNames = append(libraryNames, *library.Name)
+		}
+		hashedUniqueFields, err := util.QuickHashFields(libraryNames)
 		if err != nil {
 			return nil, util.BuildDiagnosticError(ResourceType, fmt.Sprintf("Failed to hash unique fields of response management response %s error: %s", *response.Id, err), err)
 		}

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
@@ -33,7 +33,11 @@ func getAllAuthResponsemanagementResponses(ctx context.Context, clientConfig *pl
 	}
 
 	for _, response := range *responseManagementResponses {
-		resources[*response.Id] = &resourceExporter.ResourceMeta{BlockLabel: *response.Name}
+		hashedUniqueFields, err := util.QuickHashFields(*response.Libraries, *response.Texts)
+		if err != nil {
+			return nil, util.BuildDiagnosticError(ResourceType, fmt.Sprintf("Failed to hash unique fields of response management response %s error: %s", *response.Id, err), err)
+		}
+		resources[*response.Id] = &resourceExporter.ResourceMeta{BlockLabel: *response.Name, BlockHash: hashedUniqueFields}
 	}
 	return resources, nil
 }

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
@@ -31,7 +31,11 @@ func getAllResponseAssets(ctx context.Context, clientConfig *platformclientv2.Co
 	}
 
 	for _, asset := range *assets {
-		resources[*asset.Id] = &resourceExporter.ResourceMeta{BlockLabel: *asset.Name}
+		blockHash, err := util.QuickHashFields(asset.ContentLength)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+		resources[*asset.Id] = &resourceExporter.ResourceMeta{BlockLabel: *asset.Name, BlockHash: blockHash}
 	}
 
 	return resources, nil

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -33,7 +33,11 @@ func getAllDidPools(ctx context.Context, clientConfig *platformclientv2.Configur
 
 	for _, didPool := range *didPools {
 		if didPool.State != nil && *didPool.State != "deleted" {
-			resources[*didPool.Id] = &resourceExporter.ResourceMeta{BlockLabel: *didPool.StartPhoneNumber}
+			blockHash, err := util.QuickHashFields(didPool.StartPhoneNumber, didPool.EndPhoneNumber, didPool.Description, didPool.Comments, didPool.Provider)
+			if err != nil {
+				return nil, diag.FromErr(err)
+			}
+			resources[*didPool.Id] = &resourceExporter.ResourceMeta{BlockLabel: *didPool.StartPhoneNumber, BlockHash: blockHash}
 		}
 	}
 	return resources, nil

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -33,7 +33,7 @@ func getAllDidPools(ctx context.Context, clientConfig *platformclientv2.Configur
 
 	for _, didPool := range *didPools {
 		if didPool.State != nil && *didPool.State != "deleted" {
-			blockHash, err := util.QuickHashFields(didPool.StartPhoneNumber, didPool.EndPhoneNumber, didPool.Description, didPool.Comments, didPool.Provider)
+			blockHash, err := util.QuickHashFields(didPool.StartPhoneNumber, didPool.EndPhoneNumber, didPool.Provider)
 			if err != nil {
 				return nil, diag.FromErr(err)
 			}

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -404,7 +404,7 @@ func (g *GenesysCloudResourceExporter) buildResourceConfigMap() (diagnostics dia
 		if len(g.resourceTypesMaps[resource.Type][resource.BlockLabel]) > 0 || len(g.dataSourceTypesMaps[resource.Type][resource.BlockLabel]) > 0 {
 			algorithm := fnv.New32()
 			algorithm.Write([]byte(uuid.NewString()))
-			resource.BlockLabel = resource.BlockLabel + "_" + strconv.FormatUint(uint64(algorithm.Sum32()), 10)
+			resource.BlockLabel = resource.BlockLabel + "_BRCM" + strconv.FormatUint(uint64(algorithm.Sum32()), 10)
 			g.updateSanitizeMap(*g.exporters, resource)
 		}
 

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -404,6 +404,7 @@ func (g *GenesysCloudResourceExporter) buildResourceConfigMap() (diagnostics dia
 		if len(g.resourceTypesMaps[resource.Type][resource.BlockLabel]) > 0 || len(g.dataSourceTypesMaps[resource.Type][resource.BlockLabel]) > 0 {
 			algorithm := fnv.New32()
 			algorithm.Write([]byte(uuid.NewString()))
+			// The _BRCM prefix is meant to be an identifier so we can tell that the hash was generated here and not in the sanitizer.
 			resource.BlockLabel = resource.BlockLabel + "_BRCM" + strconv.FormatUint(uint64(algorithm.Sum32()), 10)
 			g.updateSanitizeMap(*g.exporters, resource)
 		}

--- a/genesyscloud/user/resource_genesyscloud_user.go
+++ b/genesyscloud/user/resource_genesyscloud_user.go
@@ -44,7 +44,7 @@ func GetAllUsers(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 		if user.Id == nil || user.Email == nil {
 			continue
 		}
-		hashedUniqueFields, err := util.QuickHashFields(*user.Name, *user.Department, *user.PrimaryContactInfo, *user.Addresses)
+		hashedUniqueFields, err := util.QuickHashFields(user.Name, user.Department, user.PrimaryContactInfo, user.Addresses)
 		if err != nil {
 			return nil, diag.FromErr(err)
 		}

--- a/genesyscloud/user/resource_genesyscloud_user.go
+++ b/genesyscloud/user/resource_genesyscloud_user.go
@@ -44,7 +44,11 @@ func GetAllUsers(ctx context.Context, sdkConfig *platformclientv2.Configuration)
 		if user.Id == nil || user.Email == nil {
 			continue
 		}
-		resources[*user.Id] = &resourceExporter.ResourceMeta{BlockLabel: *user.Email}
+		hashedUniqueFields, err := util.QuickHashFields(*user.Name, *user.Department, *user.PrimaryContactInfo, *user.Addresses)
+		if err != nil {
+			return nil, diag.FromErr(err)
+		}
+		resources[*user.Id] = &resourceExporter.ResourceMeta{BlockLabel: *user.Email, BlockHash: hashedUniqueFields}
 	}
 
 	return resources, nil

--- a/genesyscloud/util/hash.go
+++ b/genesyscloud/util/hash.go
@@ -1,0 +1,44 @@
+package util
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/hex"
+	"fmt"
+	"sync"
+)
+
+var (
+	bufferPool = sync.Pool{
+		New: func() interface{} {
+			return new(bytes.Buffer)
+		},
+	}
+)
+
+// QuickHashFields generates a SHA-256 hash of any number of objects using gob encoding
+// Returns first 16 characters of hex-encoded hash for a good balance of uniqueness and length
+func QuickHashFields(values ...interface{}) (string, error) {
+	if len(values) == 0 {
+		return "", fmt.Errorf("no values provided to hash")
+	}
+
+	// Use buffer pool for efficiency
+	buf := bufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer bufferPool.Put(buf)
+
+	enc := gob.NewEncoder(buf)
+	for _, val := range values {
+		if val != nil {
+			if err := enc.Encode(val); err != nil {
+				return "", fmt.Errorf("failed to encode value: %v", err)
+			}
+		}
+	}
+
+	h := sha256.New()
+	h.Write(buf.Bytes())
+	return hex.EncodeToString(h.Sum(nil))[:16], nil
+}

--- a/genesyscloud/util/hash.go
+++ b/genesyscloud/util/hash.go
@@ -3,8 +3,8 @@ package util
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/gob"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"sync"
 )
@@ -29,13 +29,12 @@ func QuickHashFields(values ...interface{}) (string, error) {
 	buf.Reset()
 	defer bufferPool.Put(buf)
 
-	enc := gob.NewEncoder(buf)
+	enc := json.NewEncoder(buf)
 	for _, val := range values {
-		if val != nil {
-			if err := enc.Encode(val); err != nil {
-				return "", fmt.Errorf("failed to encode value: %v", err)
-			}
+		if err := enc.Encode(val); err != nil {
+			return "", fmt.Errorf("failed to encode value: %v", err)
 		}
+
 	}
 
 	h := sha256.New()

--- a/genesyscloud/util/hash_test.go
+++ b/genesyscloud/util/hash_test.go
@@ -5,6 +5,12 @@ import (
 )
 
 func TestUnitQuickHashFields(t *testing.T) {
+	str := "test"
+	strPtr := &str
+	var nilStrPtr *string
+	num := 123
+	numPtr := &num
+
 	tests := []struct {
 		name    string
 		values  []interface{}
@@ -26,6 +32,26 @@ func TestUnitQuickHashFields(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    "String pointer input",
+			values:  []interface{}{strPtr},
+			wantErr: false,
+		},
+		{
+			name:    "Nil string pointer input",
+			values:  []interface{}{nilStrPtr},
+			wantErr: false,
+		},
+		{
+			name:    "Single int input",
+			values:  []interface{}{123},
+			wantErr: false,
+		},
+		{
+			name:    "Single int pointer input",
+			values:  []interface{}{numPtr},
+			wantErr: false,
+		},
+		{
 			name:    "Multiple string inputs",
 			values:  []interface{}{"test1", "test2", "test3"},
 			wantErr: false,
@@ -38,6 +64,17 @@ func TestUnitQuickHashFields(t *testing.T) {
 		{
 			name:    "Multiple nil inputs",
 			values:  []interface{}{nil, nil, nil},
+			wantErr: false,
+		},
+		{
+			name: "Mixed pointer and value types",
+			values: []interface{}{
+				"test",
+				str,
+				num,
+				nilStrPtr,
+				nil,
+			},
 			wantErr: false,
 		},
 	}
@@ -80,7 +117,11 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 	type testStruct struct {
 		Field1 string
 		Field2 int
+		Field3 *string
 	}
+
+	str := "test"
+	var nilStr *string
 
 	tests := []struct {
 		name         string
@@ -94,7 +135,23 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 				testStruct{Field1: "test", Field2: 123},
 			},
 			wantErr:      false,
-			expectedHash: "72bb3bf6e605a43a",
+			expectedHash: "ef1a14bd9bd591c3",
+		},
+		{
+			name: "Struct input with nil pointer",
+			value: []interface{}{
+				testStruct{Field1: "test", Field2: 123, Field3: nilStr},
+			},
+			wantErr:      false,
+			expectedHash: "ef1a14bd9bd591c3",
+		},
+		{
+			name: "Struct input with valid pointer",
+			value: []interface{}{
+				testStruct{Field1: "test", Field2: 123, Field3: &str},
+			},
+			wantErr:      false,
+			expectedHash: "caf965b7315c3dd6",
 		},
 		{
 			name: "Multiple Struct input",
@@ -103,13 +160,13 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 				testStruct{Field1: "test2", Field2: 456},
 			},
 			wantErr:      false,
-			expectedHash: "a3eb3d4830f9153a",
+			expectedHash: "f901b0dc6747c4c3",
 		},
 		{
 			name:         "Map input",
 			value:        []interface{}{map[string]string{"key": "value"}},
 			wantErr:      false,
-			expectedHash: "aaaaa8b65ed3ff7b",
+			expectedHash: "cbdea9ab8317fcd1",
 		},
 		{
 			name: "Multiple Map input",
@@ -118,13 +175,29 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 				map[string]string{"foo": "bar"},
 			},
 			wantErr:      false,
-			expectedHash: "fe443377ca878d7d",
+			expectedHash: "92422f54645bb2d7",
+		},
+		{
+			name: "Map with pointer values",
+			value: []interface{}{
+				map[string]*string{"key": &str, "nil_key": nilStr},
+			},
+			wantErr:      false,
+			expectedHash: "00b5d32006713baa",
 		},
 		{
 			name:         "Slice input",
 			value:        []interface{}{[]string{"test1", "test2"}},
 			wantErr:      false,
-			expectedHash: "0c1efb7496fa5b19",
+			expectedHash: "45a7a10579268d62",
+		},
+		{
+			name: "Slice with pointer values",
+			value: []interface{}{
+				[]*string{&str, nilStr, &str},
+			},
+			wantErr:      false,
+			expectedHash: "1492c421fc01e363",
 		},
 		{
 			name: "Multiple Slice input",
@@ -134,7 +207,7 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 				[]string{"test2", "test1"},
 			},
 			wantErr:      false,
-			expectedHash: "0590d72ff80ff5e3",
+			expectedHash: "758cf2b128d714ab",
 		},
 		{
 			name: "Multiple Mix of Inputs",
@@ -145,10 +218,21 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 				testStruct{Field1: "test5", Field2: 987},
 			},
 			wantErr:      false,
-			expectedHash: "e63ec7734b9ca5fb",
+			expectedHash: "17f7261250799f2d",
 		},
 		{
-			name: "Multiple Mix of Inputs with some as nil",
+			name: "Mixed complex types with nil pointers",
+			value: []interface{}{
+				testStruct{Field1: "test", Field2: 123, Field3: nilStr},
+				map[string]*string{"key": nilStr, "nil_key": nilStr},
+				[]*string{nilStr, nilStr, nilStr},
+				[]*string{&str, nilStr, &str},
+			},
+			wantErr:      false,
+			expectedHash: "84e42603d87047fe",
+		},
+		{
+			name: "Multiple mixed types with some nils",
 			value: []interface{}{
 				[]string{"test1", "test2"},
 				map[string]string{"foo": "bar"},
@@ -158,7 +242,7 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 				nil,
 			},
 			wantErr:      false,
-			expectedHash: "e63ec7734b9ca5fb",
+			expectedHash: "173cb74d538c5b23",
 		},
 	}
 

--- a/genesyscloud/util/hash_test.go
+++ b/genesyscloud/util/hash_test.go
@@ -1,0 +1,170 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestUnitQuickHashFields(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []interface{}
+		wantErr bool
+	}{
+		{
+			name:    "No inputs",
+			values:  []interface{}{},
+			wantErr: true,
+		},
+		{
+			name:    "Single string input",
+			values:  []interface{}{"test"},
+			wantErr: false,
+		},
+		{
+			name:    "Single nil input",
+			values:  []interface{}{nil},
+			wantErr: false,
+		},
+		{
+			name:    "Multiple string inputs",
+			values:  []interface{}{"test1", "test2", "test3"},
+			wantErr: false,
+		},
+		{
+			name:    "Mixed type inputs",
+			values:  []interface{}{"test", 123, true},
+			wantErr: false,
+		},
+		{
+			name:    "Multiple nil inputs",
+			values:  []interface{}{nil, nil, nil},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := QuickHashFields(tt.values...)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("QuickHashFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr {
+				// Verify hash is exactly 16 characters
+				if len(got) != 16 {
+					t.Errorf("QuickHashFields() returned hash of length %d, want 16", len(got))
+				}
+
+				// Verify consistent hashing
+				got2, _ := QuickHashFields(tt.values...)
+				if got != got2 {
+					t.Errorf("QuickHashFields() not consistent: %v != %v", got, got2)
+				}
+			}
+		})
+	}
+}
+
+func TestUnitQuickHashFields_DifferentInputs(t *testing.T) {
+	hash1, _ := QuickHashFields("test1")
+	hash2, _ := QuickHashFields("test2")
+
+	if hash1 == hash2 {
+		t.Errorf("Different inputs produced same hash: %v", hash1)
+	}
+}
+
+func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
+	type testStruct struct {
+		Field1 string
+		Field2 int
+	}
+
+	tests := []struct {
+		name         string
+		value        []interface{}
+		wantErr      bool
+		expectedHash string
+	}{
+		{
+			name: "Struct input",
+			value: []interface{}{
+				testStruct{Field1: "test", Field2: 123},
+			},
+			wantErr:      false,
+			expectedHash: "72bb3bf6e605a43a",
+		},
+		{
+			name: "Multiple Struct input",
+			value: []interface{}{
+				testStruct{Field1: "test", Field2: 123},
+				testStruct{Field1: "test2", Field2: 456},
+			},
+			wantErr:      false,
+			expectedHash: "a3eb3d4830f9153a",
+		},
+		{
+			name:         "Map input",
+			value:        []interface{}{map[string]string{"key": "value"}},
+			wantErr:      false,
+			expectedHash: "aaaaa8b65ed3ff7b",
+		},
+		{
+			name: "Multiple Map input",
+			value: []interface{}{
+				map[string]string{"key": "value"},
+				map[string]string{"foo": "bar"},
+			},
+			wantErr:      false,
+			expectedHash: "fe443377ca878d7d",
+		},
+		{
+			name:         "Slice input",
+			value:        []interface{}{[]string{"test1", "test2"}},
+			wantErr:      false,
+			expectedHash: "0c1efb7496fa5b19",
+		},
+		{
+			name: "Multiple Slice input",
+			value: []interface{}{
+				[]string{"test1", "test2"},
+				[]string{"test3", "test4"},
+				[]string{"test2", "test1"},
+			},
+			wantErr:      false,
+			expectedHash: "0590d72ff80ff5e3",
+		},
+		{
+			name: "Multiple Mix of Inputs",
+			value: []interface{}{
+				[]string{"test1", "test2"},
+				map[string]string{"foo": "bar"},
+				[]string{"test3", "test4"},
+				testStruct{Field1: "test5", Field2: 987},
+			},
+			wantErr:      false,
+			expectedHash: "e63ec7734b9ca5fb",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := QuickHashFields(tt.value...)
+
+			if (err != nil) != tt.wantErr {
+				t.Errorf("QuickHashFields() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+
+			if !tt.wantErr && len(got) != 16 {
+				t.Errorf("QuickHashFields() returned hash of length %d, want 16", len(got))
+			}
+
+			if tt.expectedHash != got {
+				t.Errorf("QuickHashFields() returned hash %v, want %v", got, tt.expectedHash)
+			}
+		})
+	}
+}

--- a/genesyscloud/util/hash_test.go
+++ b/genesyscloud/util/hash_test.go
@@ -147,6 +147,19 @@ func TestUnitQuickHashFields_ComplexTypes(t *testing.T) {
 			wantErr:      false,
 			expectedHash: "e63ec7734b9ca5fb",
 		},
+		{
+			name: "Multiple Mix of Inputs with some as nil",
+			value: []interface{}{
+				[]string{"test1", "test2"},
+				map[string]string{"foo": "bar"},
+				[]string{"test3", "test4"},
+				nil,
+				testStruct{Field1: "test5", Field2: 987},
+				nil,
+			},
+			wantErr:      false,
+			expectedHash: "e63ec7734b9ca5fb",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This addresses DEVTOOLING-1183

We have several resource types that can still generate duplicate resource block labels. This addresses the issue by allowing the BCP Sanitizer to add a hash of the resource instance's unique fields to the block label. 

This should ensure consistency when comparing across orgs.