### PR TITLE
[Devtooling-1209] custom resolver for 'genesyscloud_knowledge_document' label_names

### DIFF
--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_schema.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_schema.go
@@ -22,6 +22,9 @@ func KnowledgeDocumentExporter() *resourceExporter.ResourceExporter {
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
 			"knowledge_base_id": {RefType: "genesyscloud_knowledge_knowledgebase"},
 		},
+		CustomAttributeResolver: map[string]*resourceExporter.RefAttrCustomResolver{
+			"knowledge_document.label_names": {ResolverFunc: resourceExporter.KnowledgeDocumentLabelNamesResolver},
+		},
 	}
 }
 


### PR DESCRIPTION
This custom resolver makes the label names a reference to the name of the label resource itself the same way the [documentation example](https://registry.terraform.io/providers/MyPureCloud/genesyscloud/latest/docs/resources/knowledge_document) sets it. This will ensure when exporting from one org then applying the knowledge resources elsewhere the creation/update order is correct.

Without this the labels are exported as strings, and when applied if the document is created before the label, knowledge_document.label_names will not be set and cause the consistency checker to fail.