### PR TITLE
[Devtooling-1131] genesyscloud_architect_ivr remove OpenHoursFlow from BlockLabel

### DIFF
--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
@@ -32,13 +32,7 @@ func getAllIvrConfigs(ctx context.Context, clientConfig *platformclientv2.Config
 	}
 
 	for _, entity := range *allIvrs {
-		var blockLabel string
-		if entity.OpenHoursFlow != nil && entity.OpenHoursFlow.Name != nil {
-			blockLabel = *entity.OpenHoursFlow.Name + "_" + *entity.Name
-		} else {
-			blockLabel = *entity.Name
-		}
-		resources[*entity.Id] = &resourceExporter.ResourceMeta{BlockLabel: blockLabel}
+		resources[*entity.Id] = &resourceExporter.ResourceMeta{BlockLabel: *entity.Name}
 	}
 	return resources, nil
 }


### PR DESCRIPTION
Since the BlockLabel for genesyscloud_architect_ivr is a concatenation of the ivr's name and OpenHoursFlow's name, if the resource is exported and applied to a new org and then the OpenHoursFlow changes in the original, during any subsequent export and apply terraform will attempt to create a new resource with that different label but the same id and name and throw an api error.