### PR TITLE
NO-JIRA Make callable_times an optional field 

### DIFF
--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_schema.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_schema.go
@@ -79,7 +79,7 @@ func ResourceOutboundCallabletimeset() *schema.Resource {
 			},
 			`callable_times`: {
 				Description: `The list of CallableTimes for which it is acceptable to place outbound calls.`,
-				Required:    true,
+				Optional:    true,
 				Type:        schema.TypeSet,
 				Elem:        timeSlotResource,
 			},


### PR DESCRIPTION
NO-JIRA Make callable_times an optional field to align with the UI and API, and to facilitate BCP exports/imports

---
Background:

We had a customer in BCP try to complete a sync with a callable timeset resource that did not have any callable times defined. The exporter exported the callable times block as null. When the import began, validation failed due to the field `callable_times` being a required field.

However, when I looked at the UI and the APIs, this field is not required. 

To better align with the behavior of the API, we should make this optional.