### PR TITLE
fix: DEVTOOLING-1280 by fixing phone number validator

### DIFF
--- a/genesyscloud/util/feature_toggles/bcp_running.go
+++ b/genesyscloud/util/feature_toggles/bcp_running.go
@@ -1,0 +1,14 @@
+package feature_toggles
+
+import "os"
+
+const enableBCPMode = "BCP_MODE_ENABLED"
+
+func BcpModeEnabledName() string {
+	return enableBCPMode
+}
+
+func BcpModeEnabledExists() bool {
+	_, enabled := os.LookupEnv(enableBCPMode)
+	return enabled
+}

--- a/genesyscloud/util/util_e164.go
+++ b/genesyscloud/util/util_e164.go
@@ -1,8 +1,11 @@
 package util
 
 import (
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
+	"fmt"
 	"log"
+	"regexp"
+
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/nyaruka/phonenumbers"
@@ -16,33 +19,53 @@ func NewUtilE164Service() *UtilE164Service {
 	return &UtilE164Service{GetDefaultCountryCodeFunc: provider.GetOrgDefaultCountryCode}
 }
 
-// Formats string as a valid E.164 international standard telephone format, parsing the number with
-// a default region that matches the default country code set on the GC organization.
+// Validates a string as a valid E.164 international standard telephone format, with any viable country code accepted
 // Use this when data is coming from the user so we can appropriately error.
-func (m *UtilE164Service) FormatAsValidE164Number(number string) (string, diag.Diagnostics) {
-	defaultLang := m.GetDefaultCountryCodeFunc()
-	if defaultLang == "" {
-		defaultLang = "US"
+func (m *UtilE164Service) IsValidE164Number(number string) (bool, diag.Diagnostics) {
+
+	defaultRegion := m.GetDefaultCountryCodeFunc()
+	if defaultRegion == "" {
+		defaultRegion = "ZZ" // Unknown region
 	}
-	log.Printf("Default language is %s", defaultLang)
-	phoneNumber, err := phonenumbers.Parse(number, defaultLang)
+
+	STARTING_PLUS_CHARS_REGEX := regexp.MustCompile("^[+\uFF0B]")
+
+	matchValidStartingNumber := STARTING_PLUS_CHARS_REGEX.MatchString(number)
+	if !matchValidStartingNumber {
+		return false, diag.Errorf("Phone number must start with a '+'")
+	}
+
+	phoneNumber, err := phonenumbers.Parse(number, defaultRegion)
+
 	if err != nil {
-		return "", diag.Errorf("Failed to format phone number %s: %s", number, err)
+		return false, diag.Errorf("Failed to format phone number %s: %s", number, err)
 	}
-	formattedNum := phonenumbers.Format(phoneNumber, phonenumbers.E164)
-	return formattedNum, nil
+
+	return phonenumbers.IsPossibleNumber(phoneNumber), nil
 }
 
 // Formats string as a valid E.164 international standard telephone format, parsing the number with
 // a default region that matches the default country code set on the GC organization.
 // Use this function when data is being returned back from the API already in expected format
 func (m *UtilE164Service) FormatAsCalculatedE164Number(number string) string {
+	if number == "" {
+		return ""
+	}
 	defaultLang := m.GetDefaultCountryCodeFunc()
 	if defaultLang == "" {
-		defaultLang = "US"
+		defaultLang = "ZZ"
 	}
 	log.Printf("Default language is %s", defaultLang)
 	phoneNumber, _ := phonenumbers.Parse(number, defaultLang)
 	formattedNum := phonenumbers.Format(phoneNumber, phonenumbers.E164)
+	// +00 means the number was unable to be formatted. Since it's coming from the API,
+	// we will just return the value directly, ensuring there is a leading + sign.
+	if formattedNum == "+00" {
+		if number[0:1] != "+" {
+			formattedNum = fmt.Sprintf("+%s", number)
+		} else {
+			formattedNum = number
+		}
+	}
 	return formattedNum
 }

--- a/genesyscloud/util/util_e164_test.go
+++ b/genesyscloud/util/util_e164_test.go
@@ -4,11 +4,160 @@ import (
 	"testing"
 )
 
-func TestUnitFormatsAsValidE164Number(t *testing.T) {
-	type testCase struct {
-		number        string
-		expectedValue string
+type isValidTestCase struct {
+	number        string
+	expectedValue bool
+	expectError   bool
+}
+
+var isValidTestCases = &[]isValidTestCase{
+	// US phone numbers
+	{
+		number:        "+1 (919) 333-1234",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "1-919-333-1234",
+		expectedValue: false,
+		expectError:   true,
+	},
+	// By default, add US international code if one is not given
+	{
+		number:        "(919) 333-1234",
+		expectedValue: false,
+		expectError:   true,
+	},
+	{
+		number:        "919-333-1234",
+		expectedValue: false,
+		expectError:   true,
+	},
+	// UK phone numbers
+	{
+		number:        "+44 20 7123 1234",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "+44 (020) 7123 1234",
+		expectedValue: true,
+		expectError:   false,
+	},
+	// German phone numbers
+	{
+		number:        "+49 (89) 1234-5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "+49 089 1234-5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "+49 89 1234-5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	// Indian phone numbers
+	{
+		number:        "+91 (22) 1234-5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "+91 022 1234-5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "+91 22 1234-5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	// Australian phone numbers
+	{
+		number:        "+61 3 1234 5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "+61 03 1234 5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	{
+		number:        "+61 3 1234 5678",
+		expectedValue: true,
+		expectError:   false,
+	},
+	// Edge cases
+	{
+		number:        "123-456-7890",
+		expectedValue: false, // Assuming US number without country code
+		expectError:   true,
+	},
+	{
+		number:        "+1 123",
+		expectedValue: false, // Has plus prefix but still invalid
+		expectError:   false,
+	},
+	{
+		number:        "12345",
+		expectedValue: false,
+		expectError:   true,
+	},
+	{
+		number:        "+81 123",
+		expectedValue: false, // Has plus prefix but still invalid
+		expectError:   false,
+	},
+	{
+		number:        "12345",
+		expectedValue: false, // Has plus prefix but still invalid
+		expectError:   true,
+	},
+	{
+		number:        "+00",
+		expectedValue: false,
+		expectError:   true,
+	},
+	{
+		number:        "+1",
+		expectedValue: false,
+		expectError:   true,
+	},
+	{
+		number:        "0",
+		expectedValue: true,
+		expectError:   true,
+	},
+}
+
+func testIsValidE164Number(t *testing.T, utilE164 UtilE164Service, testCases *[]isValidTestCase) {
+	for _, testCase := range *testCases {
+		val, err := utilE164.IsValidE164Number(testCase.number)
+		if testCase.expectError {
+			if err == nil {
+				t.Errorf("expected error for %v, got nil", testCase.number)
+			}
+			continue
+		} else {
+			if err != nil {
+				t.Errorf("expected no error for %v, got: %v", testCase.number, err)
+			}
+		}
+		if err != nil {
+			t.Errorf("expected error to be nil for %v, got: %v", testCase.number, err)
+		}
+		if val != testCase.expectedValue {
+			t.Errorf("number: %s, expected value: %v, actual value: %v", testCase.number, testCase.expectedValue, val)
+		}
 	}
+}
+
+func TestUnitIsValidE164Number(t *testing.T) {
 
 	countryCodeUS := func() string {
 		return "US"
@@ -16,105 +165,11 @@ func TestUnitFormatsAsValidE164Number(t *testing.T) {
 	var utilE164 = *NewUtilE164Service()
 	utilE164.GetDefaultCountryCodeFunc = countryCodeUS
 
-	testCases := &[]testCase{
-		// US phone numbers
-		{
-			number:        "+1 (919) 333-1234",
-			expectedValue: "+19193331234",
-		},
-		{
-			number:        "1-919-333-1234",
-			expectedValue: "+19193331234",
-		},
-		// By default, add US international code if one is not given
-		{
-			number:        "(919) 333-1234",
-			expectedValue: "+19193331234",
-		},
-		{
-			number:        "919-333-1234",
-			expectedValue: "+19193331234",
-		},
-		// UK phone numbers
-		{
-			number:        "+44 20 7123 1234",
-			expectedValue: "+442071231234",
-		},
-		{
-			number:        "+44 (020) 7123 1234",
-			expectedValue: "+442071231234",
-		},
-		// German phone numbers
-		{
-			number:        "+49 (89) 1234-5678",
-			expectedValue: "+498912345678",
-		},
-		{
-			number:        "+49 089 1234-5678",
-			expectedValue: "+498912345678",
-		},
-		{
-			number:        "+49 89 1234-5678",
-			expectedValue: "+498912345678",
-		},
-		// Indian phone numbers
-		{
-			number:        "+91 (22) 1234-5678",
-			expectedValue: "+912212345678",
-		},
-		{
-			number:        "+91 022 1234-5678",
-			expectedValue: "+912212345678",
-		},
-		{
-			number:        "+91 22 1234-5678",
-			expectedValue: "+912212345678",
-		},
-		// Australian phone numbers
-		{
-			number:        "+61 3 1234 5678",
-			expectedValue: "+61312345678",
-		},
-		{
-			number:        "+61 03 1234 5678",
-			expectedValue: "+61312345678",
-		},
-		{
-			number:        "+61 3 1234 5678",
-			expectedValue: "+61312345678",
-		},
-		// Edge cases
-		{
-			number:        "123-456-7890",
-			expectedValue: "+11234567890", // Assuming US number without country code
-		},
-		{
-			number:        "+1 123",
-			expectedValue: "+1123", // Invalid but still formatted
-		},
-		{
-			number:        "12345",
-			expectedValue: "+112345", // Invalid but still formatted
-		},
-	}
-
-	for _, testCase := range *testCases {
-		val, err := utilE164.FormatAsValidE164Number(testCase.number)
-		if err != nil {
-			t.Errorf("expected error to be nil, got: %v", err)
-		}
-		if val != testCase.expectedValue {
-			t.Errorf("number: %s, expected value: %s, actual value: %s", testCase.number, testCase.expectedValue, val)
-		}
-	}
+	testIsValidE164Number(t, utilE164, isValidTestCases)
 }
 
 // Same tests as above, but use a different default if the country code is different
 func TestUnitFormatsAsValidE164NumberWithAltCountryCode(t *testing.T) {
-	type testCase struct {
-		number        string
-		expectedValue string
-	}
 
 	countryCodeJP := func() string {
 		return "JP"
@@ -122,97 +177,8 @@ func TestUnitFormatsAsValidE164NumberWithAltCountryCode(t *testing.T) {
 	var utilE164 = *NewUtilE164Service()
 	utilE164.GetDefaultCountryCodeFunc = countryCodeJP
 
-	testCases := &[]testCase{
-		// US phone numbers
-		{
-			number:        "+1 (919) 333-1234",
-			expectedValue: "+19193331234",
-		},
-		{
-			number:        "1-919-333-1234",
-			expectedValue: "+8119193331234",
-		},
-		// By default, add JP international code if one is not given
-		{
-			number:        "(919) 333-1234",
-			expectedValue: "+819193331234",
-		},
-		{
-			number:        "919-333-1234",
-			expectedValue: "+819193331234",
-		},
-		// UK phone numbers
-		{
-			number:        "+44 20 7123 1234",
-			expectedValue: "+442071231234",
-		},
-		{
-			number:        "+44 (020) 7123 1234",
-			expectedValue: "+442071231234",
-		},
-		// German phone numbers
-		{
-			number:        "+49 (89) 1234-5678",
-			expectedValue: "+498912345678",
-		},
-		{
-			number:        "+49 089 1234-5678",
-			expectedValue: "+498912345678",
-		},
-		{
-			number:        "+49 89 1234-5678",
-			expectedValue: "+498912345678",
-		},
-		// Indian phone numbers
-		{
-			number:        "+91 (22) 1234-5678",
-			expectedValue: "+912212345678",
-		},
-		{
-			number:        "+91 022 1234-5678",
-			expectedValue: "+912212345678",
-		},
-		{
-			number:        "+91 22 1234-5678",
-			expectedValue: "+912212345678",
-		},
-		// Australian phone numbers
-		{
-			number:        "+61 3 1234 5678",
-			expectedValue: "+61312345678",
-		},
-		{
-			number:        "+61 03 1234 5678",
-			expectedValue: "+61312345678",
-		},
-		{
-			number:        "+61 3 1234 5678",
-			expectedValue: "+61312345678",
-		},
-		// Edge cases
-		{
-			number:        "123-456-7890",
-			expectedValue: "+811234567890", // Assuming US number without country code
-		},
-		{
-			number:        "+81 123",
-			expectedValue: "+81123", // Invalid but still formatted
-		},
-		{
-			number:        "12345",
-			expectedValue: "+8112345", // Invalid but still formatted
-		},
-	}
+	testIsValidE164Number(t, utilE164, isValidTestCases)
 
-	for _, testCase := range *testCases {
-		val, err := utilE164.FormatAsValidE164Number(testCase.number)
-		if err != nil {
-			t.Errorf("expected error to be nil, got: %v", err)
-		}
-		if val != testCase.expectedValue {
-			t.Errorf("number: %s, expected value: %s, actual value: %s", testCase.number, testCase.expectedValue, val)
-		}
-	}
 }
 
 func TestUnitFormatsAsValidE164NumberError(t *testing.T) {
@@ -251,10 +217,10 @@ func TestUnitFormatsAsValidE164NumberError(t *testing.T) {
 	}
 
 	for _, testCase := range *testCases {
-		val, err := utilE164.FormatAsValidE164Number(testCase.number)
+		val, err := utilE164.IsValidE164Number(testCase.number)
 		// We expect the error to be present for these cases
 		if err == nil {
-			t.Errorf("expected error to be to not be nil for number: %s, value: %s", testCase.number, val)
+			t.Errorf("expected error to be to not be nil for number: %v, value: %v", testCase.number, val)
 		}
 	}
 }
@@ -350,6 +316,30 @@ func TestUnitFormatsAsCalculatedE164Number(t *testing.T) {
 		{
 			number:        "12345",
 			expectedValue: "+112345", // Invalid but still formatted
+		},
+		{
+			number:        "+1",
+			expectedValue: "+1",
+		},
+		{
+			number:        "1",
+			expectedValue: "+1",
+		},
+		{
+			number:        "+81",
+			expectedValue: "+81",
+		},
+		{
+			number:        "81",
+			expectedValue: "+181",
+		},
+		{
+			number:        "0",
+			expectedValue: "+0",
+		},
+		{
+			number:        "0",
+			expectedValue: "+0",
 		},
 	}
 	for _, testCase := range *testCases {
@@ -452,6 +442,26 @@ func TestUnitFormatsAsCalculatedE164NumberWithAltCountryCode(t *testing.T) {
 			number:        "12345",
 			expectedValue: "+8112345", // Invalid but still formatted
 		},
+		{
+			number:        "+1",
+			expectedValue: "+1",
+		},
+		{
+			number:        "1",
+			expectedValue: "+1",
+		},
+		{
+			number:        "+81",
+			expectedValue: "+81",
+		},
+		{
+			number:        "81",
+			expectedValue: "+8181",
+		},
+		{
+			number:        "0",
+			expectedValue: "+0",
+		},
 	}
 
 	for _, testCase := range *testCases {
@@ -478,20 +488,20 @@ func TestUnitFormatsAsCalculatedE164NumberError(t *testing.T) {
 		// Random characters
 		{
 			number:        "+1@@##3i-[0340-231234",
-			expectedValue: "+00",
+			expectedValue: "+1@@##3i-[0340-231234",
 		},
 		{
 			number:        "adahsioidaodah",
-			expectedValue: "+00",
+			expectedValue: "+adahsioidaodah",
 		},
 		// Invalid international codes
 		{
-			number:        "+4239 (372) (332 20 7123) 23223 4334 232323 1234",
+			number:        "+423 9 (372) (332 20 7123) 23223 4334 232323 1234",
 			expectedValue: "+4230",
 		},
 		{
 			number:        "+59",
-			expectedValue: "+00",
+			expectedValue: "+59",
 		},
 		// Edge cases
 		{
@@ -500,7 +510,7 @@ func TestUnitFormatsAsCalculatedE164NumberError(t *testing.T) {
 		},
 		{
 			number:        "0",
-			expectedValue: "+00",
+			expectedValue: "+0",
 		},
 	}
 
@@ -508,7 +518,7 @@ func TestUnitFormatsAsCalculatedE164NumberError(t *testing.T) {
 		val := utilE164.FormatAsCalculatedE164Number(testCase.number)
 		// We expect the value to be blank for invalid calculated values
 		if val != testCase.expectedValue {
-			t.Errorf("expected value to be to blank for number: %s, value: %s", testCase.number, val)
+			t.Errorf("expected value to be %s for number: %s, value: %s", testCase.expectedValue, testCase.number, val)
 		}
 	}
 }


### PR DESCRIPTION
Fixes phone number validator logic, and adds a BCP enabled mode flag that can bypass the validation logic