### PR TITLE
Fix issues with dangling resources on export due to not cleaning up the resource cache on delete item

### DIFF
--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_proxy.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_proxy.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 	"net/http"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mitchellh/mapstructure"
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"

--- a/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_proxy.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_proxy.go
@@ -3,9 +3,10 @@ package architect_flow
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 	"time"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -277,7 +278,12 @@ func forceUnlockFlowFn(_ context.Context, p *architectFlowProxy, flowId string) 
 }
 
 func deleteArchitectFlowFn(_ context.Context, p *architectFlowProxy, flowId string) (*platformclientv2.APIResponse, error) {
-	return p.api.DeleteFlow(flowId)
+	resp, err := p.api.DeleteFlow(flowId)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.flowCache, flowId)
+	return resp, err
 }
 
 func createArchitectFlowJobsFn(_ context.Context, p *architectFlowProxy) (*platformclientv2.Registerarchitectjobresponse, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/architect_grammar/genesyscloud_architect_grammar_proxy.go
+++ b/genesyscloud/architect_grammar/genesyscloud_architect_grammar_proxy.go
@@ -3,8 +3,9 @@ package architect_grammar
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -191,5 +192,6 @@ func deleteArchitectGrammarFn(_ context.Context, p *architectGrammarProxy, gramm
 	if err != nil {
 		return resp, fmt.Errorf("failed to delete grammar: %s", err)
 	}
+	rc.DeleteCacheItem(p.grammarCache, grammarId)
 	return resp, nil
 }

--- a/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_proxy.go
+++ b/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_proxy.go
@@ -3,10 +3,11 @@ package architect_grammar_language
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 	"net/http"
 	"time"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -165,7 +166,12 @@ func updateArchitectGrammarLanguageFn(_ context.Context, p *architectGrammarLang
 
 // deleteArchitectGrammarLanguageFn is an implementation function for deleting a Genesys Cloud Architect Grammar Language
 func deleteArchitectGrammarLanguageFn(_ context.Context, p *architectGrammarLanguageProxy, grammarId string, languageCode string) (response *platformclientv2.APIResponse, err error) {
-	return p.architectApi.DeleteArchitectGrammarLanguage(grammarId, languageCode)
+	resp, err := p.architectApi.DeleteArchitectGrammarLanguage(grammarId, languageCode)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.grammarLanguageCache, buildGrammarLanguageId(grammarId, languageCode))
+	return resp, nil
 }
 
 // uploadGrammarLanguageFile is a function for uploading a grammar language file to Genesys cloud

--- a/genesyscloud/architect_schedules/genesyscloud_architect_schedules_proxy.go
+++ b/genesyscloud/architect_schedules/genesyscloud_architect_schedules_proxy.go
@@ -3,8 +3,9 @@ package architect_schedules
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -213,5 +214,6 @@ func deleteArchitectSchedulesFn(ctx context.Context, p *architectSchedulesProxy,
 	if err != nil {
 		return resp, fmt.Errorf("Failed to delete architect schedules: %s", err)
 	}
+	rc.DeleteCacheItem(p.schedulesCache, id)
 	return resp, nil
 }

--- a/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
+++ b/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
@@ -3,15 +3,16 @@ package architect_user_prompt
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 	"io"
 	"log"
 	"net/http"
 	"path/filepath"
 	"strings"
 	"time"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/genesyscloud/auth_role/genesyscloud_auth_role_proxy.go
+++ b/genesyscloud/auth_role/genesyscloud_auth_role_proxy.go
@@ -3,6 +3,7 @@ package auth_role
 import (
 	"context"
 	"fmt"
+
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
@@ -226,6 +227,7 @@ func deleteAuthRoleFn(ctx context.Context, p *authRoleProxy, id string) (respons
 	if err != nil {
 		return apiResponse, err
 	}
+	rc.DeleteCacheItem(p.authRoleCache, id)
 	return apiResponse, nil
 }
 

--- a/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_proxy.go
+++ b/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_proxy.go
@@ -3,8 +3,9 @@ package conversations_messaging_settings
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -173,7 +174,12 @@ func updateConversationsMessagingSettingsFn(ctx context.Context, p *conversation
 
 // deleteConversationsMessagingSettingsFn is an implementation function for deleting a Genesys Cloud conversations messaging settings
 func deleteConversationsMessagingSettingsFn(ctx context.Context, p *conversationsMessagingSettingsProxy, id string) (*platformclientv2.APIResponse, error) {
-	return p.conversationsApi.DeleteConversationsMessagingSetting(id)
+	resp, err := p.conversationsApi.DeleteConversationsMessagingSetting(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.messagingSettingsCache, id)
+	return resp, nil
 }
 
 func getConversationsMessagingSettingsDefaultFn(ctx context.Context, p *conversationsMessagingSettingsProxy) (*platformclientv2.Messagingsetting, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_proxy.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_proxy.go
@@ -3,8 +3,9 @@ package conversations_messaging_supportedcontent
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -173,5 +174,10 @@ func updateSupportedContentFn(ctx context.Context, p *supportedContentProxy, id 
 
 // deleteSupportedContentFn is an implementation function for deleting a Genesys Cloud supported content
 func deleteSupportedContentFn(ctx context.Context, p *supportedContentProxy, id string) (response *platformclientv2.APIResponse, err error) {
-	return p.conversationsApi.DeleteConversationsMessagingSupportedcontentSupportedContentId(id)
+	resp, err := p.conversationsApi.DeleteConversationsMessagingSupportedcontentSupportedContentId(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.supportedContentCache, id)
+	return resp, nil
 }

--- a/genesyscloud/external_contacts_organization/genesyscloud_externalcontacts_organization_proxy.go
+++ b/genesyscloud/external_contacts_organization/genesyscloud_externalcontacts_organization_proxy.go
@@ -3,8 +3,9 @@ package external_contacts_organization
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -179,5 +180,9 @@ func updateExternalContactsOrganizationFn(ctx context.Context, p *externalContac
 // deleteExternalContactsOrganizationFn is an implementation function for deleting a Genesys Cloud external contacts organization
 func deleteExternalContactsOrganizationFn(ctx context.Context, p *externalContactsOrganizationProxy, id string) (apiResponse *platformclientv2.APIResponse, err error) {
 	_, response, err := p.externalContactsApi.DeleteExternalcontactsOrganization(id)
+	if err != nil {
+		return response, fmt.Errorf("failed to delete external contacts organization: %s, %v", id, err)
+	}
+	rc.DeleteCacheItem(p.externalOrganizationCache, id)
 	return response, err
 }

--- a/genesyscloud/integration_facebook/genesyscloud_integration_facebook_proxy.go
+++ b/genesyscloud/integration_facebook/genesyscloud_integration_facebook_proxy.go
@@ -3,8 +3,9 @@ package integration_facebook
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -177,5 +178,10 @@ func updateIntegrationFacebookFn(ctx context.Context, p *integrationFacebookProx
 
 // deleteIntegrationFacebookFn is an implementation function for deleting a Genesys Cloud integration facebook
 func deleteIntegrationFacebookFn(ctx context.Context, p *integrationFacebookProxy, id string) (response *platformclientv2.APIResponse, err error) {
-	return p.conversationsApi.DeleteConversationsMessagingIntegrationsFacebookIntegrationId(id)
+	resp, err := p.conversationsApi.DeleteConversationsMessagingIntegrationsFacebookIntegrationId(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.facebookCache, id)
+	return resp, nil
 }

--- a/genesyscloud/journey_action_map/genesyscloud_journey_action_map_proxy.go
+++ b/genesyscloud/journey_action_map/genesyscloud_journey_action_map_proxy.go
@@ -3,8 +3,9 @@ package journey_action_map
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -214,5 +215,6 @@ func deleteJourneyActionMapFn(ctx context.Context, p *journeyActionMapProxy, id 
 	if err != nil {
 		return resp, fmt.Errorf("Failed to delete journey action map %s: %s", id, err)
 	}
+	rc.DeleteCacheItem(p.actionMapCache, id)
 	return resp, nil
 }

--- a/genesyscloud/journey_action_template/genesyscloud_journey_action_template_proxy.go
+++ b/genesyscloud/journey_action_template/genesyscloud_journey_action_template_proxy.go
@@ -3,6 +3,7 @@ package journey_action_template
 import (
 	"context"
 	"fmt"
+
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
@@ -206,5 +207,6 @@ func deleteJourneyActionTemplateFn(ctx context.Context, p *journeyActionTemplate
 	if err != nil {
 		return resp, fmt.Errorf("Failed to delete journey action template %s: %s", id, err)
 	}
+	rc.DeleteCacheItem(p.templateCache, id)
 	return resp, nil
 }

--- a/genesyscloud/journey_views/genesyscloud_journey_views_proxy.go
+++ b/genesyscloud/journey_views/genesyscloud_journey_views_proxy.go
@@ -3,9 +3,10 @@ package journey_views
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 	"strconv"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -121,7 +122,12 @@ func updateJourneyViewFn(_ context.Context, p *journeyViewsProxy, viewId string,
 }
 
 func deleteJourneyViewFn(_ context.Context, p *journeyViewsProxy, viewId string) (*platformclientv2.APIResponse, error) {
-	return p.journeyViewsApi.DeleteJourneyView(viewId)
+	resp, err := p.journeyViewsApi.DeleteJourneyView(viewId)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.journeyViewCache, viewId)
+	return resp, nil
 }
 
 // GetAllJourneyViewsFn is the implementation for retrieving all journey views in Genesys Cloud

--- a/genesyscloud/knowledge_category/genesyscloud_knowledge_category_proxy.go
+++ b/genesyscloud/knowledge_category/genesyscloud_knowledge_category_proxy.go
@@ -3,6 +3,7 @@ package knowledge_category
 import (
 	"context"
 	"fmt"
+
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
@@ -232,5 +233,10 @@ func updateKnowledgeCategoryFn(ctx context.Context, p *knowledgeCategoryProxy, k
 }
 
 func deleteKnowledgeCategoryFn(ctx context.Context, p *knowledgeCategoryProxy, knowledgeBaseId string, categoryId string) (*platformclientv2.Categoryresponse, *platformclientv2.APIResponse, error) {
-	return p.KnowledgeApi.DeleteKnowledgeKnowledgebaseCategory(knowledgeBaseId, categoryId)
+	delete, resp, err := p.KnowledgeApi.DeleteKnowledgeKnowledgebaseCategory(knowledgeBaseId, categoryId)
+	if err != nil {
+		return delete, resp, err
+	}
+	rc.DeleteCacheItem(p.knowledgeCategoryCache, categoryId)
+	return delete, resp, nil
 }

--- a/genesyscloud/knowledge_knowledgebase/genesyscloud_knowledge_knowledgebase_proxy.go
+++ b/genesyscloud/knowledge_knowledgebase/genesyscloud_knowledge_knowledgebase_proxy.go
@@ -125,5 +125,10 @@ func updateKnowledgebaseFn(ctx context.Context, p *knowledgebaseProxy, knowledge
 }
 
 func deleteKnowledgebaseFn(ctx context.Context, p *knowledgebaseProxy, knowledgebaseId string) (*platformclientv2.Knowledgebase, *platformclientv2.APIResponse, error) {
-	return p.KnowledgeApi.DeleteKnowledgeKnowledgebase(knowledgebaseId)
+	delete, resp, err := p.KnowledgeApi.DeleteKnowledgeKnowledgebase(knowledgebaseId)
+	if err != nil {
+		return delete, resp, err
+	}
+	rc.DeleteCacheItem(p.knowledgebaseCache, knowledgebaseId)
+	return delete, resp, nil
 }

--- a/genesyscloud/location/genesyscloud_location_proxy.go
+++ b/genesyscloud/location/genesyscloud_location_proxy.go
@@ -3,6 +3,7 @@ package location
 import (
 	"context"
 	"fmt"
+
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
@@ -144,5 +145,10 @@ func updateLocationFn(ctx context.Context, p *locationProxy, id string, updateRe
 }
 
 func deleteLocationFn(ctx context.Context, p *locationProxy, id string) (*platformclientv2.APIResponse, error) {
-	return p.locationsApi.DeleteLocation(id)
+	resp, err := p.locationsApi.DeleteLocation(id)
+	if err != nil {
+		return resp, fmt.Errorf("failed to delete location %s", err)
+	}
+	rc.DeleteCacheItem(p.locationCache, id)
+	return resp, nil
 }

--- a/genesyscloud/responsemanagement_responseasset/genesyscloud_responsemanagement_responseasset_proxy.go
+++ b/genesyscloud/responsemanagement_responseasset/genesyscloud_responsemanagement_responseasset_proxy.go
@@ -3,8 +3,9 @@ package responsemanagement_responseasset
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -206,5 +207,6 @@ func deleteRespManagementRespAssetFn(ctx context.Context, p *responsemanagementR
 	if err != nil {
 		return resp, fmt.Errorf("failed to delete response asset: %s", err)
 	}
+	rc.DeleteCacheItem(p.assetCache, id)
 	return resp, nil
 }

--- a/genesyscloud/routing_email_domain/genesyscloud_routing_email_domain_proxy.go
+++ b/genesyscloud/routing_email_domain/genesyscloud_routing_email_domain_proxy.go
@@ -3,8 +3,9 @@ package routing_email_domain
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -158,5 +159,10 @@ func updateRoutingEmailDomainFn(ctx context.Context, p *routingEmailDomainProxy,
 }
 
 func deleteRoutingEmailDomainFn(ctx context.Context, p *routingEmailDomainProxy, id string) (*platformclientv2.APIResponse, error) {
-	return p.routingApi.DeleteRoutingEmailDomain(id)
+	resp, err := p.routingApi.DeleteRoutingEmailDomain(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.routingEmailDomainCache, id)
+	return resp, nil
 }

--- a/genesyscloud/routing_language/genesyscloud_routing_language_proxy.go
+++ b/genesyscloud/routing_language/genesyscloud_routing_language_proxy.go
@@ -150,5 +150,10 @@ func getRoutingLanguageIdByNameFn(ctx context.Context, p *routingLanguageProxy, 
 
 // deleteRoutingLanguageFn is an implementation function for deleting a Genesys Cloud routing language
 func deleteRoutingLanguageFn(ctx context.Context, p *routingLanguageProxy, id string) (*platformclientv2.APIResponse, error) {
-	return p.routingApi.DeleteRoutingLanguage(id)
+	resp, err := p.routingApi.DeleteRoutingLanguage(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.routingLanguageCache, id)
+	return resp, nil
 }

--- a/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
+++ b/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
@@ -3,8 +3,9 @@ package routing_queue
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -278,7 +279,12 @@ func createRoutingQueueWrapupCodeFn(ctx context.Context, p *RoutingQueueProxy, q
 }
 
 func deleteRoutingQueueWrapupCodeFn(ctx context.Context, p *RoutingQueueProxy, queueId, codeId string) (*platformclientv2.APIResponse, error) {
-	return p.routingApi.DeleteRoutingQueueWrapupcode(queueId, codeId)
+	resp, err := p.routingApi.DeleteRoutingQueueWrapupcode(queueId, codeId)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.wrapupCodeCache, codeId)
+	return resp, nil
 }
 
 func addOrRemoveMembersFn(ctx context.Context, p *RoutingQueueProxy, queueId string, body []platformclientv2.Writableentity, delete bool) (*platformclientv2.APIResponse, error) {

--- a/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_proxy.go
+++ b/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_proxy.go
@@ -3,8 +3,9 @@ package routing_utilization_label
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -145,5 +146,10 @@ func updateRoutingUtilizationLabelFn(_ context.Context, p *routingUtilizationLab
 }
 
 func deleteRoutingUtilizationLabelFn(_ context.Context, p *routingUtilizationLabelProxy, id string, forceDelete bool) (*platformclientv2.APIResponse, error) {
-	return p.routingApi.DeleteRoutingUtilizationLabel(id, forceDelete)
+	resp, err := p.routingApi.DeleteRoutingUtilizationLabel(id, forceDelete)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.routingCache, id)
+	return resp, nil
 }

--- a/genesyscloud/scripts/genesyscloud_scripts_proxy.go
+++ b/genesyscloud/scripts/genesyscloud_scripts_proxy.go
@@ -4,15 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 	"io"
 	"log"
 	"net/http"
 	"strings"
 	"time"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -401,6 +402,7 @@ func deleteScriptFn(_ context.Context, p *scriptsProxy, scriptId string) error {
 		return fmt.Errorf("failed to delete script %s: %s", scriptId, resp.Status)
 	}
 
+	rc.DeleteCacheItem(p.scriptCache, scriptId)
 	log.Printf("Successfully deleted script %s", scriptId)
 	return nil
 }

--- a/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
+++ b/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
@@ -171,5 +171,6 @@ func deleteTaskManagementWorkbinFn(ctx context.Context, p *taskManagementWorkbin
 	if err != nil {
 		return resp, fmt.Errorf("failed to delete task management workbin: %s", err)
 	}
+	rc.DeleteCacheItem(p.workbinCache, id)
 	return resp, nil
 }

--- a/genesyscloud/task_management_workitem/genesyscloud_task_management_workitem_proxy.go
+++ b/genesyscloud/task_management_workitem/genesyscloud_task_management_workitem_proxy.go
@@ -245,5 +245,10 @@ func updateTaskManagementWorkitemFn(ctx context.Context, p *taskManagementWorkit
 
 // deleteTaskManagementWorkitemFn is an implementation function for deleting a Genesys Cloud task management workitem
 func deleteTaskManagementWorkitemFn(ctx context.Context, p *taskManagementWorkitemProxy, id string) (resp *platformclientv2.APIResponse, err error) {
-	return p.taskManagementApi.DeleteTaskmanagementWorkitem(id)
+	resp, err = p.taskManagementApi.DeleteTaskmanagementWorkitem(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.workitemCache, id)
+	return resp, nil
 }

--- a/genesyscloud/task_management_workitem_schema/genesyscloud_task_management_workitem_schema_proxy.go
+++ b/genesyscloud/task_management_workitem_schema/genesyscloud_task_management_workitem_schema_proxy.go
@@ -180,6 +180,7 @@ func deleteTaskManagementWorkitemSchemaFn(ctx context.Context, p *taskManagement
 	if err != nil {
 		return resp, fmt.Errorf("failed to delete task management workitem schema: %s", err)
 	}
+	rc.DeleteCacheItem(p.workitemSchemaCache, id)
 	return resp, nil
 }
 

--- a/genesyscloud/task_management_worktype/genesyscloud_task_management_worktype_proxy.go
+++ b/genesyscloud/task_management_worktype/genesyscloud_task_management_worktype_proxy.go
@@ -3,8 +3,9 @@ package task_management_worktype
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )
@@ -214,5 +215,10 @@ func updateTaskManagementWorktypeFn(ctx context.Context, p *TaskManagementWorkty
 
 // deleteTaskManagementWorktypeFn is an implementation function for deleting a Genesys Cloud task management worktype
 func deleteTaskManagementWorktypeFn(ctx context.Context, p *TaskManagementWorktypeProxy, id string) (resp *platformclientv2.APIResponse, err error) {
-	return p.taskManagementApi.DeleteTaskmanagementWorktype(id)
+	resp, err = p.taskManagementApi.DeleteTaskmanagementWorktype(id)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.worktypeCache, id)
+	return resp, nil
 }

--- a/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_proxy.go
+++ b/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_proxy.go
@@ -294,6 +294,10 @@ func updatePhoneFn(ctx context.Context, p *phoneProxy, phoneId string, phoneConf
 // deletePhoneFn is an implementation function for deleting a Genesys Cloud Phone
 func deletePhoneFn(ctx context.Context, p *phoneProxy, phoneId string) (response *platformclientv2.APIResponse, err error) {
 	resp, err := p.edgesApi.DeleteTelephonyProvidersEdgesPhone(phoneId)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.phoneCache, phoneId)
 	return resp, err
 }
 

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
@@ -3,6 +3,7 @@ package telephony_providers_edges_site
 import (
 	"context"
 	"fmt"
+
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
@@ -292,7 +293,7 @@ func deleteSiteFn(ctx context.Context, p *SiteProxy, siteId string) (*platformcl
 	if err != nil {
 		return resp, err
 	}
-
+	rc.DeleteCacheItem(p.managedSiteCache, siteId)
 	return resp, nil
 }
 
@@ -409,7 +410,6 @@ func deleteSiteOutboundRouteFn(ctx context.Context, p *SiteProxy, siteId string,
 	if err != nil {
 		return resp, err
 	}
-
 	return resp, nil
 }
 

--- a/genesyscloud/telephony_providers_edges_trunkbasesettings/genesyscloud_telephony_providers_edges_trunkbasesettings_proxy.go
+++ b/genesyscloud/telephony_providers_edges_trunkbasesettings/genesyscloud_telephony_providers_edges_trunkbasesettings_proxy.go
@@ -190,5 +190,10 @@ func updateTrunkBaseSettingFn(ctx context.Context, p *trunkbaseSettingProxy, tru
 }
 
 func deleteTrunkBaseSettingFn(ctx context.Context, p *trunkbaseSettingProxy, trunkBaseSettingId string) (*platformclientv2.APIResponse, error) {
-	return p.edgesApi.DeleteTelephonyProvidersEdgesTrunkbasesetting(trunkBaseSettingId)
+	resp, err := p.edgesApi.DeleteTelephonyProvidersEdgesTrunkbasesetting(trunkBaseSettingId)
+	if err != nil {
+		return resp, err
+	}
+	rc.DeleteCacheItem(p.trunkBaseCache, trunkBaseSettingId)
+	return resp, nil
 }

--- a/genesyscloud/user/genesyscloud_user_proxy.go
+++ b/genesyscloud/user/genesyscloud_user_proxy.go
@@ -3,10 +3,11 @@ package user
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 	"net/http"
 	"time"
+
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v157/platformclientv2"
 )


### PR DESCRIPTION
As I was working on https://github.com/MyPureCloud/terraform-provider-genesyscloud/pull/1682, specifically when testing the tf_exporter examples, it kept failing due to dangling resources.

Digging in, I discovered that the reason came back to the fact that many resources were using `get{Resource}ById()` after deletion to confirm the delete. They typically first check the cache and returns items. The reason they were returning items is because the cache item hadn't been removed yet.

This PR is the result of an audit I did to ensure that all resources that exercised a cache ensured the cache item was deleted at the time the resource instance was deleted.