### PR TITLE
NO-JIRA - Update/bcp sanitizer to always include ufh

### DIFF
--- a/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
+++ b/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
@@ -41,18 +41,20 @@ type deleteExternalContactFunc func(ctx context.Context, p *externalContactsCont
 type getExternalContactByIdFunc func(ctx context.Context, p *externalContactsContactsProxy, externalContactId string) (externalContact *platformclientv2.Externalcontact, response *platformclientv2.APIResponse, err error)
 type getExternalContactIdBySearchFunc func(ctx context.Context, p *externalContactsContactsProxy, search string) (externalContactId string, retryable bool, response *platformclientv2.APIResponse, err error)
 type updateExternalContactFunc func(ctx context.Context, p *externalContactsContactsProxy, externalContactId string, externalContact platformclientv2.Externalcontact) (*platformclientv2.Externalcontact, *platformclientv2.APIResponse, error)
+type getExternalContactsOrganizationByIdFunc func(ctx context.Context, p *externalContactsContactsProxy, id string) (externalOrganization *platformclientv2.Externalorganization, apiResponse *platformclientv2.APIResponse, err error)
 
 // externalContactsContactsProxy contains all of the methods that call genesys cloud APIs.
 type externalContactsContactsProxy struct {
-	clientConfig                     *platformclientv2.Configuration
-	externalContactsApi              *platformclientv2.ExternalContactsApi
-	getAllExternalContactsAttr       getAllExternalContactsFunc
-	createExternalContactAttr        createExternalContactFunc
-	deleteExternalContactByIdAttr    deleteExternalContactFunc
-	getExternalContactByIdAttr       getExternalContactByIdFunc
-	getExternalContactIdBySearchAttr getExternalContactIdBySearchFunc
-	updateExternalContactAttr        updateExternalContactFunc
-	externalContactsCache            rc.CacheInterface[platformclientv2.Externalcontact]
+	clientConfig                            *platformclientv2.Configuration
+	externalContactsApi                     *platformclientv2.ExternalContactsApi
+	getAllExternalContactsAttr              getAllExternalContactsFunc
+	createExternalContactAttr               createExternalContactFunc
+	deleteExternalContactByIdAttr           deleteExternalContactFunc
+	getExternalContactByIdAttr              getExternalContactByIdFunc
+	getExternalContactIdBySearchAttr        getExternalContactIdBySearchFunc
+	updateExternalContactAttr               updateExternalContactFunc
+	getExternalContactsOrganizationByIdAttr getExternalContactsOrganizationByIdFunc
+	externalContactsCache                   rc.CacheInterface[platformclientv2.Externalcontact]
 }
 
 // newExternalContactsContactsProxy initializes the External Contacts proxy with all of the data needed to communicate with Genesys Cloud
@@ -60,15 +62,16 @@ func newExternalContactsContactsProxy(clientConfig *platformclientv2.Configurati
 	api := platformclientv2.NewExternalContactsApiWithConfig(clientConfig)
 	externalContactsCache := rc.NewResourceCache[platformclientv2.Externalcontact]()
 	return &externalContactsContactsProxy{
-		clientConfig:                     clientConfig,
-		externalContactsApi:              api,
-		externalContactsCache:            externalContactsCache,
-		getAllExternalContactsAttr:       getAllExternalContactsFn,
-		createExternalContactAttr:        createExternalContactFn,
-		getExternalContactByIdAttr:       getExternalContactByIdFn,
-		deleteExternalContactByIdAttr:    deleteExternalContactsFn,
-		getExternalContactIdBySearchAttr: getExternalContactIdBySearchFn,
-		updateExternalContactAttr:        updateExternalContactFn,
+		clientConfig:                            clientConfig,
+		externalContactsApi:                     api,
+		externalContactsCache:                   externalContactsCache,
+		getAllExternalContactsAttr:              getAllExternalContactsFn,
+		createExternalContactAttr:               createExternalContactFn,
+		getExternalContactByIdAttr:              getExternalContactByIdFn,
+		deleteExternalContactByIdAttr:           deleteExternalContactsFn,
+		getExternalContactIdBySearchAttr:        getExternalContactIdBySearchFn,
+		updateExternalContactAttr:               updateExternalContactFn,
+		getExternalContactsOrganizationByIdAttr: getExternalContactsOrganizationByIdFn,
 	}
 }
 
@@ -112,6 +115,11 @@ func (p *externalContactsContactsProxy) getExternalContactIdBySearch(ctx context
 // updateExternalContact updates a Genesys Cloud External Contact
 func (p *externalContactsContactsProxy) updateExternalContact(ctx context.Context, externalContactId string, externalContact platformclientv2.Externalcontact) (*platformclientv2.Externalcontact, *platformclientv2.APIResponse, error) {
 	return p.updateExternalContactAttr(ctx, p, externalContactId, externalContact)
+}
+
+// getExternalContactsOrganizationById returns a single Genesys Cloud external contacts organization by Id
+func (p *externalContactsContactsProxy) getExternalContactsOrganizationById(ctx context.Context, id string) (externalContactsOrganization *platformclientv2.Externalorganization, apiResponse *platformclientv2.APIResponse, err error) {
+	return p.getExternalContactsOrganizationByIdAttr(ctx, p, id)
 }
 
 // getAllExternalContactsFn is the implementation for retrieving all external contacts in Genesys Cloud
@@ -196,4 +204,9 @@ func getExternalContactIdBySearchFn(ctx context.Context, p *externalContactsCont
 // updateExternalContactFn is an implementation of the function to update a Genesys Cloud external contact
 func updateExternalContactFn(ctx context.Context, p *externalContactsContactsProxy, externalContactId string, externalContact platformclientv2.Externalcontact) (*platformclientv2.Externalcontact, *platformclientv2.APIResponse, error) {
 	return p.externalContactsApi.PutExternalcontactsContact(externalContactId, externalContact)
+}
+
+// getExternalContactsOrganizationByIdFn is an implementation of the function to get a Genesys Cloud external contacts organization by Id
+func getExternalContactsOrganizationByIdFn(ctx context.Context, p *externalContactsContactsProxy, id string) (externalContactsOrganization *platformclientv2.Externalorganization, apiResponse *platformclientv2.APIResponse, err error) {
+	return p.externalContactsApi.GetExternalcontactsOrganization(id, []string{}, false)
 }

--- a/genesyscloud/resource_exporter/resource_name_sanitizer_test.go
+++ b/genesyscloud/resource_exporter/resource_name_sanitizer_test.go
@@ -331,8 +331,8 @@ func TestUnitSanitize(t *testing.T) {
 				assert.NotEqual(t, result["id5"].BlockLabel, result["id6"].BlockLabel)
 				assert.NotEqual(t, result["id5"].BlockLabel, result["id7"].BlockLabel)
 				assert.Equal(t, result["id6"].BlockLabel, result["id7"].BlockLabel)
-				assert.Equal(t, result["id1"].BlockLabel, "test_distinct_user_foo_com")
-				assert.Equal(t, result["id2"].BlockLabel, "test_distinct_user2_foo_com")
+				assert.Equal(t, "test_distinct_user_foo_com", result["id1"].BlockLabel)
+				assert.Equal(t, "test_distinct_user2_foo_com", result["id2"].BlockLabel)
 				assert.True(t, strings.HasPrefix(result["id3"].BlockLabel, "test_user_foo_com_"))
 				assert.True(t, strings.HasPrefix(result["id4"].BlockLabel, "test_user_foo_com_"))
 				assert.True(t, strings.HasPrefix(result["id5"].BlockLabel, "test_user_foo_com_"))
@@ -384,8 +384,8 @@ func TestUnitSanitize(t *testing.T) {
 				// Intentionally commented out, as this could be equal (same hash) or
 				// not equal (one without the hash). Retained for consistency purposes.
 				// assert.NotEqual(t, result["id6"].BlockLabel, result["id7"].BlockLabel)
-				assert.Equal(t, result["id1"].BlockLabel, "test_distinct_user_foo_com")
-				assert.Equal(t, result["id2"].BlockLabel, "test_distinct_user2_foo_com")
+				assert.Equal(t, "test_distinct_user_foo_com", result["id1"].BlockLabel)
+				assert.Equal(t, "test_distinct_user2_foo_com", result["id2"].BlockLabel)
 				assert.True(t, strings.HasPrefix(result["id3"].BlockLabel, "test_user_foo_com"))
 				assert.True(t, strings.HasPrefix(result["id4"].BlockLabel, "test_user_foo_com"))
 				assert.True(t, strings.HasPrefix(result["id5"].BlockLabel, "test_user_foo_com"))
@@ -456,11 +456,11 @@ func TestUnitSanitize(t *testing.T) {
 				assert.NotEqual(t, id5Hash, id7Hash)
 				assert.Equal(t, id6Hash, id7Hash)
 
-				assert.Equal(t, result["id1"].BlockLabel, fmt.Sprintf("test_distinct_user_foo_com__BLH%s", id1Hash))
-				assert.Equal(t, result["id2"].BlockLabel, fmt.Sprintf("test_distinct_user2_foo_com__BLH%s", id2Hash))
-				assert.Equal(t, result["id3"].BlockLabel, fmt.Sprintf("test_user_foo_com__BLH%s", id3Hash))
-				assert.Equal(t, result["id4"].BlockLabel, fmt.Sprintf("test_user_foo_com__BLH%s_UFH%s", id4Hash, result["id4"].BlockHash))
-				assert.Equal(t, result["id5"].BlockLabel, fmt.Sprintf("test_user_foo_com__BLH%s_UFH%s", id5Hash, result["id5"].BlockHash))
+				assert.Equal(t, fmt.Sprintf("test_distinct_user_foo_com__BLH%s_UFH%s", id1Hash, result["id1"].BlockHash), result["id1"].BlockLabel)
+				assert.Equal(t, fmt.Sprintf("test_distinct_user2_foo_com__BLH%s", id2Hash), result["id2"].BlockLabel) // No BlockHash value
+				assert.Equal(t, fmt.Sprintf("test_user_foo_com__BLH%s_UFH%s", id3Hash, result["id3"].BlockHash), result["id3"].BlockLabel)
+				assert.Equal(t, fmt.Sprintf("test_user_foo_com__BLH%s_UFH%s", id4Hash, result["id4"].BlockHash), result["id4"].BlockLabel)
+				assert.Equal(t, fmt.Sprintf("test_user_foo_com__BLH%s_UFH%s", id5Hash, result["id5"].BlockHash), result["id5"].BlockLabel)
 				assert.True(t, strings.HasPrefix(result["id6"].BlockLabel, fmt.Sprintf("test_user_foo_com__BLH%s_UFH%s", id6Hash, result["id6"].BlockHash)))
 				assert.True(t, strings.HasPrefix(result["id7"].BlockLabel, fmt.Sprintf("test_user_foo_com__BLH%s_UFH%s", id6Hash, result["id7"].BlockHash)))
 				assert.False(t, strings.Contains(result["id1"].BlockLabel, "_DUPLICATE_INSTANCE_")) // Duplicate NOT appended
@@ -502,12 +502,12 @@ func TestUnitSanitize(t *testing.T) {
 				"id2": &ResourceMeta{BlockLabel: "456#test"},
 			},
 			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
-				assert.Equal(t, result["id1"].BlockLabel, "_123_test")
-				assert.Equal(t, result["id2"].BlockLabel, "_456_test")
+				assert.Equal(t, "_123_test", result["id1"].BlockLabel)
+				assert.Equal(t, "_456_test", result["id2"].BlockLabel)
 			},
 			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
-				assert.Equal(t, result["id1"].BlockLabel, "_123_test")
-				assert.Equal(t, result["id2"].BlockLabel, "_456_test")
+				assert.Equal(t, "_123_test", result["id1"].BlockLabel)
+				assert.Equal(t, "_456_test", result["id2"].BlockLabel)
 			},
 			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {
 				assert.True(t, strings.HasPrefix(result["id1"].BlockLabel, "_123_test_"))
@@ -521,13 +521,13 @@ func TestUnitSanitize(t *testing.T) {
 				"id2": &ResourceMeta{BlockLabel: "Test#Label_456"},
 			},
 			validateOriginal: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOriginal) {
-				assert.Equal(t, result["id1"].BlockLabel, "Test_Label_123")
-				assert.Equal(t, result["id2"].BlockLabel, "Test_Label_456")
+				assert.Equal(t, "Test_Label_123", result["id1"].BlockLabel)
+				assert.Equal(t, "Test_Label_456", result["id2"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 			},
 			validateOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerOptimized) {
-				assert.Equal(t, result["id1"].BlockLabel, "Test_Label_123")
-				assert.Equal(t, result["id2"].BlockLabel, "Test_Label_456")
+				assert.Equal(t, "Test_Label_123", result["id1"].BlockLabel)
+				assert.Equal(t, "Test_Label_456", result["id2"].BlockLabel)
 				assert.NotEqual(t, result["id1"].BlockLabel, result["id2"].BlockLabel)
 			},
 			validateBCPOptimized: func(t *testing.T, result ResourceIDMetaMap, sanitizer sanitizerBCPOptimized) {

--- a/genesyscloud/util/hash.go
+++ b/genesyscloud/util/hash.go
@@ -19,10 +19,14 @@ var (
 
 // QuickHashFields generates a SHA-256 hash of any number of objects using gob encoding
 // Returns first 16 characters of hex-encoded hash for a good balance of uniqueness and length
+// For large structs, consider passing pointers to reduce copying overhead.
 func QuickHashFields(values ...interface{}) (string, error) {
 	if len(values) == 0 {
 		return "", fmt.Errorf("no values provided to hash")
 	}
+
+	// Keep track when we have any non-nil values
+	hasNonNilValue := false
 
 	// Use buffer pool for efficiency
 	buf := bufferPool.Get().(*bytes.Buffer)
@@ -31,13 +35,38 @@ func QuickHashFields(values ...interface{}) (string, error) {
 
 	enc := json.NewEncoder(buf)
 	for _, val := range values {
+		// Skip nil values
+		if val == nil {
+			continue
+		}
+
+		hasNonNilValue = true
 		if err := enc.Encode(val); err != nil {
 			return "", fmt.Errorf("failed to encode value: %v", err)
 		}
 
 	}
 
+	// If all values were nil, return empty
+	if !hasNonNilValue {
+		return "", nil
+	}
+
 	h := sha256.New()
 	h.Write(buf.Bytes())
 	return hex.EncodeToString(h.Sum(nil))[:16], nil
+}
+
+// QuickHashFieldsWithDefault generates a SHA-256 hash of any non-nil objects using json encoding
+// Returns first 16 characters of hex-encoded hash for a good balance of uniqueness and length
+// If all values are nil, returns the provided default value instead
+func QuickHashFieldsWithDefault(defaultValue string, values ...interface{}) (string, error) {
+	hash, err := QuickHashFields(values...)
+	if err != nil {
+		return "", err
+	}
+	if hash == "" {
+		return defaultValue, nil
+	}
+	return hash, nil
 }

--- a/genesyscloud/util/hash_test.go
+++ b/genesyscloud/util/hash_test.go
@@ -12,59 +12,70 @@ func TestUnitQuickHashFields(t *testing.T) {
 	numPtr := &num
 
 	tests := []struct {
-		name    string
-		values  []interface{}
-		wantErr bool
+		name     string
+		values   []interface{}
+		wantErr  bool
+		wantHash bool
 	}{
 		{
-			name:    "No inputs",
-			values:  []interface{}{},
-			wantErr: true,
+			name:     "No inputs",
+			values:   []interface{}{},
+			wantErr:  true,
+			wantHash: false,
 		},
 		{
-			name:    "Single string input",
-			values:  []interface{}{"test"},
-			wantErr: false,
+			name:     "Single string input",
+			values:   []interface{}{"test"},
+			wantErr:  false,
+			wantHash: true,
 		},
 		{
-			name:    "Single nil input",
-			values:  []interface{}{nil},
-			wantErr: false,
+			name:     "Single nil input",
+			values:   []interface{}{nil},
+			wantErr:  false,
+			wantHash: false,
 		},
 		{
-			name:    "String pointer input",
-			values:  []interface{}{strPtr},
-			wantErr: false,
+			name:     "String pointer input",
+			values:   []interface{}{strPtr},
+			wantErr:  false,
+			wantHash: true,
 		},
 		{
-			name:    "Nil string pointer input",
-			values:  []interface{}{nilStrPtr},
-			wantErr: false,
+			name:     "Nil string pointer input",
+			values:   []interface{}{nilStrPtr},
+			wantErr:  false,
+			wantHash: false,
 		},
 		{
-			name:    "Single int input",
-			values:  []interface{}{123},
-			wantErr: false,
+			name:     "Single int input",
+			values:   []interface{}{123},
+			wantErr:  false,
+			wantHash: true,
 		},
 		{
-			name:    "Single int pointer input",
-			values:  []interface{}{numPtr},
-			wantErr: false,
+			name:     "Single int pointer input",
+			values:   []interface{}{numPtr},
+			wantErr:  false,
+			wantHash: true,
 		},
 		{
-			name:    "Multiple string inputs",
-			values:  []interface{}{"test1", "test2", "test3"},
-			wantErr: false,
+			name:     "Multiple string inputs",
+			values:   []interface{}{"test1", "test2", "test3"},
+			wantErr:  false,
+			wantHash: true,
 		},
 		{
-			name:    "Mixed type inputs",
-			values:  []interface{}{"test", 123, true},
-			wantErr: false,
+			name:     "Mixed type inputs",
+			values:   []interface{}{"test", 123, true},
+			wantErr:  false,
+			wantHash: true,
 		},
 		{
-			name:    "Multiple nil inputs",
-			values:  []interface{}{nil, nil, nil},
-			wantErr: false,
+			name:     "Multiple nil inputs",
+			values:   []interface{}{nil, nil, nil},
+			wantErr:  false,
+			wantHash: false,
 		},
 		{
 			name: "Mixed pointer and value types",
@@ -75,7 +86,8 @@ func TestUnitQuickHashFields(t *testing.T) {
 				nilStrPtr,
 				nil,
 			},
-			wantErr: false,
+			wantErr:  false,
+			wantHash: true,
 		},
 	}
 
@@ -88,7 +100,7 @@ func TestUnitQuickHashFields(t *testing.T) {
 				return
 			}
 
-			if !tt.wantErr {
+			if tt.wantHash {
 				// Verify hash is exactly 16 characters
 				if len(got) != 16 {
 					t.Errorf("QuickHashFields() returned hash of length %d, want 16", len(got))


### PR DESCRIPTION
We have had some more discussions about the BCP Sanitizer logic and need to make some tweaks to it to account for edge cases such as:
> we don't know which resources will be duplicates when comparing the source and dest orgs. If there are duplicates in the source org but only a single instance in the dest org, without the suffix, there is no way to match the resources together. We need the hashes to always be the same

We also need to add support for external contacts