### PR TITLE
(DEVTOOLING-1230) Addressed the issue of increased export times 

### DIFF
--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
@@ -235,8 +235,8 @@ func ContactsExporterResolver(resourceId, exportDirectory, subDirectory string, 
 		}
 
 		// Give the system time to generate the URL
-		// Exponential backoff - 1st sleep: 1 second, 10th sleep: 200 seconds
-		waitTime := time.Duration(math.Pow(200, float64(retryAttempt)/10)) * time.Second
+		// Exponential backoff - 1st sleep: 2 seconds, 10th sleep: 1024 seconds (total: 2046 seconds/34 minutes)
+		waitTime := time.Duration(2*math.Pow(2, float64(retryAttempt)-1)) * time.Second
 		log.Printf("Sleeping for %f seconds before retrying", waitTime.Seconds())
 		time.Sleep(waitTime)
 

--- a/genesyscloud/user/genesyscloud_user_proxy.go
+++ b/genesyscloud/user/genesyscloud_user_proxy.go
@@ -70,6 +70,9 @@ type userProxy struct {
 	extensionPoolCache                       rc.CacheInterface[platformclientv2.Extensionpool]
 }
 
+var userCache = rc.NewResourceCache[platformclientv2.User]()
+var extensionPoolCache = rc.NewResourceCache[platformclientv2.Extensionpool]()
+
 /*
 The function newUserProxy sets up the user proxy by providing it
 with all the necessary information to communicate effectively with Genesys Cloud.
@@ -81,8 +84,6 @@ func newUserProxy(clientConfig *platformclientv2.Configuration) *userProxy {
 	routingApi := platformclientv2.NewRoutingApiWithConfig(clientConfig) // NewRoutingApiWithConfig creates an Genesyc Cloud API instance using the provided configuration
 	voicemailApi := platformclientv2.NewVoicemailApiWithConfig(clientConfig)
 	extensionPoolApi := platformclientv2.NewTelephonyProvidersEdgeApiWithConfig(clientConfig)
-	userCache := rc.NewResourceCache[platformclientv2.User]() // Create Cache for User resource
-	extensionPoolCache := rc.NewResourceCache[platformclientv2.Extensionpool]()
 	return &userProxy{
 		clientConfig:                             clientConfig,
 		userApi:                                  userApi,
@@ -115,10 +116,7 @@ This ensures consistency and control in managing the internalProxy across our co
 facilitating efficient testing by providing a straightforward way to substitute the proxy for testing purposes.
 */
 func GetUserProxy(clientConfig *platformclientv2.Configuration) *userProxy {
-	if internalProxy == nil {
-		internalProxy = newUserProxy(clientConfig)
-	}
-	return internalProxy
+	return newUserProxy(clientConfig)
 }
 
 // createUser creates a Genesys Cloud User


### PR DESCRIPTION
* DEVTOOLING-991 introduced an extra API call to the export of users; [GET /api/v2/routing/users/{userId}/utilization](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-users--userId--utilization). This almost doubles the export time for users because the endpoint is sensitive to rate-limiting. Removing the singleton pattern in the proxy file addressed this. 
* The main cause of the export time increase was the work done for DEVTOOLING-1191. Sometimes the download URL for a contact list export would take some time generate (if the list is huge), so a sleep was introduced. The mistake was sleeping for 30 seconds even before making the API call. So a 30 second sleep occurred for each contact list and 600 * 30 seconds is 5 hours. 