### PR TITLE
[Devtooling-1327] Reference to Flows Missing on Export

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -652,7 +652,16 @@ func (g *GenesysCloudResourceExporter) buildResourceConfigMap() (diagnostics dia
 		}
 
 		if resource.Type == architectFlow.ResourceType && !g.d.Get("use_legacy_architect_flow_exporter").(bool) {
-			(*g.exporters)[architectFlow.ResourceType] = resourceExporter.GetNewFlowResourceExporter()
+			// Get the current flow exporter to preserve its SanitizedResourceMap
+			currentFlowExporter := (*g.exporters)[architectFlow.ResourceType]
+			newFlowExporter := resourceExporter.GetNewFlowResourceExporter()
+
+			// Copy the SanitizedResourceMap from the current exporter to the new one to resolve flow references
+			if currentFlowExporter != nil && currentFlowExporter.SanitizedResourceMap != nil {
+				newFlowExporter.SetSanitizedResourceMap(currentFlowExporter.GetSanitizedResourceMap())
+			}
+
+			(*g.exporters)[architectFlow.ResourceType] = newFlowExporter
 		}
 
 		// 4. Convert the instance state to a map


### PR DESCRIPTION
When exporting with `use_legacy_architect_flow_exporter = false` the reference to flows are missing from the exported resources. This was due to the sanitizedResourceMap and the refAttrs being lost when the export is changed from legacy to the new one for the flows. 
This fix copies the sanitizedResourceMap for flows into the new exporter