### PR TITLE
[Devtooling 1205] Knowledge Document Variation 'Plan to Change' fix

### DIFF
--- a/docs/resources/knowledge_document_variation.md
+++ b/docs/resources/knowledge_document_variation.md
@@ -105,8 +105,11 @@ Optional:
 
 - `body` (Block List, Max: 1) The content for the variation. (see [below for nested schema](#nestedblock--knowledge_document_variation--body))
 - `contexts` (Block List) The context values associated with the variation (see [below for nested schema](#nestedblock--knowledge_document_variation--contexts))
-- `document_version` (Block List, Max: 1) The version of the document. (see [below for nested schema](#nestedblock--knowledge_document_variation--document_version))
 - `name` (String) The name of the variation
+
+Read-Only:
+
+- `document_version` (List of Object) The version of the document. (see [below for nested schema](#nestedatt--knowledge_document_variation--document_version))
 
 <a id="nestedblock--knowledge_document_variation--body"></a>
 ### Nested Schema for `knowledge_document_variation.body`
@@ -438,10 +441,10 @@ Required:
 
 
 
-<a id="nestedblock--knowledge_document_variation--document_version"></a>
+<a id="nestedatt--knowledge_document_variation--document_version"></a>
 ### Nested Schema for `knowledge_document_variation.document_version`
 
-Optional:
+Read-Only:
 
-- `id` (String) Id
+- `id` (String)
 

--- a/genesyscloud/knowledge_document_variation/genesyscloud_knowledge_document_variation_proxy.go
+++ b/genesyscloud/knowledge_document_variation/genesyscloud_knowledge_document_variation_proxy.go
@@ -164,6 +164,7 @@ func getLatestPublishedOrDraftVariationFn(ctx context.Context, p *variationReque
 
 // createVariationFn is an implementation function for creating a Genesys Cloud variation request
 func createVariationFn(ctx context.Context, p *variationRequestProxy, variationRequest *platformclientv2.Documentvariationrequest, knowledgeDocumentId, knowledgeBaseId string) (*platformclientv2.Documentvariationresponse, *platformclientv2.APIResponse, error) {
+	log.Println("variationRequest", variationRequest)
 	return p.knowledgeApi.PostKnowledgeKnowledgebaseDocumentVariations(knowledgeBaseId, knowledgeDocumentId, *variationRequest)
 }
 

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation.go
@@ -126,24 +126,17 @@ func createKnowledgeDocumentVariation(ctx context.Context, d *schema.ResourceDat
 		published = publishedIn.(bool)
 	}
 
-	log.Println("knowledgeDocumentVariation", knowledgeDocumentVariation)
 	knowledgeDocumentVariationRequest := buildKnowledgeDocumentVariation(knowledgeDocumentVariation)
 
 	log.Printf("Creating knowledge document variation for document %s", ids.knowledgeDocumentID)
 
-	log.Println("knowledgeDocumentVariationRequest", knowledgeDocumentVariationRequest)
 	knowledgeDocumentVariationResponse, resp, err := variationProxy.CreateVariation(ctx, knowledgeDocumentVariationRequest, ids.knowledgeDocumentID, ids.knowledgeBaseID)
 	if err != nil {
 		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to create variation for knowledge document (%s) error: %s", ids.knowledgeDocumentID, err), resp)
 	}
 
-	versionId := knowledgeDocumentVariationRequest.DocumentVersion.Id
-	log.Println("knowledgeDocumentVariationResponse", knowledgeDocumentVariationResponse)
-
 	if published {
-		_, resp, versionErr := variationProxy.createKnowledgeKnowledgebaseDocumentVersions(ctx, ids.knowledgeDocumentID, ids.knowledgeBaseID, &platformclientv2.Knowledgedocumentversion{
-			Id: versionId,
-		})
+		_, resp, versionErr := variationProxy.createKnowledgeKnowledgebaseDocumentVersions(ctx, ids.knowledgeDocumentID, ids.knowledgeBaseID, &platformclientv2.Knowledgedocumentversion{})
 		if versionErr != nil {
 			return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to publish knowledge document error: %s", versionErr.Error()), resp)
 		}
@@ -191,7 +184,6 @@ func readKnowledgeDocumentVariation(ctx context.Context, d *schema.ResourceData,
 			return retry.NonRetryableError(err)
 		}
 
-		log.Println("knowledgeDocVariation", knowledgeDocVariation)
 		if knowledgeDocVariation.Document == nil || knowledgeDocVariation.Document.KnowledgeBase == nil {
 			return retry.NonRetryableError(fmt.Errorf("returned knowledge document variation '%s' did not include a Document object", ids.knowledgeDocumentVariationID))
 		}

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation.go
@@ -126,17 +126,24 @@ func createKnowledgeDocumentVariation(ctx context.Context, d *schema.ResourceDat
 		published = publishedIn.(bool)
 	}
 
+	log.Println("knowledgeDocumentVariation", knowledgeDocumentVariation)
 	knowledgeDocumentVariationRequest := buildKnowledgeDocumentVariation(knowledgeDocumentVariation)
 
 	log.Printf("Creating knowledge document variation for document %s", ids.knowledgeDocumentID)
 
+	log.Println("knowledgeDocumentVariationRequest", knowledgeDocumentVariationRequest)
 	knowledgeDocumentVariationResponse, resp, err := variationProxy.CreateVariation(ctx, knowledgeDocumentVariationRequest, ids.knowledgeDocumentID, ids.knowledgeBaseID)
 	if err != nil {
 		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to create variation for knowledge document (%s) error: %s", ids.knowledgeDocumentID, err), resp)
 	}
 
+	versionId := knowledgeDocumentVariationRequest.DocumentVersion.Id
+	log.Println("knowledgeDocumentVariationResponse", knowledgeDocumentVariationResponse)
+
 	if published {
-		_, resp, versionErr := variationProxy.createKnowledgeKnowledgebaseDocumentVersions(ctx, ids.knowledgeDocumentID, ids.knowledgeBaseID, &platformclientv2.Knowledgedocumentversion{})
+		_, resp, versionErr := variationProxy.createKnowledgeKnowledgebaseDocumentVersions(ctx, ids.knowledgeDocumentID, ids.knowledgeBaseID, &platformclientv2.Knowledgedocumentversion{
+			Id: versionId,
+		})
 		if versionErr != nil {
 			return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to publish knowledge document error: %s", versionErr.Error()), resp)
 		}
@@ -184,6 +191,7 @@ func readKnowledgeDocumentVariation(ctx context.Context, d *schema.ResourceData,
 			return retry.NonRetryableError(err)
 		}
 
+		log.Println("knowledgeDocVariation", knowledgeDocVariation)
 		if knowledgeDocVariation.Document == nil || knowledgeDocVariation.Document.KnowledgeBase == nil {
 			return retry.NonRetryableError(fmt.Errorf("returned knowledge document variation '%s' did not include a Document object", ids.knowledgeDocumentVariationID))
 		}

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_schema.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_schema.go
@@ -1,9 +1,10 @@
 package knowledge_document_variation
 
 import (
+	"strconv"
+
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
-	"strconv"
 
 	registrar "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_register"
 
@@ -34,8 +35,9 @@ var (
 			"document_version": {
 				Description: "The version of the document.",
 				Type:        schema.TypeList,
-				MaxItems:    1,
-				Optional:    true,
+				Optional:    false,
+				Required:    false,
+				Computed:    true,
 				Elem:        addressableEntityRef,
 			},
 			"name": {

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_schema.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_schema.go
@@ -37,7 +37,6 @@ var (
 				MaxItems:    1,
 				Optional:    true,
 				Elem:        addressableEntityRef,
-				Computed:    true,
 			},
 			"name": {
 				Description: "The name of the variation",

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_utils.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_utils.go
@@ -2,6 +2,7 @@ package knowledge_document_variation
 
 import (
 	"fmt"
+	"log"
 	"strings"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
@@ -371,11 +372,22 @@ func buildKnowledgeDocumentVariation(variationIn map[string]interface{}) *platfo
 		return nil
 	}
 
-	return &platformclientv2.Documentvariationrequest{
+	log.Println("variationIn", variationIn)
+
+	request := platformclientv2.Documentvariationrequest{
 		Name:     resourcedata.GetNillableValueFromMap[string](variationIn, "name", true),
 		Body:     buildVariationBody(variationIn),
 		Contexts: buildVariationContexts(variationIn),
 	}
+
+	versionId := variationIn["document_version"].([]interface{})[0].(map[string]interface{})["id"].(string)
+	if versionId != "" {
+		request.DocumentVersion = &platformclientv2.Addressableentityref{
+			Id: &versionId,
+		}
+	}
+
+	return &request
 }
 
 func buildVariationContexts(variationIn map[string]interface{}) *[]platformclientv2.Documentvariationcontext {

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_utils.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_utils.go
@@ -2,7 +2,6 @@ package knowledge_document_variation
 
 import (
 	"fmt"
-	"log"
 	"strings"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
@@ -372,19 +371,10 @@ func buildKnowledgeDocumentVariation(variationIn map[string]interface{}) *platfo
 		return nil
 	}
 
-	log.Println("variationIn", variationIn)
-
 	request := platformclientv2.Documentvariationrequest{
 		Name:     resourcedata.GetNillableValueFromMap[string](variationIn, "name", true),
 		Body:     buildVariationBody(variationIn),
 		Contexts: buildVariationContexts(variationIn),
-	}
-
-	versionId := variationIn["document_version"].([]interface{})[0].(map[string]interface{})["id"].(string)
-	if versionId != "" {
-		request.DocumentVersion = &platformclientv2.Addressableentityref{
-			Id: &versionId,
-		}
 	}
 
 	return &request


### PR DESCRIPTION
When Setting Document Version, Terraform detects changes in the config. This is due to document version being returned by the API. I was informed it should not be set by the user. The fix makes document version read only