### PR TITLE
Util list hardening to prevent nil dereference panics

### DIFF
--- a/genesyscloud/util/lists/util_lists.go
+++ b/genesyscloud/util/lists/util_lists.go
@@ -119,6 +119,9 @@ func StringListToInterfaceList(list []string) []interface{} {
 }
 
 func SetToStringList(strSet *schema.Set) *[]string {
+	if strSet == nil {
+		return nil
+	}
 	interfaceList := strSet.List()
 	strList := InterfaceListToStrings(interfaceList)
 	return &strList
@@ -127,13 +130,20 @@ func SetToStringList(strSet *schema.Set) *[]string {
 func InterfaceListToStrings(interfaceList []interface{}) []string {
 	strs := make([]string, len(interfaceList))
 	for i, val := range interfaceList {
-		strs[i] = val.(string)
+		if val, ok := val.(string); ok {
+			strs[i] = val
+		} else {
+			strs[i] = ""
+		}
 	}
 	return strs
 }
 
 func BuildStringListFromSetInMap(m map[string]any, key string) []string {
 	var strList []string
+	if m == nil || m[key] == nil {
+		return strList
+	}
 	if setVal, ok := m[key].(*schema.Set); ok {
 		listVal := setVal.List()
 		if len(listVal) > 0 {
@@ -144,13 +154,21 @@ func BuildStringListFromSetInMap(m map[string]any, key string) []string {
 }
 
 func BuildSdkStringList(d *schema.ResourceData, attrName string) *[]string {
+	if d == nil {
+		return nil
+	}
 	if val, ok := d.GetOk(attrName); ok {
-		return SetToStringList(val.(*schema.Set))
+		if setVal, ok := val.(*schema.Set); ok {
+			return SetToStringList(setVal)
+		}
 	}
 	return nil
 }
 
 func BuildSdkStringListFromInterfaceArray(d *schema.ResourceData, attrName string) *[]string {
+	if d == nil {
+		return nil
+	}
 	var stringArray []string
 	if val, ok := d.GetOk(attrName); ok {
 		if valArray, ok := val.([]interface{}); ok {
@@ -164,6 +182,9 @@ func FlattenList[T interface{}](resourceList *[]T, elementFlattener func(resourc
 	if resourceList == nil {
 		return nil
 	}
+	if elementFlattener == nil {
+		return nil
+	}
 
 	var resultList []map[string]interface{}
 
@@ -175,6 +196,9 @@ func FlattenList[T interface{}](resourceList *[]T, elementFlattener func(resourc
 
 func FlattenAsList[T interface{}](resource *T, elementFlattener func(resource *T) map[string]interface{}) *[]map[string]interface{} {
 	if resource == nil {
+		return nil
+	}
+	if elementFlattener == nil {
 		return nil
 	}
 
@@ -196,6 +220,9 @@ func NilToEmptyList[T interface{}](list *[]T) *[]T {
 
 // Remove an item from a string list based on the value
 func Remove[T comparable](s []T, r T) []T {
+	if len(s) == 0 {
+		return s
+	}
 	for i, v := range s {
 		if v == r {
 			return append(s[:i], s[i+1:]...)
@@ -211,13 +238,22 @@ func ConvertMapStringAnyToMapStringString(m map[string]any) map[string]string {
 	}
 	sm := make(map[string]string)
 	for k, v := range m {
-		sm[k] = v.(string)
+		if v == nil {
+			sm[k] = ""
+		} else if valStr, ok := v.(string); ok {
+			sm[k] = valStr
+		} else {
+			sm[k] = ""
+		}
 	}
 	return sm
 }
 
 // Generic function to apply a function for each item over a list
 func Map[T, V any](ts []T, fn func(T) V) []V {
+	if fn == nil {
+		return nil
+	}
 	result := make([]V, len(ts))
 	for i, t := range ts {
 		result[i] = fn(t)

--- a/genesyscloud/util/lists/util_lists_test.go
+++ b/genesyscloud/util/lists/util_lists_test.go
@@ -1,44 +1,45 @@
 package lists
 
 import (
+	"reflect"
 	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type AreEquivalentTestCase struct {
-	arrayA     []string
-	arrayB     []string
-	equivalent bool
-}
-
-type RemoveTestCase struct {
-	originalSlice  []string
-	resultingSlice []string
-	itemToRemove   string
-}
-
 func TestAreEquivalent(t *testing.T) {
-	testCases := []AreEquivalentTestCase{
+	testCases := []struct {
+		name       string
+		arrayA     []string
+		arrayB     []string
+		equivalent bool
+	}{
 		{
+			name:       "Empty string lists",
 			arrayA:     []string{},
 			arrayB:     []string{},
 			equivalent: true,
 		},
 		{
+			name:       "Equivalent lists not in same order",
 			arrayA:     []string{"foo", "bar"},
 			arrayB:     []string{"bar", "foo"},
 			equivalent: true,
 		},
 		{
+			name:       "Equivalent longer lists not in same order",
 			arrayA:     []string{"y", "x", "foo", "bar"},
 			arrayB:     []string{"x", "bar", "foo", "y"},
 			equivalent: true,
 		},
 		{
+			name:       "Lists of unequal length with same content",
 			arrayA:     []string{"x", "x", "x"},
 			arrayB:     []string{"x", "x"},
 			equivalent: false,
 		},
 		{
+			name:       "Lists of equal length with different content",
 			arrayA:     []string{"x", "x"},
 			arrayB:     []string{"x", "y"},
 			equivalent: false,
@@ -46,59 +47,789 @@ func TestAreEquivalent(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		arrayACopy := make([]string, len(tc.arrayA))
-		arrayBCopy := make([]string, len(tc.arrayB))
-		copy(arrayACopy, tc.arrayA)
-		copy(arrayBCopy, tc.arrayB)
+		t.Run(tc.name, func(t *testing.T) {
+			arrayACopy := make([]string, len(tc.arrayA))
+			arrayBCopy := make([]string, len(tc.arrayB))
+			copy(arrayACopy, tc.arrayA)
+			copy(arrayBCopy, tc.arrayB)
 
-		result := AreEquivalent(tc.arrayA, tc.arrayB)
-		if result != tc.equivalent {
-			t.Errorf("Got %v for lists %v and %v. Should have got %v.", result, tc.arrayA, tc.arrayB, tc.equivalent)
-		}
+			result := AreEquivalent(tc.arrayA, tc.arrayB)
+			if result != tc.equivalent {
+				t.Errorf("Got %v for lists %v and %v. Should have got %v.", result, tc.arrayA, tc.arrayB, tc.equivalent)
+			}
 
-		// Ensure the sort function hasn't manipulated the arrays that were passed into AreEquivalent()
-		if len(tc.arrayA) != len(arrayACopy) {
-			t.Errorf("arrayA has changed after going through the function. Should be %v, got %v", arrayACopy, tc.arrayA)
-		}
-		if len(tc.arrayB) != len(arrayBCopy) {
-			t.Errorf("arrayB has changed after going through the function. Should be %v, got %v", arrayBCopy, tc.arrayB)
-		}
-		for k, v := range tc.arrayA {
-			if v != arrayACopy[k] {
+			// Ensure the sort function hasn't manipulated the arrays that were passed into AreEquivalent()
+			if len(tc.arrayA) != len(arrayACopy) {
 				t.Errorf("arrayA has changed after going through the function. Should be %v, got %v", arrayACopy, tc.arrayA)
 			}
-		}
-		for k, v := range tc.arrayB {
-			if v != arrayBCopy[k] {
+			if len(tc.arrayB) != len(arrayBCopy) {
 				t.Errorf("arrayB has changed after going through the function. Should be %v, got %v", arrayBCopy, tc.arrayB)
 			}
-		}
+			for k, v := range tc.arrayA {
+				if v != arrayACopy[k] {
+					t.Errorf("arrayA has changed after going through the function. Should be %v, got %v", arrayACopy, tc.arrayA)
+				}
+			}
+			for k, v := range tc.arrayB {
+				if v != arrayBCopy[k] {
+					t.Errorf("arrayB has changed after going through the function. Should be %v, got %v", arrayBCopy, tc.arrayB)
+				}
+			}
+		})
 	}
 }
 
 func TestRemove(t *testing.T) {
-	testCases := []RemoveTestCase{
+	testCases := []struct {
+		name          string
+		originalSlice []string
+		itemToRemove  string
+		expectedSlice []string
+	}{
 		{
-			originalSlice:  []string{"a", "b", "c"},
-			itemToRemove:   "b",
-			resultingSlice: []string{"a", "c"},
+			name:          "Empty slice",
+			originalSlice: []string{},
+			itemToRemove:  "test",
+			expectedSlice: []string{},
 		},
 		{
-			originalSlice:  []string{"a", "b", "c"},
-			itemToRemove:   "a",
-			resultingSlice: []string{"b", "c"},
+			name:          "Item in middle of slice",
+			originalSlice: []string{"a", "b", "c"},
+			itemToRemove:  "b",
+			expectedSlice: []string{"a", "c"},
 		},
 		{
-			originalSlice:  []string{"a", "b", "c"},
-			itemToRemove:   "c",
-			resultingSlice: []string{"a", "b"},
+			name:          "Item at start of slice",
+			originalSlice: []string{"a", "b", "c"},
+			itemToRemove:  "a",
+			expectedSlice: []string{"b", "c"},
+		},
+		{
+			name:          "Item at end of slice",
+			originalSlice: []string{"a", "b", "c"},
+			itemToRemove:  "c",
+			expectedSlice: []string{"a", "b"},
+		},
+		{
+			name:          "Item not in slice",
+			originalSlice: []string{"test1", "test2", "test3"},
+			itemToRemove:  "test4",
+			expectedSlice: []string{"test1", "test2", "test3"},
 		},
 	}
 
 	for _, testCase := range testCases {
-		res := Remove(testCase.originalSlice, testCase.itemToRemove)
-		if !AreEquivalent(res, testCase.resultingSlice) {
-			t.Errorf("expected %v, got %v", testCase.resultingSlice, res)
-		}
+		t.Run(testCase.name, func(t *testing.T) {
+			res := Remove(testCase.originalSlice, testCase.itemToRemove)
+			if !AreEquivalent(res, testCase.expectedSlice) {
+				t.Errorf("expected %v, got %v", testCase.expectedSlice, res)
+			}
+		})
+	}
+}
+
+func TestItemInSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		item     string
+		slice    []string
+		expected bool
+	}{
+		{
+			name:     "Empty slice",
+			item:     "test",
+			slice:    []string{},
+			expected: false,
+		},
+		{
+			name:     "Item in slice",
+			item:     "test",
+			slice:    []string{"test", "other"},
+			expected: true,
+		},
+		{
+			name:     "Item not in slice",
+			item:     "test",
+			slice:    []string{"other", "another"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ItemInSlice(tt.item, tt.slice)
+			if result != tt.expected {
+				t.Errorf("ItemInSlice() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+
+	// Test with integers
+	intTests := []struct {
+		name     string
+		item     int
+		slice    []int
+		expected bool
+	}{
+		{
+			name:     "Empty int slice",
+			item:     1,
+			slice:    []int{},
+			expected: false,
+		},
+		{
+			name:     "Int in slice",
+			item:     1,
+			slice:    []int{1, 2, 3},
+			expected: true,
+		},
+		{
+			name:     "Int not in slice",
+			item:     4,
+			slice:    []int{1, 2, 3},
+			expected: false,
+		},
+	}
+
+	for _, tt := range intTests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ItemInSlice(tt.item, tt.slice)
+			if result != tt.expected {
+				t.Errorf("ItemInSlice() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestRemoveStringFromSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    string
+		slice    []string
+		expected []string
+	}{
+		{
+			name:     "Empty slice",
+			value:    "test",
+			slice:    []string{},
+			expected: []string{},
+		},
+		{
+			name:     "Value in slice",
+			value:    "test",
+			slice:    []string{"test", "other"},
+			expected: []string{"other"},
+		},
+		{
+			name:     "Value not in slice",
+			value:    "test",
+			slice:    []string{"other", "another"},
+			expected: []string{"other", "another"},
+		},
+		{
+			name:     "Multiple occurrences",
+			value:    "test",
+			slice:    []string{"test", "other", "test"},
+			expected: []string{"other"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RemoveStringFromSlice(tt.value, tt.slice)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("RemoveStringFromSlice() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSubStringInSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		substr   string
+		slice    []string
+		expected bool
+	}{
+		{
+			name:     "Empty slice",
+			substr:   "test",
+			slice:    []string{},
+			expected: false,
+		},
+		{
+			name:     "Substring in slice",
+			substr:   "est",
+			slice:    []string{"test", "other"},
+			expected: true,
+		},
+		{
+			name:     "Substring not in slice",
+			substr:   "xyz",
+			slice:    []string{"test", "other"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SubStringInSlice(tt.substr, tt.slice)
+			if result != tt.expected {
+				t.Errorf("SubStringInSlice() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestContainsAnySubStringSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		str      string
+		slice    []string
+		expected bool
+	}{
+		{
+			name:     "Empty slice",
+			str:      "test",
+			slice:    []string{},
+			expected: false,
+		},
+		{
+			name:     "String contains substring",
+			str:      "testing",
+			slice:    []string{"est", "xyz"},
+			expected: true,
+		},
+		{
+			name:     "String doesn't contain substring",
+			str:      "testing",
+			slice:    []string{"abc", "xyz"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ContainsAnySubStringSlice(tt.str, tt.slice)
+			if result != tt.expected {
+				t.Errorf("ContainsAnySubStringSlice() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestSliceDifference(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        []string
+		b        []string
+		expected []string
+	}{
+		{
+			name:     "Both empty",
+			a:        []string{},
+			b:        []string{},
+			expected: nil,
+		},
+		{
+			name:     "A empty",
+			a:        []string{},
+			b:        []string{"test"},
+			expected: nil,
+		},
+		{
+			name:     "B empty",
+			a:        []string{"test"},
+			b:        []string{},
+			expected: []string{"test"},
+		},
+		{
+			name:     "No common elements",
+			a:        []string{"test1", "test2"},
+			b:        []string{"test3", "test4"},
+			expected: []string{"test1", "test2"},
+		},
+		{
+			name:     "Some common elements",
+			a:        []string{"test1", "test2", "test3"},
+			b:        []string{"test2", "test3", "test4"},
+			expected: []string{"test1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SliceDifference(tt.a, tt.b)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("SliceDifference() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStringListToSet(t *testing.T) {
+	tests := []struct {
+		name  string
+		list  []string
+		empty bool
+	}{
+		{
+			name:  "Empty list",
+			list:  []string{},
+			empty: true,
+		},
+		{
+			name:  "Single item",
+			list:  []string{"test"},
+			empty: false,
+		},
+		{
+			name:  "Multiple items",
+			list:  []string{"test1", "test2"},
+			empty: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StringListToSet(tt.list)
+			if tt.empty && result.Len() != 0 {
+				t.Errorf("StringListToSet() expected empty set, got %v", result)
+			}
+			if !tt.empty {
+				for _, item := range tt.list {
+					if !result.Contains(item) {
+						t.Errorf("StringListToSet() result doesn't contain %s", item)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestStringListToSetOrNil(t *testing.T) {
+	tests := []struct {
+		name     string
+		list     *[]string
+		expected bool // true if result should be nil
+	}{
+		{
+			name:     "Nil list",
+			list:     nil,
+			expected: true,
+		},
+		{
+			name:     "Empty list",
+			list:     &[]string{},
+			expected: false,
+		},
+		{
+			name:     "Non-empty list",
+			list:     &[]string{"test"},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StringListToSetOrNil(tt.list)
+			if tt.expected && result != nil {
+				t.Errorf("StringListToSetOrNil() expected nil, got %v", result)
+			}
+			if !tt.expected && result == nil {
+				t.Errorf("StringListToSetOrNil() expected non-nil, got nil")
+			}
+		})
+	}
+}
+
+func TestStringListToInterfaceList(t *testing.T) {
+	tests := []struct {
+		name     string
+		list     []string
+		expected int // expected length
+	}{
+		{
+			name:     "Empty list",
+			list:     []string{},
+			expected: 0,
+		},
+		{
+			name:     "Single item",
+			list:     []string{"test"},
+			expected: 1,
+		},
+		{
+			name:     "Multiple items",
+			list:     []string{"test1", "test2"},
+			expected: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StringListToInterfaceList(tt.list)
+			if len(result) != tt.expected {
+				t.Errorf("StringListToInterfaceList() expected length %d, got %d", tt.expected, len(result))
+			}
+			for i, item := range result {
+				if item.(string) != tt.list[i] {
+					t.Errorf("StringListToInterfaceList() item at index %d = %v, want %v", i, item, tt.list[i])
+				}
+			}
+		})
+	}
+}
+
+func TestSetToStringList(t *testing.T) {
+	tests := []struct {
+		name     string
+		set      *schema.Set
+		expected *[]string
+	}{
+		{
+			name:     "Nil set",
+			set:      nil,
+			expected: nil,
+		},
+		{
+			name:     "Empty set",
+			set:      schema.NewSet(schema.HashString, []interface{}{}),
+			expected: &[]string{},
+		},
+		{
+			name:     "Set with values",
+			set:      schema.NewSet(schema.HashString, []interface{}{"test1", "test2"}),
+			expected: &[]string{"test1", "test2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := SetToStringList(tt.set)
+			if tt.expected == nil && result != nil {
+				t.Errorf("SetToStringList() expected nil, got %v", result)
+				return
+			}
+			if tt.expected != nil && result == nil {
+				t.Errorf("SetToStringList() expected non-nil, got nil")
+				return
+			}
+			if tt.expected != nil && result != nil {
+				if len(*result) != len(*tt.expected) {
+					t.Errorf("SetToStringList() expected length %d, got %d", len(*tt.expected), len(*result))
+				}
+			}
+		})
+	}
+}
+
+func TestInterfaceListToStrings(t *testing.T) {
+	tests := []struct {
+		name          string
+		interfaceList []interface{}
+		expected      []string
+	}{
+		{
+			name:          "Empty list",
+			interfaceList: []interface{}{},
+			expected:      []string{},
+		},
+		{
+			name:          "String values",
+			interfaceList: []interface{}{"test1", "test2"},
+			expected:      []string{"test1", "test2"},
+		},
+		{
+			name:          "Mixed values",
+			interfaceList: []interface{}{"test1", 123, nil, true},
+			expected:      []string{"test1", "", "", ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := InterfaceListToStrings(tt.interfaceList)
+			if len(result) != len(tt.expected) {
+				t.Errorf("InterfaceListToStrings() expected length %d, got %d", len(tt.expected), len(result))
+				return
+			}
+			for i, val := range result {
+				if val != tt.expected[i] {
+					t.Errorf("InterfaceListToStrings() at index %d = %v, want %v", i, val, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBuildStringListFromSetInMap(t *testing.T) {
+	testSet := schema.NewSet(schema.HashString, []interface{}{"test1", "test2"})
+	emptySet := schema.NewSet(schema.HashString, []interface{}{})
+
+	tests := []struct {
+		name     string
+		mapValue map[string]any
+		key      string
+		expected []string
+	}{
+		{
+			name:     "Nil map",
+			mapValue: nil,
+			key:      "key",
+			expected: nil,
+		},
+		{
+			name:     "Key not in map",
+			mapValue: map[string]any{"otherKey": testSet},
+			key:      "key",
+			expected: nil,
+		},
+		{
+			name:     "Nil value in map",
+			mapValue: map[string]any{"key": nil},
+			key:      "key",
+			expected: nil,
+		},
+		{
+			name:     "Non-set value in map",
+			mapValue: map[string]any{"key": "not a set"},
+			key:      "key",
+			expected: nil,
+		},
+		{
+			name:     "Empty set in map",
+			mapValue: map[string]any{"key": emptySet},
+			key:      "key",
+			expected: nil,
+		},
+		{
+			name:     "Set with values",
+			mapValue: map[string]any{"key": testSet},
+			key:      "key",
+			expected: []string{"test1", "test2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildStringListFromSetInMap(tt.mapValue, tt.key)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("BuildStringListFromSetInMap() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestBuildSdkStringList(t *testing.T) {
+
+	tests := []struct {
+		name     string
+		d        *schema.ResourceData
+		attrName string
+		expected *[]string
+	}{
+		{
+			name:     "Nil ResourceData",
+			d:        nil,
+			attrName: "attr",
+			expected: nil,
+		},
+		{
+			name:     "Attribute not found",
+			d:        &schema.ResourceData{},
+			attrName: "attr",
+			expected: nil,
+		},
+		{
+			name:     "Attribute not a set",
+			d:        &schema.ResourceData{},
+			attrName: "attr",
+			expected: nil,
+		},
+		{
+			name: "Attribute in set",
+			d: func() *schema.ResourceData {
+				schemaMap := map[string]*schema.Schema{
+					"attr": {
+						Type:     schema.TypeSet,
+						Required: true,
+						Elem:     &schema.Schema{Type: schema.TypeString},
+					},
+				}
+
+				dataMap := map[string]interface{}{
+					"attr": []interface{}{"test1", "test2"},
+				}
+				d := schema.TestResourceDataRaw(t, schemaMap, dataMap)
+				return d
+			}(),
+			attrName: "attr",
+			expected: &[]string{"test1", "test2"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := BuildSdkStringList(tt.d, tt.attrName)
+			if tt.expected == nil && result != nil {
+				t.Errorf("BuildSdkStringList() expected nil, got %v", result)
+			}
+			if tt.expected != nil && result == nil {
+				t.Errorf("BuildSdkStringList() expected non-nil, got nil")
+			}
+		})
+	}
+}
+
+func TestNilToEmptyList(t *testing.T) {
+	var nilList *[]string
+	nonNilList := &[]string{"test"}
+	emptyList := []string{}
+
+	tests := []struct {
+		name     string
+		list     *[]string
+		expected *[]string
+	}{
+		{
+			name:     "Nil",
+			list:     nil,
+			expected: &emptyList,
+		},
+		{
+			name:     "Nil list",
+			list:     nilList,
+			expected: &emptyList,
+		},
+		{
+			name:     "Non-nil list",
+			list:     nonNilList,
+			expected: nonNilList,
+		},
+		{
+			name:     "Empty list",
+			list:     &emptyList,
+			expected: &emptyList,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NilToEmptyList(tt.list)
+			if result == nil {
+				t.Errorf("NilToEmptyList() returned nil")
+			}
+			if !reflect.DeepEqual(*tt.expected, *result) {
+				t.Errorf("NilToEmptyList() expected %v, got %v", tt.expected, *result)
+			}
+		})
+	}
+}
+
+func TestConvertMapStringAnyToMapStringString(t *testing.T) {
+	tests := []struct {
+		name     string
+		m        map[string]any
+		expected map[string]string
+	}{
+		{
+			name:     "Nil map",
+			m:        nil,
+			expected: nil,
+		},
+		{
+			name:     "Empty map",
+			m:        map[string]any{},
+			expected: map[string]string{},
+		},
+		{
+			name:     "String values",
+			m:        map[string]any{"key1": "value1", "key2": "value2"},
+			expected: map[string]string{"key1": "value1", "key2": "value2"},
+		},
+		{
+			name:     "Mixed values",
+			m:        map[string]any{"key1": "value1", "key2": 123, "key3": nil},
+			expected: map[string]string{"key1": "value1", "key2": "", "key3": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ConvertMapStringAnyToMapStringString(tt.m)
+			if tt.expected == nil && result != nil {
+				t.Errorf("ConvertMapStringAnyToMapStringString() expected nil, got %v", result)
+				return
+			}
+			if tt.expected != nil && result == nil {
+				t.Errorf("ConvertMapStringAnyToMapStringString() expected non-nil, got nil")
+				return
+			}
+			if tt.expected != nil && result != nil {
+				if len(result) != len(tt.expected) {
+					t.Errorf("ConvertMapStringAnyToMapStringString() expected length %d, got %d", len(tt.expected), len(result))
+					return
+				}
+				for k, v := range tt.expected {
+					if result[k] != v {
+						t.Errorf("ConvertMapStringAnyToMapStringString() key %s = %v, want %v", k, result[k], v)
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestMap(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []int
+		fn       func(int) string
+		expected []string
+	}{
+		{
+			name:     "Nil function",
+			slice:    []int{1, 2, 3},
+			fn:       nil,
+			expected: nil,
+		},
+		{
+			name:     "Empty slice",
+			slice:    []int{},
+			fn:       func(i int) string { return "test" },
+			expected: []string{},
+		},
+		{
+			name:     "Normal case",
+			slice:    []int{1, 2, 3},
+			fn:       func(i int) string { return "test" + string(rune(i+'0')) },
+			expected: []string{"test1", "test2", "test3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := Map(tt.slice, tt.fn)
+			if tt.expected == nil && result != nil {
+				t.Errorf("Map() expected nil, got %v", result)
+				return
+			}
+			if tt.expected != nil && result == nil {
+				t.Errorf("Map() expected non-nil, got nil")
+				return
+			}
+			if tt.expected != nil && result != nil {
+				if len(result) != len(tt.expected) {
+					t.Errorf("Map() expected length %d, got %d", len(tt.expected), len(result))
+					return
+				}
+				for i, v := range tt.expected {
+					if result[i] != v {
+						t.Errorf("Map() index %d = %v, want %v", i, result[i], v)
+					}
+				}
+			}
+		})
 	}
 }


### PR DESCRIPTION
Andrew Appleton reported this error:

```
Stack trace from the terraform-provider-genesyscloud_v1.63.0 plugin:

panic: interface conversion: interface {} is nil, not string

goroutine 338 [running]:
terraform-provider-genesyscloud/genesyscloud/util/lists.InterfaceListToStrings(...)
	terraform-provider-genesyscloud/genesyscloud/util/lists/util_lists.go:130
terraform-provider-genesyscloud/genesyscloud/util/lists.BuildSdkStringListFromInterfaceArray(0xc00052bd00, {0x1aa9aab, 0xc})
	terraform-provider-genesyscloud/genesyscloud/util/lists/util_lists.go:157 +0x138
terraform-provider-genesyscloud/genesyscloud/idp_generic.updateIdpGeneric({0x1f0e180, 0xc000b676c0}, 0xc00052bd00, {0x16e83a0, 0xc00014bc20})
	terraform-provider-genesyscloud/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go:110 +0x2b1
terraform-provider-genesyscloud/genesyscloud/idp_generic.createIdpGeneric({0x1f0e180, 0xc000b676c0}, 0xc00052bd00, {0x16e83a0, 0xc00014bc20})
	terraform-provider-genesyscloud/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go:55 +0xbf
terraform-provider-genesyscloud/genesyscloud/idp_generic.ResourceIdpGeneric.CreateWithPooledClient.wrapWithRecover.func3({0x1f0e180, 0xc000b676c0}, 0xc00052bd00, {0x16e83a0, 0xc00014bc20})
	terraform-provider-genesyscloud/genesyscloud/provider/sdk_client_pool.go:488 +0x151
terraform-provider-genesyscloud/genesyscloud/idp_generic.ResourceIdpGeneric.CreateWithPooledClient.runWithPooledClient.func4({0x1f0e180, 0xc000b676c0}, 0xc00052bd00, {0x16e83a0, 0xc0001b78c0})
	terraform-provider-genesyscloud/genesyscloud/provider/sdk_client_pool.go:528 +0x1a5
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).create(0xc000513700, {0x1f0e0d8, 0xc000b76840}, 0xc00052bd00, {0x16e83a0, 0xc0001b78c0})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/resource.go:838 +0x119
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).Apply(0xc000513700, {0x1f0e0d8, 0xc000b76840}, 0xc000b5ef70, 0xc00052bb80, {0x16e83a0, 0xc0001b78c0})
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/resource.go:969 +0xa69
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ApplyResourceChange(0xc0005c3098, {0x1f0e0d8?, 0xc000b76780?}, 0xc000b47540)
	github.com/hashicorp/terraform-plugin-sdk/v2@v2.36.1/helper/schema/grpc_provider.go:1188 +0xd5c
github.com/hashicorp/terraform-plugin-go/tfprotov5/tf5server.(*server).ApplyResourceChange(0xc0002dc500, {0x1f0e0d8?, 0xc000b5bf20?}, 0xc000b67180)
	github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/tf5server/server.go:866 +0x3bc
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ApplyResourceChange_Handler({0x19ff9a0, 0xc0002dc500}, {0x1f0e0d8, 0xc000b5bf20}, 0xc00052b900, 0x0)
	github.com/hashicorp/terraform-plugin-go@v0.26.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:611 +0x1a6
google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001be000, {0x1f0e0d8, 0xc000b5bec0}, 0xc00014b8c0, 0xc0005d06f0, 0x2aa84f8, 0x0)
	google.golang.org/grpc@v1.69.4/server.go:1392 +0xfc3
google.golang.org/grpc.(*Server).handleStream(0xc0001be000, {0x1f0ef30, 0xc00055f860}, 0xc00014b8c0)
	google.golang.org/grpc@v1.69.4/server.go:1802 +0xbaa
google.golang.org/grpc.(*Server).serveStreams.func2.1()
	google.golang.org/grpc@v1.69.4/server.go:1030 +0x7f
created by google.golang.org/grpc.(*Server).serveStreams.func2 in goroutine 16
	google.golang.org/grpc@v1.69.4/server.go:1041 +0x125

Error: The terraform-provider-genesyscloud_v1.63.0 plugin crashed!
```

Turns out you can apparently pass nil values to a resource attribute using variables:

```
resource "genesyscloud_idp_generic" "sso-idp-atruvia" {
  name                     = var.issuer_name
  certificates             = [var.issuer_certificates]
  issuer_uri               = var.issuer_uri
  target_uri               = var.target_uri
  relying_party_identifier = var.relying_party_identifier
  logo_image_data          = var.logo_image_data
  endpoint_compression     = var.endpoint_compression
  name_identifier_format   = var.name_identifier_format
  slo_binding              = var.slo_binding
}
```

The variable `var.issuer_certificates` was not set (or set to null) and so we ran into a NPE. 

I went ahead and hardened all of the helper list utility methods and added tests for them to prevent this sort of thing happening elsewhere.