### PR TITLE
(NO-JIRA) genesyscloud_organization_presence_definition: Removing validators to fix export

### DIFF
--- a/docs/resources/organization_presence_definition.md
+++ b/docs/resources/organization_presence_definition.md
@@ -36,7 +36,7 @@ resource "genesyscloud_organization_presence_definition" "Away_From_Keyboard" {
 
 ### Required
 
-- `language_labels` (Map of String) The localized language labels for the presence definition. Valid labels include: ar, cs, da, de, en, en_US, en-us, es, es_US, fi, fr, he, hi, it, ja, ko, nl, no, pl, pt, pt_BR, pt_PT, ru, sv, th, tr, uk, zh_CN, zh_TW
+- `language_labels` (Map of String) The localized language labels for the presence definition. Valid labels include: ar, cs, da, de, en, en_US, es, fi, fr, he, hi, it, ja, ko, nl, no, pl, pt, pt_BR, pt_PT, ru, sv, th, tr, uk, zh_CN, zh_TW
 - `system_presence` (String) System presence to create presence definition for. Once presence definition is created, this cannot be changed. Valid presences include: Available, Away, Break, Busy, Meal, Meeting, Training, OnQueue, Offline, Idle
 
 ### Optional

--- a/docs/resources/organization_presence_definition.md
+++ b/docs/resources/organization_presence_definition.md
@@ -36,8 +36,8 @@ resource "genesyscloud_organization_presence_definition" "Away_From_Keyboard" {
 
 ### Required
 
-- `language_labels` (Map of String) The localized language labels for the presence definition. Valid labels: ar, cs, da, de, en, en_US, es, fi, fr, he, hi, it, ja, ko, nl, no, pl, pt_BR, pt_PT, ru, sv, th, tr, uk, zh_CN, zh_TW
-- `system_presence` (String) System presence to create presence definition for. Once presence definition is created, this cannot be changed. Valid presences: Available, Away, Break, Busy, Meal, Meeting, Training
+- `language_labels` (Map of String) The localized language labels for the presence definition. Valid labels include: ar, cs, da, de, en, en_US, en-us, es, es_US, fi, fr, he, hi, it, ja, ko, nl, no, pl, pt, pt_BR, pt_PT, ru, sv, th, tr, uk, zh_CN, zh_TW
+- `system_presence` (String) System presence to create presence definition for. Once presence definition is created, this cannot be changed. Valid presences include: Available, Away, Break, Busy, Meal, Meeting, Training, OnQueue, Offline, Idle
 
 ### Optional
 

--- a/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition_schema.go
+++ b/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition_schema.go
@@ -1,6 +1,7 @@
 package organization_presence_definition
 
 import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -31,9 +32,7 @@ var validLanguageLabels = []string{
 	"de",
 	"en",
 	"en_US",
-	"en-us",
 	"es",
-	"es_US",
 	"fi",
 	"fr",
 	"he",
@@ -90,9 +89,10 @@ func ResourceOrganizationPresenceDefinition() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			`system_presence`: {
-				Description: `System presence to create presence definition for. Once presence definition is created, this cannot be changed. Valid presences include: ` + strings.Join(validSystemPresences, `, `),
-				Type:        schema.TypeString,
-				Required:    true,
+				Description:  `System presence to create presence definition for. Once presence definition is created, this cannot be changed. Valid presences include: ` + strings.Join(validSystemPresences, `, `),
+				Type:         schema.TypeString,
+				Required:     true,
+				ValidateFunc: validation.StringInSlice(validSystemPresences, true),
 			},
 			`division_id`: {
 				Description: `The division to which the presence definition will belong. If not set, the presence definition will apply to all divisions.`,

--- a/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition_schema.go
+++ b/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition_schema.go
@@ -4,12 +4,9 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_register"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/validators"
 )
 
 /*
@@ -34,7 +31,9 @@ var validLanguageLabels = []string{
 	"de",
 	"en",
 	"en_US",
+	"en-us",
 	"es",
+	"es_US",
 	"fi",
 	"fr",
 	"he",
@@ -45,6 +44,7 @@ var validLanguageLabels = []string{
 	"nl",
 	"no",
 	"pl",
+	"pt",
 	"pt_BR",
 	"pt_PT",
 	"ru",
@@ -64,6 +64,9 @@ var validSystemPresences = []string{
 	"Meal",
 	"Meeting",
 	"Training",
+	"OnQueue",
+	"Offline",
+	"Idle",
 }
 
 // ResourceOrganizationPresenceDefinition registers the genesyscloud_organization_presence_definition resource with Terraform
@@ -81,17 +84,15 @@ func ResourceOrganizationPresenceDefinition() *schema.Resource {
 		SchemaVersion: 1,
 		Schema: map[string]*schema.Schema{
 			`language_labels`: {
-				Description:      `The localized language labels for the presence definition. Valid labels: ` + strings.Join(validLanguageLabels, `, `),
-				Type:             schema.TypeMap,
-				Required:         true,
-				Elem:             &schema.Schema{Type: schema.TypeString},
-				ValidateDiagFunc: validators.ValidateStringInMap(validLanguageLabels, true),
+				Description: `The localized language labels for the presence definition. Valid labels include: ` + strings.Join(validLanguageLabels, `, `),
+				Type:        schema.TypeMap,
+				Required:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			`system_presence`: {
-				Description:  `System presence to create presence definition for. Once presence definition is created, this cannot be changed. Valid presences: ` + strings.Join(validSystemPresences, `, `),
-				Type:         schema.TypeString,
-				Required:     true,
-				ValidateFunc: validation.StringInSlice(validSystemPresences, true),
+				Description: `System presence to create presence definition for. Once presence definition is created, this cannot be changed. Valid presences include: ` + strings.Join(validSystemPresences, `, `),
+				Type:        schema.TypeString,
+				Required:    true,
 			},
 			`division_id`: {
 				Description: `The division to which the presence definition will belong. If not set, the presence definition will apply to all divisions.`,


### PR DESCRIPTION
While trying to recreate another export bug, I caught a few instances where the validator functions in the new presence definition resource was producing plan errors e.g. `expected system_presence to be one of [...] got "abc"`

To fix this I removed the validators. I think it is better to list the known valid options in the descriptions and leave the validation up to the API. 