### PR TITLE
feat/AAPL-316 updated platform-client-sdk-go to v171

### DIFF
--- a/examples/docs_examples_test.go
+++ b/examples/docs_examples_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // SHOW_EXAMPLE_TERRAFORM_CONFIG_OUTPUT_WITH_LINES controls whether to display the full output

--- a/genesyscloud/architect_datatable/data_source_genesyscloud_architect_datatable.go
+++ b/genesyscloud/architect_datatable/data_source_genesyscloud_architect_datatable.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func DataSourceArchitectDatatableRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type Datatableproperty struct {

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_proxy.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_proxy.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"net/http"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_test.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectDatatable(t *testing.T) {

--- a/genesyscloud/architect_datatable_row/genesyscloud_architect_datatable_row_utils.go
+++ b/genesyscloud/architect_datatable_row/genesyscloud_architect_datatable_row_utils.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // Row IDs structured as {table-id}/{key-value}

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type Datatableproperty struct {

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_proxy.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_proxy.go
@@ -10,7 +10,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mitchellh/mapstructure"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // Type definitions for each func on our proxy so we can easily mock them out later

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_test.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectDatatableRow(t *testing.T) {

--- a/genesyscloud/architect_emergencygroup/genesyscloud_architect_emergencygroup_proxy.go
+++ b/genesyscloud/architect_emergencygroup/genesyscloud_architect_emergencygroup_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *architectEmergencyGroupProxy

--- a/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup.go
+++ b/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllEmergencyGroups(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_test.go
+++ b/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectEmergencyGroups(t *testing.T) {

--- a/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_utils.go
+++ b/genesyscloud/architect_emergencygroup/resource_genesyscloud_architect_emergencygroup_utils.go
@@ -2,7 +2,7 @@ package architect_emergencygroup
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSdkEmergencyGroupCallFlows(d *schema.ResourceData) *[]platformclientv2.Emergencycallflow {

--- a/genesyscloud/architect_flow/data_source_genesyscloud_flow.go
+++ b/genesyscloud/architect_flow/data_source_genesyscloud_flow.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_proxy.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_proxy.go
@@ -12,7 +12,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *architectFlowProxy

--- a/genesyscloud/architect_flow/resource_genesyscloud_flow.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_flow.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllFlows(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/architect_flow/resource_genesyscloud_flow_test.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_flow_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // lockFlow will search for a specific flow and then lock it.  This is to specifically test the force_unlock flag where I want to create a flow,  simulate some one locking it and then attempt to

--- a/genesyscloud/architect_flow/resource_genesyscloud_flow_unit_test.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_flow_unit_test.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestUnitGenerateDownloadUrlFn(t *testing.T) {

--- a/genesyscloud/architect_grammar/genesyscloud_architect_grammar_proxy.go
+++ b/genesyscloud/architect_grammar/genesyscloud_architect_grammar_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar.go
+++ b/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar_test.go
+++ b/genesyscloud/architect_grammar/resource_genesyscloud_architect_grammar_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectGrammar(t *testing.T) {

--- a/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_proxy.go
+++ b/genesyscloud/architect_grammar_language/genesyscloud_architect_grammar_language_proxy.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type FileType int

--- a/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language.go
+++ b/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_test.go
+++ b/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectGrammarLanguage(t *testing.T) {

--- a/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_utils.go
+++ b/genesyscloud/architect_grammar_language/resource_genesyscloud_architect_grammar_language_utils.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_ivr/data_source_genesyscloud_architect_ivr_test.go
+++ b/genesyscloud/architect_ivr/data_source_genesyscloud_architect_ivr_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/google/uuid"

--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_init_test.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_init_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	didPool "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_did_pool"

--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy.go
@@ -8,7 +8,7 @@ import (
 
 	utillists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
+++ b/genesyscloud/architect_ivr/genesyscloud_architect_ivr_proxy_unit_test.go
@@ -12,7 +12,7 @@ import (
 	utillists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestUnitUploadIvrDnisChunksSuccess(t *testing.T) {

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // getAllIvrConfigs retrieves all architect IVRs and is used for the exporter

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_test.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectIvrConfigBasic(t *testing.T) {

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_unit_test.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_unit_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_utils.go
+++ b/genesyscloud/architect_ivr/resource_genesyscloud_architect_ivr_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type IvrConfigStruct struct {

--- a/genesyscloud/architect_schedulegroups/genesyscloud_architect_schedulegroups_proxy.go
+++ b/genesyscloud/architect_schedulegroups/genesyscloud_architect_schedulegroups_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups.go
+++ b/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups_test.go
+++ b/genesyscloud/architect_schedulegroups/resource_genesyscloud_architect_schedulegroups_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectScheduleGroups(t *testing.T) {

--- a/genesyscloud/architect_schedules/genesyscloud_architect_schedules_proxy.go
+++ b/genesyscloud/architect_schedules/genesyscloud_architect_schedules_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules.go
@@ -19,7 +19,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllArchitectSchedules(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
+++ b/genesyscloud/architect_schedules/resource_genesyscloud_architect_schedules_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const errorMessageToMatch = "invalid start date."

--- a/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
+++ b/genesyscloud/architect_user_prompt/genesyscloud_architect_user_prompt_proxy.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllUserPrompts(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_test.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceArchitectUserPromptBasic(t *testing.T) {

--- a/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_utils.go
+++ b/genesyscloud/architect_user_prompt/resource_genesyscloud_architect_user_prompt_utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type PromptAudioData struct {

--- a/genesyscloud/auth_division/genesyscloud_auth_division_proxy.go
+++ b/genesyscloud/auth_division/genesyscloud_auth_division_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *authDivisionProxy

--- a/genesyscloud/auth_division/resource_genesyscloud_auth_division.go
+++ b/genesyscloud/auth_division/resource_genesyscloud_auth_division.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllAuthDivisions(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/auth_division/resource_genesyscloud_auth_division_test.go
+++ b/genesyscloud/auth_division/resource_genesyscloud_auth_division_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/auth_role/data_source_genesyscloud_auth_role.go
+++ b/genesyscloud/auth_role/data_source_genesyscloud_auth_role.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/auth_role/genesyscloud_auth_role_proxy.go
+++ b/genesyscloud/auth_role/genesyscloud_auth_role_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/auth_role/resource_genesyscloud_auth_role.go
+++ b/genesyscloud/auth_role/resource_genesyscloud_auth_role.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/auth_role/resource_genesyscloud_auth_role_test.go
+++ b/genesyscloud/auth_role/resource_genesyscloud_auth_role_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceAuthRoleDefault(t *testing.T) {

--- a/genesyscloud/auth_role/resource_genesyscloud_auth_role_utils.go
+++ b/genesyscloud/auth_role/resource_genesyscloud_auth_role_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func validatePermissionPolicy(proxy *authRoleProxy, policy platformclientv2.Domainpermissionpolicy) (*platformclientv2.APIResponse, error) {

--- a/genesyscloud/authorization_product/data_source_genesyscloud_authorization_product_test.go
+++ b/genesyscloud/authorization_product/data_source_genesyscloud_authorization_product_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/net/context"
 

--- a/genesyscloud/authorization_product/genesyscloud_authorization_product_proxy.go
+++ b/genesyscloud/authorization_product/genesyscloud_authorization_product_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/business_rules_decision_table/genesyscloud_business_rules_decision_table_init_test.go
+++ b/genesyscloud/business_rules_decision_table/genesyscloud_business_rules_decision_table_init_test.go
@@ -11,7 +11,7 @@ import (
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 )
 

--- a/genesyscloud/business_rules_decision_table/genesyscloud_business_rules_decision_table_proxy.go
+++ b/genesyscloud/business_rules_decision_table/genesyscloud_business_rules_decision_table_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 )

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	platformclientv2 "github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	platformclientv2 "github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceBusinessRulesDecisionTableHappyPath(t *testing.T) {

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test_utils.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test_utils.go
@@ -5,7 +5,7 @@ import (
 
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // generateBusinessRulesDecisionTableResource generates a basic business rules decision table resource

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_utils.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_utils.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 )
 

--- a/genesyscloud/business_rules_schema/genesyscloud_business_rules_schema_proxy.go
+++ b/genesyscloud/business_rules_schema/genesyscloud_business_rules_schema_proxy.go
@@ -10,7 +10,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*
@@ -23,11 +23,11 @@ out during testing.
 var internalProxy *businessRulesSchemaProxy
 
 // Type definitions for each func on our proxy so we can easily mock them out later
-type createBusinessRulesSchemaFunc func(ctx context.Context, p *businessRulesSchemaProxy, schema *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error)
-type getAllBusinessRulesSchemaFunc func(ctx context.Context, p *businessRulesSchemaProxy) (*[]platformclientv2.Dataschema, *platformclientv2.APIResponse, error)
-type getBusinessRulesSchemasByNameFunc func(ctx context.Context, p *businessRulesSchemaProxy, name string) (schemas *[]platformclientv2.Dataschema, retryable bool, resp *platformclientv2.APIResponse, err error)
-type getBusinessRulesSchemaByIdFunc func(ctx context.Context, p *businessRulesSchemaProxy, id string) (schema *platformclientv2.Dataschema, response *platformclientv2.APIResponse, err error)
-type updateBusinessRulesSchemaFunc func(ctx context.Context, p *businessRulesSchemaProxy, id string, schema *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error)
+type createBusinessRulesSchemaFunc func(ctx context.Context, p *businessRulesSchemaProxy, schema *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error)
+type getAllBusinessRulesSchemaFunc func(ctx context.Context, p *businessRulesSchemaProxy) (*[]platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error)
+type getBusinessRulesSchemasByNameFunc func(ctx context.Context, p *businessRulesSchemaProxy, name string) (schemas *[]platformclientv2.Businessrulesdataschema, retryable bool, resp *platformclientv2.APIResponse, err error)
+type getBusinessRulesSchemaByIdFunc func(ctx context.Context, p *businessRulesSchemaProxy, id string) (schema *platformclientv2.Businessrulesdataschema, response *platformclientv2.APIResponse, err error)
+type updateBusinessRulesSchemaFunc func(ctx context.Context, p *businessRulesSchemaProxy, id string, schema *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error)
 type deleteBusinessRulesSchemaFunc func(ctx context.Context, p *businessRulesSchemaProxy, id string) (response *platformclientv2.APIResponse, err error)
 type getBusinessRulesSchemaDeletedStatusFunc func(ctx context.Context, p *businessRulesSchemaProxy, schemaId string) (isDeleted bool, resp *platformclientv2.APIResponse, err error)
 
@@ -42,13 +42,13 @@ type businessRulesSchemaProxy struct {
 	updateBusinessRulesSchemaAttr           updateBusinessRulesSchemaFunc
 	deleteBusinessRulesSchemaAttr           deleteBusinessRulesSchemaFunc
 	getBusinessRulesSchemaDeletedStatusAttr getBusinessRulesSchemaDeletedStatusFunc
-	businessRulesSchemaCache                rc.CacheInterface[platformclientv2.Dataschema]
+	businessRulesSchemaCache                rc.CacheInterface[platformclientv2.Businessrulesdataschema]
 }
 
 // newBusinessRulesSchemaProxy initializes the business rules schema proxy with all of the data needed to communicate with Genesys Cloud
 func newBusinessRulesSchemaProxy(clientConfig *platformclientv2.Configuration) *businessRulesSchemaProxy {
 	api := platformclientv2.NewBusinessRulesApiWithConfig(clientConfig)
-	businessRulesSchemaCache := rc.NewResourceCache[platformclientv2.Dataschema]()
+	businessRulesSchemaCache := rc.NewResourceCache[platformclientv2.Businessrulesdataschema]()
 
 	return &businessRulesSchemaProxy{
 		clientConfig:                            clientConfig,
@@ -74,27 +74,27 @@ func getBusinessRulesSchemaProxy(clientConfig *platformclientv2.Configuration) *
 }
 
 // createBusinessRulesSchema creates a Genesys Cloud business rules schema
-func (p *businessRulesSchemaProxy) createBusinessRulesSchema(ctx context.Context, schema *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+func (p *businessRulesSchemaProxy) createBusinessRulesSchema(ctx context.Context, schema *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 	return p.createBusinessRulesSchemaAttr(ctx, p, schema)
 }
 
 // getAllBusinessRulesSchema retrieves all Genesys Cloud business rules schemas
-func (p *businessRulesSchemaProxy) getAllBusinessRulesSchema(ctx context.Context) (*[]platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+func (p *businessRulesSchemaProxy) getAllBusinessRulesSchema(ctx context.Context) (*[]platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 	return p.getAllBusinessRulesSchemaAttr(ctx, p)
 }
 
 // getBusinessRulesSchemasByName returns a single Genesys Cloud business rules schema by a name
-func (p *businessRulesSchemaProxy) getBusinessRulesSchemasByName(ctx context.Context, name string) (schemas *[]platformclientv2.Dataschema, retryable bool, resp *platformclientv2.APIResponse, err error) {
+func (p *businessRulesSchemaProxy) getBusinessRulesSchemasByName(ctx context.Context, name string) (schemas *[]platformclientv2.Businessrulesdataschema, retryable bool, resp *platformclientv2.APIResponse, err error) {
 	return p.getBusinessRulesSchemasByNameAttr(ctx, p, name)
 }
 
 // getBusinessRulesSchemaById returns a single Genesys Cloud business rules schema by Id
-func (p *businessRulesSchemaProxy) getBusinessRulesSchemaById(ctx context.Context, id string) (schema *platformclientv2.Dataschema, resp *platformclientv2.APIResponse, err error) {
+func (p *businessRulesSchemaProxy) getBusinessRulesSchemaById(ctx context.Context, id string) (schema *platformclientv2.Businessrulesdataschema, resp *platformclientv2.APIResponse, err error) {
 	return p.getBusinessRulesSchemaByIdAttr(ctx, p, id)
 }
 
 // updateBusinessRulesSchema updates a Genesys Cloud business rules schema
-func (p *businessRulesSchemaProxy) updateBusinessRulesSchema(ctx context.Context, id string, schemaUpdate *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+func (p *businessRulesSchemaProxy) updateBusinessRulesSchema(ctx context.Context, id string, schemaUpdate *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 	return p.updateBusinessRulesSchemaAttr(ctx, p, id, schemaUpdate)
 }
 
@@ -109,9 +109,10 @@ func (p *businessRulesSchemaProxy) getBusinessRulesSchemaDeletedStatus(ctx conte
 }
 
 // createBusinessRulesSchemaFn is an implementation function for creating a Genesys Cloud business rules schema
-func createBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProxy, schema *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+func createBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProxy, schema *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 	log.Printf("Creating business rules schema: %s", *schema.Name)
-	createdSchema, resp, err := p.businessRulesApi.PostBusinessrulesSchemas(*schema)
+	request := platformclientv2.Businessrulesschemacreaterequest{}
+	createdSchema, resp, err := p.businessRulesApi.PostBusinessrulesSchemas(request)
 	log.Printf("Completed call to create business rules schema %s with status code %d, correlation id %s", *schema.Name, resp.StatusCode, resp.CorrelationID)
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to create business rules schema: %s", err)
@@ -120,7 +121,7 @@ func createBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProx
 }
 
 // getAllBusinessRulesSchemaFn is the implementation for retrieving all business rules schemas in Genesys Cloud
-func getAllBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProxy) (*[]platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+func getAllBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProxy) (*[]platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 	// NOTE: At the time of implementation (Preview API) retrieving schemas does not have any sort of pagination.
 	// It seemingly will return all schemas in one call. This might have to be updated as there may be some
 	// undocumented limit or if there would be changes to the API call before release.
@@ -129,15 +130,15 @@ func getAllBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProx
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to get all business rules schemas: %v", err)
 	}
-	if schemas.Entities == nil || *schemas.Total == 0 {
-		return &([]platformclientv2.Dataschema{}), resp, nil
+	if schemas.Entities == nil || len(*schemas.Entities) == 0 {
+		return &([]platformclientv2.Businessrulesdataschema{}), resp, nil
 	}
 	return schemas.Entities, resp, nil
 }
 
 // getBusinessRulesSchemasByNameFn is an implementation of the function to get a Genesys Cloud business rules schemas by name
-func getBusinessRulesSchemasByNameFn(ctx context.Context, p *businessRulesSchemaProxy, name string) (matchingSchemas *[]platformclientv2.Dataschema, retryable bool, resp *platformclientv2.APIResponse, err error) {
-	finalSchemas := []platformclientv2.Dataschema{}
+func getBusinessRulesSchemasByNameFn(ctx context.Context, p *businessRulesSchemaProxy, name string) (matchingSchemas *[]platformclientv2.Businessrulesdataschema, retryable bool, resp *platformclientv2.APIResponse, err error) {
+	finalSchemas := []platformclientv2.Businessrulesdataschema{}
 
 	schemas, resp, err := p.getAllBusinessRulesSchema(ctx)
 	if err != nil {
@@ -157,7 +158,7 @@ func getBusinessRulesSchemasByNameFn(ctx context.Context, p *businessRulesSchema
 }
 
 // getBusinessRulesSchemaByIdFn is an implementation of the function to get a Genesys Cloud business rules schema by Id
-func getBusinessRulesSchemaByIdFn(ctx context.Context, p *businessRulesSchemaProxy, id string) (schema *platformclientv2.Dataschema, resp *platformclientv2.APIResponse, err error) {
+func getBusinessRulesSchemaByIdFn(ctx context.Context, p *businessRulesSchemaProxy, id string) (schema *platformclientv2.Businessrulesdataschema, resp *platformclientv2.APIResponse, err error) {
 	businessRulesSchema := rc.GetCacheItem(p.businessRulesSchemaCache, id)
 	if businessRulesSchema != nil {
 		return businessRulesSchema, nil, nil
@@ -166,8 +167,12 @@ func getBusinessRulesSchemaByIdFn(ctx context.Context, p *businessRulesSchemaPro
 }
 
 // updateBusinessRulesSchemaFn is an implementation of the function to update a Genesys Cloud business rules schema
-func updateBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProxy, id string, schemaUpdate *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
-	schema, resp, err := p.businessRulesApi.PutBusinessrulesSchema(id, *schemaUpdate)
+func updateBusinessRulesSchemaFn(ctx context.Context, p *businessRulesSchemaProxy, id string, schemaUpdate *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
+	request := platformclientv2.Businessrulesschemaupdaterequest{
+		Version: schemaUpdate.Version,
+		Enabled: schemaUpdate.Enabled,
+	}
+	schema, resp, err := p.businessRulesApi.PutBusinessrulesSchema(id, request)
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to update business rules schema: %s", err)
 	}

--- a/genesyscloud/business_rules_schema/genesyscloud_business_schema_init_test.go
+++ b/genesyscloud/business_rules_schema/genesyscloud_business_schema_init_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 )
 

--- a/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema.go
+++ b/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 
@@ -55,7 +55,7 @@ func createBusinessRulesSchema(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("Creating business rules schema")
-	schema, resp, err := proxy.createBusinessRulesSchema(ctx, dataSchema)
+	schema, resp, err := proxy.createBusinessRulesSchema(ctx, (*platformclientv2.Businessrulesdataschema)(dataSchema))
 	if err != nil {
 		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to create business rules schema %s error: %s", *dataSchema.Name, err), resp)
 	}
@@ -66,7 +66,7 @@ func createBusinessRulesSchema(ctx context.Context, d *schema.ResourceData, meta
 	if enabled, ok := d.Get("enabled").(bool); ok && !enabled {
 		log.Printf("Updating business rules schema: %s, to set 'enabled' to 'false'", *schema.Name)
 		dataSchema.Version = platformclientv2.Int(1)
-		_, resp, err := proxy.updateBusinessRulesSchema(ctx, *schema.Id, dataSchema)
+		_, resp, err := proxy.updateBusinessRulesSchema(ctx, *schema.Id, (*platformclientv2.Businessrulesdataschema)(dataSchema))
 		if err != nil {
 			return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update business rules schema %s error: %s", d.Id(), err), resp)
 		}
@@ -136,7 +136,7 @@ func updateBusinessRulesSchema(ctx context.Context, d *schema.ResourceData, meta
 	}
 
 	log.Printf("Updating business rules schema")
-	updatedSchema, resp, err := proxy.updateBusinessRulesSchema(ctx, d.Id(), dataSchema)
+	updatedSchema, resp, err := proxy.updateBusinessRulesSchema(ctx, d.Id(), (*platformclientv2.Businessrulesdataschema)(dataSchema))
 	if err != nil {
 		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update business rules schema %s error: %s", d.Id(), err), resp)
 	}

--- a/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema_test.go
+++ b/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema_test.go
@@ -16,7 +16,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema_unit_test.go
+++ b/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema_unit_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -43,9 +43,9 @@ func TestUnitResourceBusinessRulesSchemaCreate(t *testing.T) {
 
 	schemaProxy := &businessRulesSchemaProxy{}
 
-	schemaProxy.getBusinessRulesSchemaByIdAttr = func(ctx context.Context, p *businessRulesSchemaProxy, id string) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+	schemaProxy.getBusinessRulesSchemaByIdAttr = func(ctx context.Context, p *businessRulesSchemaProxy, id string) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 		assert.Equal(t, tId, id)
-		schema := &platformclientv2.Dataschema{
+		schema := &platformclientv2.Businessrulesdataschema{
 			Name:       &tName,
 			Enabled:    &tEnabled,
 			JsonSchema: &tJsonSchema,
@@ -56,8 +56,8 @@ func TestUnitResourceBusinessRulesSchemaCreate(t *testing.T) {
 		return schema, apiResponse, nil
 	}
 
-	schemaProxy.createBusinessRulesSchemaAttr = func(ctx context.Context, p *businessRulesSchemaProxy, schemaCreate *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
-		schema := platformclientv2.Dataschema{}
+	schemaProxy.createBusinessRulesSchemaAttr = func(ctx context.Context, p *businessRulesSchemaProxy, schemaCreate *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
+		schema := platformclientv2.Businessrulesdataschema{}
 
 		assert.Equal(t, tName, *schemaCreate.Name, "schema.Name check failed in create createBusinessRulesSchemaAttr")
 		assert.Equal(t, tDescription, *schemaCreate.JsonSchema.Description, "schema.JsonSchema.Description check failed in create createBusinessRulesSchemaAttr")
@@ -121,9 +121,9 @@ func TestUnitResourceBusinessRulesSchemaRead(t *testing.T) {
 
 	schemaProxy := &businessRulesSchemaProxy{}
 
-	schemaProxy.getBusinessRulesSchemaByIdAttr = func(ctx context.Context, p *businessRulesSchemaProxy, id string) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+	schemaProxy.getBusinessRulesSchemaByIdAttr = func(ctx context.Context, p *businessRulesSchemaProxy, id string) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 		assert.Equal(t, tId, id)
-		schema := &platformclientv2.Dataschema{
+		schema := &platformclientv2.Businessrulesdataschema{
 			Name:       &tName,
 			Enabled:    &tEnabled,
 			JsonSchema: &tJsonSchema,
@@ -250,9 +250,9 @@ func TestUnitResourceBusinessRulesSchemaUpdate(t *testing.T) {
 
 	schemaProxy := &businessRulesSchemaProxy{}
 
-	schemaProxy.getBusinessRulesSchemaByIdAttr = func(ctx context.Context, p *businessRulesSchemaProxy, id string) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
+	schemaProxy.getBusinessRulesSchemaByIdAttr = func(ctx context.Context, p *businessRulesSchemaProxy, id string) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
 		assert.Equal(t, tId, id)
-		schema := &platformclientv2.Dataschema{
+		schema := &platformclientv2.Businessrulesdataschema{
 			Name:       &tName,
 			Enabled:    &tEnabled,
 			JsonSchema: &tJsonSchema,
@@ -263,8 +263,8 @@ func TestUnitResourceBusinessRulesSchemaUpdate(t *testing.T) {
 		return schema, apiResponse, nil
 	}
 
-	schemaProxy.updateBusinessRulesSchemaAttr = func(ctx context.Context, p *businessRulesSchemaProxy, schemaId string, schemaCreate *platformclientv2.Dataschema) (*platformclientv2.Dataschema, *platformclientv2.APIResponse, error) {
-		schema := platformclientv2.Dataschema{}
+	schemaProxy.updateBusinessRulesSchemaAttr = func(ctx context.Context, p *businessRulesSchemaProxy, schemaId string, schemaCreate *platformclientv2.Businessrulesdataschema) (*platformclientv2.Businessrulesdataschema, *platformclientv2.APIResponse, error) {
+		schema := platformclientv2.Businessrulesdataschema{}
 
 		assert.Equal(t, tName, *schemaCreate.Name, "schema.Name check failed in create createBusinessRulesSchemaAttr")
 		assert.Equal(t, tDescription, *schemaCreate.JsonSchema.Description, "schema.JsonSchema.Description check failed in create createBusinessRulesSchemaAttr")

--- a/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema_utils.go
+++ b/genesyscloud/business_rules_schema/resource_genesyscloud_business_rules_schema_utils.go
@@ -7,7 +7,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const (

--- a/genesyscloud/conversations_messaging_integrations_instagram/genesyscloud_conversations_messaging_integrations_instagram_proxy.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/genesyscloud_conversations_messaging_integrations_instagram_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_test.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_unit_test.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_unit_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_utils.go
+++ b/genesyscloud/conversations_messaging_integrations_instagram/resource_genesyscloud_conversations_messaging_integrations_instagram_utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_open/genesyscloud_conversations_messaging_integrations_open_init_test.go
+++ b/genesyscloud/conversations_messaging_integrations_open/genesyscloud_conversations_messaging_integrations_open_init_test.go
@@ -9,7 +9,7 @@ import (
 	cmSupportedContent "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/conversations_messaging_supportedcontent"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 )
 

--- a/genesyscloud/conversations_messaging_integrations_open/genesyscloud_conversations_messaging_integrations_open_proxy.go
+++ b/genesyscloud/conversations_messaging_integrations_open/genesyscloud_conversations_messaging_integrations_open_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open.go
+++ b/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_test.go
+++ b/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_utils.go
+++ b/genesyscloud/conversations_messaging_integrations_open/resource_genesyscloud_conversations_messaging_integrations_open_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_whatsapp/data_source_genesyscloud_conversations_messaging_integrations_whatsapp_test.go
+++ b/genesyscloud/conversations_messaging_integrations_whatsapp/data_source_genesyscloud_conversations_messaging_integrations_whatsapp_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_whatsapp/genesyscloud_conversations_messaging_integrations_whatsapp_init_test.go
+++ b/genesyscloud/conversations_messaging_integrations_whatsapp/genesyscloud_conversations_messaging_integrations_whatsapp_init_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	cmMessagingSetting "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/conversations_messaging_settings"
 	cmSupportedContent "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/conversations_messaging_supportedcontent"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"

--- a/genesyscloud/conversations_messaging_integrations_whatsapp/genesyscloud_conversations_messaging_integrations_whatsapp_proxy.go
+++ b/genesyscloud/conversations_messaging_integrations_whatsapp/genesyscloud_conversations_messaging_integrations_whatsapp_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp.go
+++ b/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp_test.go
+++ b/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp_unit_test.go
+++ b/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp_unit_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp_utils.go
+++ b/genesyscloud/conversations_messaging_integrations_whatsapp/resource_genesyscloud_conversations_messaging_integrations_whatsapp_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_settings/data_source_genesyscloud_conversations_messaging_settings_test.go
+++ b/genesyscloud/conversations_messaging_settings/data_source_genesyscloud_conversations_messaging_settings_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 

--- a/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_init_test.go
+++ b/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_init_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 )
 

--- a/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_proxy.go
+++ b/genesyscloud/conversations_messaging_settings/genesyscloud_conversations_messaging_settings_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *conversationsMessagingSettingsProxy

--- a/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings.go
+++ b/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllAuthConversationsMessagingSettings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_test.go
+++ b/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_utils.go
+++ b/genesyscloud/conversations_messaging_settings/resource_genesyscloud_conversations_messaging_settings_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getConversationsMessagingSettingsFromResourceData(d *schema.ResourceData) platformclientv2.Messagingsettingrequest {

--- a/genesyscloud/conversations_messaging_settings_default/genesyscloud_conversations_messaging_settings_default_proxy.go
+++ b/genesyscloud/conversations_messaging_settings_default/genesyscloud_conversations_messaging_settings_default_proxy.go
@@ -3,7 +3,7 @@ package conversations_messaging_settings_default
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_settings_default/resource_genesyscloud_conversations_messaging_settings_default.go
+++ b/genesyscloud/conversations_messaging_settings_default/resource_genesyscloud_conversations_messaging_settings_default.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func createConversationsMessagingSettingsDefault(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_init_test.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_init_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 )
 

--- a/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_proxy.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/genesyscloud_conversations_messaging_supportedcontent_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_test.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_utils.go
+++ b/genesyscloud/conversations_messaging_supportedcontent/resource_genesyscloud_conversations_messaging_supportedcontent_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_supportedcontent_default/genesyscloud_conversations_messaging_supportedcontent_default_init_test.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/genesyscloud_conversations_messaging_supportedcontent_default_init_test.go
@@ -1,7 +1,7 @@
 package conversations_messaging_supportedcontent_default
 
 import (
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"log"
 	"sync"

--- a/genesyscloud/conversations_messaging_supportedcontent_default/genesyscloud_conversations_messaging_supportedcontent_default_proxy.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/genesyscloud_conversations_messaging_supportedcontent_default_proxy.go
@@ -3,7 +3,7 @@ package conversations_messaging_supportedcontent_default
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default_test.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"log"

--- a/genesyscloud/data_source_genesyscloud_auth_division_home.go
+++ b/genesyscloud/data_source_genesyscloud_auth_division_home.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const homeDivisionDataSourceType = "genesyscloud_auth_division_home"

--- a/genesyscloud/data_source_genesyscloud_organizations_me.go
+++ b/genesyscloud/data_source_genesyscloud_organizations_me.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const DataSourceOrganizationsMeResourceType = "genesyscloud_organizations_me"

--- a/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy.go
+++ b/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/stringmap"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type DependentConsumerProxy struct {

--- a/genesyscloud/employeeperformance_externalmetrics_definitions/genesyscloud_employeeperformance_externalmetrics_definitions_proxy.go
+++ b/genesyscloud/employeeperformance_externalmetrics_definitions/genesyscloud_employeeperformance_externalmetrics_definitions_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions.go
+++ b/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 

--- a/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions_test.go
+++ b/genesyscloud/employeeperformance_externalmetrics_definitions/resource_genesyscloud_employeeperformance_externalmetrics_definitions_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceEmployeePerformanceExternalMetricsDefintions(t *testing.T) {

--- a/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
+++ b/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_test.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/external_contacts_external_source/genesyscloud_externalcontacts_external_source_proxy.go
+++ b/genesyscloud/external_contacts_external_source/genesyscloud_externalcontacts_external_source_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/external_contacts_external_source/resource_genesyscloud_externalcontacts_external_source.go
+++ b/genesyscloud/external_contacts_external_source/resource_genesyscloud_externalcontacts_external_source.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"

--- a/genesyscloud/external_contacts_external_source/resource_genesyscloud_externalcontacts_external_source_test.go
+++ b/genesyscloud/external_contacts_external_source/resource_genesyscloud_externalcontacts_external_source_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceExternalSources(t *testing.T) {

--- a/genesyscloud/external_contacts_external_source/resource_genesyscloud_externalcontacts_external_source_utils.go
+++ b/genesyscloud/external_contacts_external_source/resource_genesyscloud_externalcontacts_external_source_utils.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts_organization/genesyscloud_externalcontacts_organization_proxy.go
+++ b/genesyscloud/external_contacts_organization/genesyscloud_externalcontacts_organization_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization.go
+++ b/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_test.go
+++ b/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceExternalContacts(t *testing.T) {

--- a/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_utils.go
+++ b/genesyscloud/external_contacts_organization/resource_genesyscloud_externalcontacts_organization_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/external_user/genesyscloud_externalusers_identity_proxy.go
+++ b/genesyscloud/external_user/genesyscloud_externalusers_identity_proxy.go
@@ -10,7 +10,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/external_user/resource_genesyscloud_externalusers_identity.go
+++ b/genesyscloud/external_user/resource_genesyscloud_externalusers_identity.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/external_user/resource_genesyscloud_externalusers_identity_unit_test.go
+++ b/genesyscloud/external_user/resource_genesyscloud_externalusers_identity_unit_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/flow_loglevel/genesyscloud_flow_loglevel_proxy.go
+++ b/genesyscloud/flow_loglevel/genesyscloud_flow_loglevel_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel.go
+++ b/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel_test.go
+++ b/genesyscloud/flow_loglevel/resource_genesyscloud_flow_loglevel_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceFlowLogLevel(t *testing.T) {

--- a/genesyscloud/flow_milestone/genesyscloud_flow_milestone_proxy.go
+++ b/genesyscloud/flow_milestone/genesyscloud_flow_milestone_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone.go
+++ b/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_test.go
+++ b/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceFlowMilestone(t *testing.T) {

--- a/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_utils.go
+++ b/genesyscloud/flow_milestone/resource_genesyscloud_flow_milestone_utils.go
@@ -2,7 +2,7 @@ package flow_milestone
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_outcome/genesyscloud_flow_outcome_proxy.go
+++ b/genesyscloud/flow_outcome/genesyscloud_flow_outcome_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome.go
+++ b/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome_unit_test.go
+++ b/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome_utils.go
+++ b/genesyscloud/flow_outcome/resource_genesyscloud_flow_outcome_utils.go
@@ -2,7 +2,7 @@ package flow_outcome
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/group/data_source_genesyscloud_group_test.go
+++ b/genesyscloud/group/data_source_genesyscloud_group_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"

--- a/genesyscloud/group/genesyscloud_group_proxy.go
+++ b/genesyscloud/group/genesyscloud_group_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type createGroupFunc func(ctx context.Context, p *groupProxy, group *platformclientv2.Groupcreate) (*platformclientv2.Group, *platformclientv2.APIResponse, error)

--- a/genesyscloud/group/resource_genesyscloud_group.go
+++ b/genesyscloud/group/resource_genesyscloud_group.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllGroups(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/group/resource_genesyscloud_group_test.go
+++ b/genesyscloud/group/resource_genesyscloud_group_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceGroupBasic(t *testing.T) {

--- a/genesyscloud/group/resource_genesyscloud_group_utils.go
+++ b/genesyscloud/group/resource_genesyscloud_group_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // 'number' and 'extension' conflict with eachother. However, one must be set.

--- a/genesyscloud/group_roles/genesyscloud_group_roles_proxy.go
+++ b/genesyscloud/group_roles/genesyscloud_group_roles_proxy.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *groupRolesProxy

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles_schema.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles_schema.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles_test.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 	authRole "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_role"

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles_utils.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func flattenSubjectRoles(d *schema.ResourceData, p *groupRolesProxy) (*schema.Set, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/guide/genesyscloud_guide_proxy.go
+++ b/genesyscloud/guide/genesyscloud_guide_proxy.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 )

--- a/genesyscloud/guide/resource_genesyscloud_guide.go
+++ b/genesyscloud/guide/resource_genesyscloud_guide.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"

--- a/genesyscloud/guide/resource_genesyscloud_guide_unit_test.go
+++ b/genesyscloud/guide/resource_genesyscloud_guide_unit_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/stretchr/testify/assert"
 )

--- a/genesyscloud/guide/resource_genesyscloud_guide_utils.go
+++ b/genesyscloud/guide/resource_genesyscloud_guide_utils.go
@@ -9,7 +9,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // GenerateGuideResource generates terraform for a guide resource

--- a/genesyscloud/guide_version/genesyscloud_guide_version_proxy.go
+++ b/genesyscloud/guide_version/genesyscloud_guide_version_proxy.go
@@ -11,7 +11,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *guideVersionProxy

--- a/genesyscloud/guide_version/resource_genesyscloud_guide_version.go
+++ b/genesyscloud/guide_version/resource_genesyscloud_guide_version.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"

--- a/genesyscloud/idp_adfs/genesyscloud_idp_adfs_proxy.go
+++ b/genesyscloud/idp_adfs/genesyscloud_idp_adfs_proxy.go
@@ -3,7 +3,7 @@ package idp_adfs
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_test.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceIdpAdfs(t *testing.T) {

--- a/genesyscloud/idp_generic/genesyscloud_idp_generic_proxy.go
+++ b/genesyscloud/idp_generic/genesyscloud_idp_generic_proxy.go
@@ -3,7 +3,7 @@ package idp_generic
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_test.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceIdpGeneric(t *testing.T) {

--- a/genesyscloud/idp_gsuite/genesyscloud_idp_gsuite_proxy.go
+++ b/genesyscloud/idp_gsuite/genesyscloud_idp_gsuite_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_test.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceIdpGsuite(t *testing.T) {

--- a/genesyscloud/idp_okta/genesyscloud_idp_okta_proxy.go
+++ b/genesyscloud/idp_okta/genesyscloud_idp_okta_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_test.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceIdpOkta(t *testing.T) {

--- a/genesyscloud/idp_onelogin/genesyscloud_idp_onelogin_proxy.go
+++ b/genesyscloud/idp_onelogin/genesyscloud_idp_onelogin_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_test.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceIdpOnelogin(t *testing.T) {

--- a/genesyscloud/idp_ping/genesyscloud_idp_ping_proxy.go
+++ b/genesyscloud/idp_ping/genesyscloud_idp_ping_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_test.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceIdpPing(t *testing.T) {

--- a/genesyscloud/idp_salesforce/genesyscloud_idp_salesforce_proxy.go
+++ b/genesyscloud/idp_salesforce/genesyscloud_idp_salesforce_proxy.go
@@ -3,7 +3,7 @@ package idp_salesforce
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_test.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceIdpSalesforce(t *testing.T) {

--- a/genesyscloud/integration/genesyscloud_integration_proxy.go
+++ b/genesyscloud/integration/genesyscloud_integration_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*
@@ -127,7 +127,7 @@ func getAllIntegrationsFn(ctx context.Context, p *integrationsProxy) (*[]platfor
 	var resp *platformclientv2.APIResponse
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		integrations, response, err := p.integrationsApi.GetIntegrations(pageSize, pageNum, "", nil, "", "")
+		integrations, response, err := p.integrationsApi.GetIntegrations(pageSize, pageNum, "", []string{}, "", "", []string{}, "", "")
 		if err != nil {
 			return nil, resp, err
 		}
@@ -166,7 +166,7 @@ func getIntegrationByNameFn(ctx context.Context, p *integrationsProxy, integrati
 	var resp *platformclientv2.APIResponse
 	const pageSize = 100
 	for pageNum := 1; ; pageNum++ {
-		integrations, response, err := p.integrationsApi.GetIntegrations(pageSize, pageNum, "", nil, "", "")
+		integrations, response, err := p.integrationsApi.GetIntegrations(pageSize, pageNum, "", []string{}, "", "", []string{}, "", "")
 		if err != nil {
 			return nil, false, resp, err
 		}

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration/resource_genesyscloud_integration_test.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/integration/resource_genesyscloud_integration_utils.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_utils.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_action/genesyscloud_integration_action_proxy.go
+++ b/genesyscloud/integration_action/genesyscloud_integration_action_proxy.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"path/filepath"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 )

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_test.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 )

--- a/genesyscloud/integration_action_draft/genesyscloud_integration_action_draft_proxy.go
+++ b/genesyscloud/integration_action_draft/genesyscloud_integration_action_draft_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *integrationActionsProxy

--- a/genesyscloud/integration_action_draft/resource_genesyscloud_integration_action_draft.go
+++ b/genesyscloud/integration_action_draft/resource_genesyscloud_integration_action_draft.go
@@ -14,7 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/integration_action_draft/resource_genesyscloud_integration_action_draft_test.go
+++ b/genesyscloud/integration_action_draft/resource_genesyscloud_integration_action_draft_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 )
 

--- a/genesyscloud/integration_action_draft/resource_genesyscloud_integration_action_draft_utils.go
+++ b/genesyscloud/integration_action_draft/resource_genesyscloud_integration_action_draft_utils.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"

--- a/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
+++ b/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_test.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_utils.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_utils.go
@@ -5,7 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	oauth "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/oauth_client"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 )

--- a/genesyscloud/integration_custom_auth_action/genesyscloud_integration_custom_auth_action_proxy.go
+++ b/genesyscloud/integration_custom_auth_action/genesyscloud_integration_custom_auth_action_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_test.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type customAuthActionResource struct {

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_utils.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_utils.go
@@ -7,7 +7,7 @@ import (
 	integrationAction "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/integration_action"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_facebook/genesyscloud_integration_facebook_proxy.go
+++ b/genesyscloud/integration_facebook/genesyscloud_integration_facebook_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_test.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_unit_test.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_unit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_utils.go
+++ b/genesyscloud/integration_facebook/resource_genesyscloud_integration_facebook_utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_action_map/genesyscloud_journey_action_map_init_test.go
+++ b/genesyscloud/journey_action_map/genesyscloud_journey_action_map_init_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/journey_action_map/genesyscloud_journey_action_map_proxy.go
+++ b/genesyscloud/journey_action_map/genesyscloud_journey_action_map_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllJourneyActionMaps(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_test.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceJourneyActionMapActionMediaTypes(t *testing.T) {

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/typeconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func flattenActionMap(d *schema.ResourceData, actionMap *platformclientv2.Actionmap) {

--- a/genesyscloud/journey_action_template/genesyscloud_journey_action_template_init_test.go
+++ b/genesyscloud/journey_action_template/genesyscloud_journey_action_template_init_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/journey_action_template/genesyscloud_journey_action_template_proxy.go
+++ b/genesyscloud/journey_action_template/genesyscloud_journey_action_template_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllJourneyActionTemplates(_ context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_test.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceJourneyActionTemplate(t *testing.T) {

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_utils.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/typeconv"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // All buildSdkPatch*  functions are helper method which maps Create operation of journeyApi's Actiontemplates

--- a/genesyscloud/journey_outcome/genesyscloud_journey_outcome_init_test.go
+++ b/genesyscloud/journey_outcome/genesyscloud_journey_outcome_init_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/journey_outcome/genesyscloud_journey_outcome_proxy.go
+++ b/genesyscloud/journey_outcome/genesyscloud_journey_outcome_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_outcome/resource_genesyscloud_journey_outcome.go
+++ b/genesyscloud/journey_outcome/resource_genesyscloud_journey_outcome.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // getAllJourneyOutcomes retrieves all journey outcomes from the Genesys Cloud platform.

--- a/genesyscloud/journey_outcome/resource_genesyscloud_journey_outcome_test.go
+++ b/genesyscloud/journey_outcome/resource_genesyscloud_journey_outcome_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceJourneyOutcome(t *testing.T) {

--- a/genesyscloud/journey_outcome/resource_genesyscloud_journey_outcome_utils.go
+++ b/genesyscloud/journey_outcome/resource_genesyscloud_journey_outcome_utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/stringmap"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func flattenContext(context *platformclientv2.Context) map[string]interface{} {

--- a/genesyscloud/journey_outcome_predictor/genesyscloud_journey_outcome_predictor_proxy.go
+++ b/genesyscloud/journey_outcome_predictor/genesyscloud_journey_outcome_predictor_proxy.go
@@ -3,7 +3,7 @@ package journey_outcome_predictor
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor.go
+++ b/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor_test.go
+++ b/genesyscloud/journey_outcome_predictor/resource_genesyscloud_journey_outcome_predictor_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceJourneyOutcomePredictor(t *testing.T) {

--- a/genesyscloud/journey_segment/genesyscloud_journey_segment_init_test.go
+++ b/genesyscloud/journey_segment/genesyscloud_journey_segment_init_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/journey_segment/genesyscloud_journey_segment_proxy.go
+++ b/genesyscloud/journey_segment/genesyscloud_journey_segment_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/journey_segment/resource_genesyscloud_journey_segment.go
+++ b/genesyscloud/journey_segment/resource_genesyscloud_journey_segment.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // getAllJourneySegments retrieves all journey segments from the Genesys Cloud platform.

--- a/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_test.go
+++ b/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceJourneySegment(t *testing.T) {

--- a/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_utils.go
+++ b/genesyscloud/journey_segment/resource_genesyscloud_journey_segment_utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/stringmap"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func flattenJourneySegment(d *schema.ResourceData, journeySegment *platformclientv2.Journeysegment) {

--- a/genesyscloud/journey_view_schedule/genesyscloud_journey_view_schedule_proxy.go
+++ b/genesyscloud/journey_view_schedule/genesyscloud_journey_view_schedule_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 )

--- a/genesyscloud/journey_view_schedule/resource_genesyscloud_journey_view_schedule.go
+++ b/genesyscloud/journey_view_schedule/resource_genesyscloud_journey_view_schedule.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"

--- a/genesyscloud/journey_view_schedule/resource_genesyscloud_journey_view_schedule_test.go
+++ b/genesyscloud/journey_view_schedule/resource_genesyscloud_journey_view_schedule_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/journey_views/genesyscloud_journey_views_proxy.go
+++ b/genesyscloud/journey_views/genesyscloud_journey_views_proxy.go
@@ -8,7 +8,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *journeyViewsProxy

--- a/genesyscloud/journey_views/resource_genesyscloud_journey_views.go
+++ b/genesyscloud/journey_views/resource_genesyscloud_journey_views.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllJourneyViews(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/journey_views/resource_genesyscloud_journey_views_test.go
+++ b/genesyscloud/journey_views/resource_genesyscloud_journey_views_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceJourneyViewsBasic(t *testing.T) {

--- a/genesyscloud/journey_views/resource_genesyscloud_journey_views_utils.go
+++ b/genesyscloud/journey_views/resource_genesyscloud_journey_views_utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildElements(d *schema.ResourceData) (*[]platformclientv2.Journeyviewelement, error) {

--- a/genesyscloud/knowledge_category/genesyscloud_knowledge_category_proxy.go
+++ b/genesyscloud/knowledge_category/genesyscloud_knowledge_category_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *knowledgeCategoryProxy

--- a/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category.go
+++ b/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllKnowledgeCategories(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_test.go
+++ b/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceKnowledgeCategoryBasic(t *testing.T) {

--- a/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_utils.go
+++ b/genesyscloud/knowledge_category/resource_genesyscloud_knowledge_category_utils.go
@@ -3,7 +3,7 @@ package knowledge_category
 import (
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildKnowledgeCategoryUpdate(categoryIn map[string]interface{}) *platformclientv2.Categoryupdaterequest {

--- a/genesyscloud/knowledge_document/genesyscloud_knowledge_document_proxy.go
+++ b/genesyscloud/knowledge_document/genesyscloud_knowledge_document_proxy.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *knowledgeDocumentProxy

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllKnowledgeDocuments(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_test.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceKnowledgeDocumentBasic(t *testing.T) {

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_utils.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_utils.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const documentIDSeparator = ","

--- a/genesyscloud/knowledge_document_variation/genesyscloud_knowledge_document_variation_proxy.go
+++ b/genesyscloud/knowledge_document_variation/genesyscloud_knowledge_document_variation_proxy.go
@@ -9,7 +9,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"time"
 )

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const variationIdSeparator = " "

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_test.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceKnowledgeDocumentVariationBasic(t *testing.T) {

--- a/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_utils.go
+++ b/genesyscloud/knowledge_document_variation/resource_genesyscloud_knowledge_document_variation_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildDocumentContentListBlocks(blocksIn map[string]interface{}) *[]platformclientv2.Documentlistcontentblock {

--- a/genesyscloud/knowledge_knowledgebase/genesyscloud_knowledge_knowledgebase_init_test.go
+++ b/genesyscloud/knowledge_knowledgebase/genesyscloud_knowledge_knowledgebase_init_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 )
 

--- a/genesyscloud/knowledge_knowledgebase/genesyscloud_knowledge_knowledgebase_proxy.go
+++ b/genesyscloud/knowledge_knowledgebase/genesyscloud_knowledge_knowledgebase_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *knowledgebaseProxy

--- a/genesyscloud/knowledge_knowledgebase/resource_genesyscloud_knowledge_knowledgebase.go
+++ b/genesyscloud/knowledge_knowledgebase/resource_genesyscloud_knowledge_knowledgebase.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllKnowledgeKnowledgebases(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/knowledge_knowledgebase/resource_genesyscloud_knowledge_knowledgebase_test.go
+++ b/genesyscloud/knowledge_knowledgebase/resource_genesyscloud_knowledge_knowledgebase_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceKnowledgeKnowledgebaseBasic(t *testing.T) {

--- a/genesyscloud/knowledge_label/data_source_genesyscloud_knowledge_label.go
+++ b/genesyscloud/knowledge_label/data_source_genesyscloud_knowledge_label.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func dataSourceKnowledgeLabelRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/knowledge_label/genesyscloud_knowledge_label_proxy.go
+++ b/genesyscloud/knowledge_label/genesyscloud_knowledge_label_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *knowledgeLabelProxy

--- a/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label.go
+++ b/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllKnowledgeLabels(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_test.go
+++ b/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceKnowledgeLabelBasic(t *testing.T) {

--- a/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_utils.go
+++ b/genesyscloud/knowledge_label/resource_genesyscloud_knowledge_label_utils.go
@@ -1,7 +1,7 @@
 package knowledge_label
 
 import (
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildKnowledgeLabel(labelIn map[string]interface{}) platformclientv2.Labelcreaterequest {

--- a/genesyscloud/location/data_source_genesyscloud_location.go
+++ b/genesyscloud/location/data_source_genesyscloud_location.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func dataSourceLocationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/location/genesyscloud_location_proxy.go
+++ b/genesyscloud/location/genesyscloud_location_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *locationProxy

--- a/genesyscloud/location/resource_genesyscloud_location.go
+++ b/genesyscloud/location/resource_genesyscloud_location.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllLocations(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/location/resource_genesyscloud_location_test.go
+++ b/genesyscloud/location/resource_genesyscloud_location_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceLocationBasic(t *testing.T) {

--- a/genesyscloud/location/resource_genesyscloud_location_utils.go
+++ b/genesyscloud/location/resource_genesyscloud_location_utils.go
@@ -9,7 +9,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/mrmo/exporter/main_test.go
+++ b/genesyscloud/mrmo/exporter/main_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccExport(t *testing.T) {

--- a/genesyscloud/mrmo/exporter/utils.go
+++ b/genesyscloud/mrmo/exporter/utils.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 )
 

--- a/genesyscloud/mrmo/mrmo.go
+++ b/genesyscloud/mrmo/mrmo.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"sync"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var CacheFile = "/shared-cache.json"

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_proxy.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_proxy.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"sync"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *oauthClientProxy

--- a/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_utils.go
+++ b/genesyscloud/oauth_client/resource_genesyscloud_oauth_client_utils.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildOAuthRedirectURIs(d *schema.ResourceData) *[]string {

--- a/genesyscloud/oauth_client/resource_genesyscloude_oauth_client_unit_test.go
+++ b/genesyscloud/oauth_client/resource_genesyscloude_oauth_client_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/organization_authentication_settings/genesyscloud_organization_authentication_settings_proxy.go
+++ b/genesyscloud/organization_authentication_settings/genesyscloud_organization_authentication_settings_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_utils.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/organization_presence_definition/genesyscloud_organization_presence_definition_proxy.go
+++ b/genesyscloud/organization_presence_definition/genesyscloud_organization_presence_definition_proxy.go
@@ -3,7 +3,7 @@ package organization_presence_definition
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition.go
+++ b/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition_test.go
+++ b/genesyscloud/organization_presence_definition/resource_genesyscloud_organization_presence_definition_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/orgauthorization_pairing/genesyscloud_orgauthorization_pairing_proxy.go
+++ b/genesyscloud/orgauthorization_pairing/genesyscloud_orgauthorization_pairing_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *orgauthorizationPairingProxy

--- a/genesyscloud/orgauthorization_pairing/resource_genesyscloud_orgauthorization_pairing.go
+++ b/genesyscloud/orgauthorization_pairing/resource_genesyscloud_orgauthorization_pairing.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func createOrgauthorizationPairing(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/data_source_genesyscloud_outbound_attempt_limit.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func DataSourceOutboundAttemptLimit() *schema.Resource {

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const (

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // func init() {

--- a/genesyscloud/outbound_callabletimeset/genesyscloud_outbound_callabletimeset_proxy.go
+++ b/genesyscloud/outbound_callabletimeset/genesyscloud_outbound_callabletimeset_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_test.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundCallabletimeset(t *testing.T) {

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_utils.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callanalysisresponseset/genesyscloud_outbound_callanalysisresponseset_proxy.go
+++ b/genesyscloud/outbound_callanalysisresponseset/genesyscloud_outbound_callanalysisresponseset_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_test.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundCallAnalysisResponseSet(t *testing.T) {

--- a/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_utils.go
+++ b/genesyscloud/outbound_callanalysisresponseset/resource_genesyscloud_outbound_callanalysisresponseset_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getResponseSetFromResourceData(d *schema.ResourceData) platformclientv2.Responseset {

--- a/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
+++ b/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_init_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/scripts"
 	telephonyProvidersEdgesSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_proxy.go
+++ b/genesyscloud/outbound_campaign/genesyscloud_outbound_campaign_proxy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_test.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // Add a special generator DEVENGAGE-1646.  Basically, the API makes it look like you need a full phone_columns field here.  However, the API ignores the type because the devs reused the phone_columns object.  However,

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaignrule/data_source_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/outbound_campaignrule/data_source_genesyscloud_outbound_campaignrule.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func dataSourceOutboundCampaignruleRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/outbound_campaignrule/genesyscloud_outbound_campaignrule_proxy.go
+++ b/genesyscloud/outbound_campaignrule/genesyscloud_outbound_campaignrule_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllAuthCampaignRules(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_test.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundCampaignRuleBasic(t *testing.T) {

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_utils.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_utils.go
@@ -5,7 +5,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getCampaignruleFromResourceData(d *schema.ResourceData) platformclientv2.Campaignrule {

--- a/genesyscloud/outbound_contact_list/genesyscloud_outbound_contact_list_proxy.go
+++ b/genesyscloud/outbound_contact_list/genesyscloud_outbound_contact_list_proxy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllOutboundContactLists(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_test.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/aws/localstack"
 	localStackEnv "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/aws/localstack/environment"

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSdkOutboundContactListContactPhoneNumberColumnSlice(contactPhoneNumberColumn *schema.Set) *[]platformclientv2.Contactphonenumbercolumn {

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils_test.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils_test.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestContactListBuildSdkOutboundContactListContactPhoneNumberColumnSlice(t *testing.T) {

--- a/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
+++ b/genesyscloud/outbound_contact_list_contact/genesyscloud_outbound_contact_list_contact_proxy.go
@@ -8,7 +8,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var contactCache = rc.NewResourceCache[platformclientv2.Dialercontact]()

--- a/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
+++ b/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func createOutboundContactListContact(ctx context.Context, d *schema.ResourceData, meta any) diag.Diagnostics {

--- a/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact_utils.go
+++ b/genesyscloud/outbound_contact_list_contact/resource_genesyscloud_outbound_contact_list_contact_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // buildWritableContactFromResourceData used to build the request body for contact creation

--- a/genesyscloud/outbound_contact_list_template/genesyscloud_outbound_contact_list_template_proxy.go
+++ b/genesyscloud/outbound_contact_list_template/genesyscloud_outbound_contact_list_template_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllOutboundContactListTemplates(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_test.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundContactListTemplateBasic(t *testing.T) {

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_utils.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSdkOutboundContactListTemplateContactPhoneNumberColumnSlice(contactPhoneNumberColumn *schema.Set) *[]platformclientv2.Contactphonenumbercolumn {

--- a/genesyscloud/outbound_contactlistfilter/genesyscloud_outbound_contactlistfilter_proxy.go
+++ b/genesyscloud/outbound_contactlistfilter/genesyscloud_outbound_contactlistfilter_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter.go
+++ b/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_test.go
+++ b/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundContactListFilter(t *testing.T) {

--- a/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_utils.go
+++ b/genesyscloud/outbound_contactlistfilter/resource_genesyscloud_outbound_contactlistfilter_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getContactlistfilterFromResourceData(d *schema.ResourceData) platformclientv2.Contactlistfilter {

--- a/genesyscloud/outbound_digitalruleset/genesyscloud_outbound_digitalruleset_proxy.go
+++ b/genesyscloud/outbound_digitalruleset/genesyscloud_outbound_digitalruleset_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_test.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_utils.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_utils.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_dnclist/genesyscloud_outbound_dnclist_proxy.go
+++ b/genesyscloud/outbound_dnclist/genesyscloud_outbound_dnclist_proxy.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *outboundDnclistProxy

--- a/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist.go
+++ b/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllOutboundDncLists(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_test.go
+++ b/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundDncListRdsListType(t *testing.T) {

--- a/genesyscloud/outbound_filespecificationtemplate/genesyscloud_outbound_filespecificationtemplate_proxy.go
+++ b/genesyscloud/outbound_filespecificationtemplate/genesyscloud_outbound_filespecificationtemplate_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate.go
+++ b/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllFileSpecificationTemplates(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_test.go
+++ b/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundFileSpecificationTemplate(t *testing.T) {

--- a/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_utils.go
+++ b/genesyscloud/outbound_filespecificationtemplate/resource_genesyscloud_outbound_filespecificationtemplate_utils.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getFilespecificationtemplateFromResourceData(d *schema.ResourceData) platformclientv2.Filespecificationtemplate {

--- a/genesyscloud/outbound_messagingcampaign/data_source_genesyscloud_outbound_messagingcampaign_test.go
+++ b/genesyscloud/outbound_messagingcampaign/data_source_genesyscloud_outbound_messagingcampaign_test.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_messagingcampaign/genesyscloud_outbound_messagingcampaign_proxy.go
+++ b/genesyscloud/outbound_messagingcampaign/genesyscloud_outbound_messagingcampaign_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 )

--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_test.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	obCallableTimeset "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/outbound_callabletimeset"
 	obContactList "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/outbound_contact_list"
@@ -834,7 +834,7 @@ func CheckOutboundDomainExists(id string) error {
 	routingApi := platformclientv2.NewRoutingApiWithConfig(config)
 
 	log.Printf("Checking if outbound domain (%s) exists", id)
-	outboundDomain, resp, err := routingApi.GetRoutingEmailOutboundDomain(id)
+	outboundDomain, resp, err := routingApi.GetRoutingEmailOutboundDomain(id, "")
 	if err != nil && resp.StatusCode != http.StatusNotFound {
 		return fmt.Errorf("error getting outbound domain (%s): %v", id, err)
 	}
@@ -847,7 +847,7 @@ func CheckOutboundDomainExists(id string) error {
 	if resp.StatusCode == 404 {
 		// outbound domain for test does not exist so create it
 		log.Printf("Outbound domain (%s) does not exist. Creating...", id)
-		_, _, postErr := routingApi.PostRoutingEmailOutboundDomains(platformclientv2.Outbounddomainrequest{
+		_, _, postErr := routingApi.PostRoutingEmailOutboundDomains(platformclientv2.Outbounddomaincreaterequest{
 			Id: &id,
 		})
 		if postErr != nil {

--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_utils.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"

--- a/genesyscloud/outbound_ruleset/genesyscloud_outbound_ruleset_proxy.go
+++ b/genesyscloud/outbound_ruleset/genesyscloud_outbound_ruleset_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_test.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	obContactList "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/outbound_contact_list"
 )

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_unit_test.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_unit_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestUnitDoesRuleConditionsRefDeletedSkill(t *testing.T) {

--- a/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_utils.go
+++ b/genesyscloud/outbound_ruleset/resource_genesyscloud_outbound_ruleset_utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_init_test.go
+++ b/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_init_test.go
@@ -17,7 +17,7 @@ import (
 
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_proxy.go
+++ b/genesyscloud/outbound_sequence/genesyscloud_outbound_sequence_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_test.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceOutboundSequence(t *testing.T) {

--- a/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_utils.go
+++ b/genesyscloud/outbound_sequence/resource_genesyscloud_outbound_sequence_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_settings/genesyscloud_outbound_settings_proxy.go
+++ b/genesyscloud/outbound_settings/genesyscloud_outbound_settings_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_utils.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_utils.go
@@ -6,7 +6,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildOutboundSettingsAutomaticTimeZoneMapping(d *schema.ResourceData) *platformclientv2.Automatictimezonemappingsettings {

--- a/genesyscloud/outbound_wrapupcode_mappings/genesyscloud_wrapupcode_mappings_proxy.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/genesyscloud_wrapupcode_mappings_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *outboundWrapupCodeMappingsProxy

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcode_mappings_utils.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcode_mappings_utils.go
@@ -4,7 +4,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // flattenOutboundWrapupCodeMappings maps a Genesys Cloud Wrapupcodemapping to a schema.Set

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // getOutboundWrapupCodeMappings is used by the exporter to return all wrapupcode mappings

--- a/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/data_source_genesyscloud_processautomation_trigger.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type ProcessAutomationTriggers struct {

--- a/genesyscloud/process_automation_trigger/process_automation_triggers_proxy.go
+++ b/genesyscloud/process_automation_trigger/process_automation_triggers_proxy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func postProcessAutomationTrigger(pat *ProcessAutomationTrigger, api *platformclientv2.IntegrationsApi) (*ProcessAutomationTrigger, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
+++ b/genesyscloud/process_automation_trigger/process_automations_triggers_struct.go
@@ -3,7 +3,7 @@ package process_automation_trigger
 import (
 	"encoding/json"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type ProcessAutomationTrigger struct {

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger.go
@@ -14,7 +14,7 @@ import (
 
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
+++ b/genesyscloud/process_automation_trigger/resource_genesyscloud_processautomation_trigger_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceProcessAutomationTrigger(t *testing.T) {

--- a/genesyscloud/provider/division.go
+++ b/genesyscloud/provider/division.go
@@ -4,7 +4,7 @@ import (
 	"sync"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type JsonMap map[string]interface{}

--- a/genesyscloud/provider/provider.go
+++ b/genesyscloud/provider/provider.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func init() {

--- a/genesyscloud/provider/sdk_client_pool.go
+++ b/genesyscloud/provider/sdk_client_pool.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const (

--- a/genesyscloud/provider/sdk_client_pool_test.go
+++ b/genesyscloud/provider/sdk_client_pool_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/quality_forms_evaluation/genesyscloud_quality_forms_evaluation_proxy.go
+++ b/genesyscloud/quality_forms_evaluation/genesyscloud_quality_forms_evaluation_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/quality_forms_evaluation/resource_genesyscloud_quality_forms_evaluation.go
+++ b/genesyscloud/quality_forms_evaluation/resource_genesyscloud_quality_forms_evaluation.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // getAllEvaluationForms retrieves all evaluation forms from Genesys Cloud

--- a/genesyscloud/quality_forms_evaluation/resource_genesyscloud_quality_forms_evaluation_test.go
+++ b/genesyscloud/quality_forms_evaluation/resource_genesyscloud_quality_forms_evaluation_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceEvaluationFormBasic(t *testing.T) {

--- a/genesyscloud/quality_forms_evaluation/resource_genesyscloud_quality_forms_evaluation_utils.go
+++ b/genesyscloud/quality_forms_evaluation/resource_genesyscloud_quality_forms_evaluation_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSdkQuestionGroups(d *schema.ResourceData) *[]platformclientv2.Evaluationquestiongroup {

--- a/genesyscloud/quality_forms_survey/genesyscloud_quality_forms_survey_init_test.go
+++ b/genesyscloud/quality_forms_survey/genesyscloud_quality_forms_survey_init_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/quality_forms_survey/genesyscloud_quality_forms_survey_proxy.go
+++ b/genesyscloud/quality_forms_survey/genesyscloud_quality_forms_survey_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/quality_forms_survey/resource_genesyscloud_quality_forms_survey.go
+++ b/genesyscloud/quality_forms_survey/resource_genesyscloud_quality_forms_survey.go
@@ -15,7 +15,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type SurveyFormStruct struct {

--- a/genesyscloud/quality_forms_survey/resource_genesyscloud_quality_forms_survey_test.go
+++ b/genesyscloud/quality_forms_survey/resource_genesyscloud_quality_forms_survey_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceSurveyFormBasic(t *testing.T) {

--- a/genesyscloud/quality_forms_survey/resource_genesyscloud_quality_forms_survey_utils.go
+++ b/genesyscloud/quality_forms_survey/resource_genesyscloud_quality_forms_survey_utils.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSurveyQuestionGroups(d *schema.ResourceData) (*[]platformclientv2.Surveyquestiongroup, diag.Diagnostics) {

--- a/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_init_test.go
+++ b/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_init_test.go
@@ -21,7 +21,7 @@ import (
 	userRoles "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user_roles"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_proxy.go
+++ b/genesyscloud/recording_media_retention_policy/genesyscloud_recording_media_retention_policy_proxy.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_test.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*
@@ -2642,7 +2642,7 @@ func CleanupRoutingEmailDomains(prefix string) error {
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "")
+		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "", "")
 		if getErr != nil {
 			return fmt.Errorf("failed to get page %v of routing email domains: %v", pageNum, getErr)
 		}

--- a/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_utils.go
+++ b/genesyscloud/recording_media_retention_policy/resource_genesyscloud_recording_media_retention_policy_utils.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*
@@ -925,10 +925,10 @@ func buildCallMediaPolicyConditions(callMediaPolicyConditions []interface{}) *pl
 		idStrings = append(idStrings, fmt.Sprintf("%v", id))
 	}
 
-	forUsers := make([]platformclientv2.User, 0)
+	forUsers := make([]platformclientv2.Policyuser, 0)
 	for _, id := range idStrings {
 		userId := id
-		forUsers = append(forUsers, platformclientv2.User{Id: &userId})
+		forUsers = append(forUsers, platformclientv2.Policyuser{Id: &userId})
 	}
 
 	wrapupCodeIds := conditionsMap["wrapup_code_ids"].([]interface{})
@@ -1052,10 +1052,10 @@ func buildChatMediaPolicyConditions(chatMediaPolicyConditions []interface{}) *pl
 		idStrings = append(idStrings, fmt.Sprintf("%v", id))
 	}
 
-	forUsers := make([]platformclientv2.User, 0)
+	forUsers := make([]platformclientv2.Policyuser, 0)
 	for _, id := range idStrings {
 		userId := id
-		forUsers = append(forUsers, platformclientv2.User{Id: &userId})
+		forUsers = append(forUsers, platformclientv2.Policyuser{Id: &userId})
 	}
 
 	wrapupCodeIds := conditionsMap["wrapup_code_ids"].([]interface{})
@@ -1178,10 +1178,10 @@ func buildEmailMediaPolicyConditions(emailMediaPolicyConditions []interface{}) *
 		idStrings = append(idStrings, fmt.Sprintf("%v", id))
 	}
 
-	forUsers := make([]platformclientv2.User, 0)
+	forUsers := make([]platformclientv2.Policyuser, 0)
 	for _, id := range idStrings {
 		userId := id
-		forUsers = append(forUsers, platformclientv2.User{Id: &userId})
+		forUsers = append(forUsers, platformclientv2.Policyuser{Id: &userId})
 	}
 
 	wrapupCodeIds := conditionsMap["wrapup_code_ids"].([]interface{})
@@ -1312,10 +1312,10 @@ func buildMessageMediaPolicyConditions(messageMediaPolicyConditions []interface{
 		idStrings = append(idStrings, fmt.Sprintf("%v", id))
 	}
 
-	forUsers := make([]platformclientv2.User, 0)
+	forUsers := make([]platformclientv2.Policyuser, 0)
 	for _, id := range idStrings {
 		userId := id
-		forUsers = append(forUsers, platformclientv2.User{Id: &userId})
+		forUsers = append(forUsers, platformclientv2.Policyuser{Id: &userId})
 	}
 
 	wrapupCodeIds := conditionsMap["wrapup_code_ids"].([]interface{})
@@ -1676,10 +1676,10 @@ func buildConditions(d *schema.ResourceData) *platformclientv2.Policyconditions 
 			idStrings = append(idStrings, fmt.Sprintf("%v", id))
 		}
 
-		forUsers := make([]platformclientv2.User, 0)
+		forUsers := make([]platformclientv2.Policyuser, 0)
 		for _, id := range idStrings {
 			userId := id
-			forUsers = append(forUsers, platformclientv2.User{Id: &userId})
+			forUsers = append(forUsers, platformclientv2.Policyuser{Id: &userId})
 		}
 
 		wrapupCodeIds := conditionsMap["wrapup_code_ids"].([]interface{})

--- a/genesyscloud/resource_cache/datasource_cache.go
+++ b/genesyscloud/resource_cache/datasource_cache.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // Cache for Data Sources

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 

--- a/genesyscloud/resource_exporter/resource_exporter_custom.go
+++ b/genesyscloud/resource_exporter/resource_exporter_custom.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/resource_genesyscloud_init_test.go
+++ b/genesyscloud/resource_genesyscloud_init_test.go
@@ -28,7 +28,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/responsemanagement_library/genesyscloud_responsemanagement_library_proxy.go
+++ b/genesyscloud/responsemanagement_library/genesyscloud_responsemanagement_library_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library.go
+++ b/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library_test.go
+++ b/genesyscloud/responsemanagement_library/resource_genesyscloud_responsemanagement_library_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceResponseManagementLibrary(t *testing.T) {

--- a/genesyscloud/responsemanagement_response/genesyscloud_responsemanagement_response_proxy.go
+++ b/genesyscloud/responsemanagement_response/genesyscloud_responsemanagement_response_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response.go
@@ -16,7 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_test.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceResponseManagementResponseFooterField(t *testing.T) {

--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_utils.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getResponseFromResourceData(d *schema.ResourceData) platformclientv2.Response {

--- a/genesyscloud/responsemanagement_responseasset/genesyscloud_responsemanagement_responseasset_proxy.go
+++ b/genesyscloud/responsemanagement_responseasset/genesyscloud_responsemanagement_responseasset_proxy.go
@@ -15,7 +15,7 @@ import (
 
 	"io"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_test.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceResponseManagementResponseAsset(t *testing.T) {

--- a/genesyscloud/routing_email_domain/data_source_genesyscloud_routing_email_domain_test.go
+++ b/genesyscloud/routing_email_domain/data_source_genesyscloud_routing_email_domain_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccDataSourceRoutingEmailDomain(t *testing.T) {
@@ -64,7 +64,7 @@ func CleanupRoutingEmailDomains() {
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "")
+		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "", "")
 		if getErr != nil {
 			log.Printf("failed to get page %v of routing email domains: %v", pageNum, getErr)
 			return

--- a/genesyscloud/routing_email_domain/genesyscloud_routing_email_domain_proxy.go
+++ b/genesyscloud/routing_email_domain/genesyscloud_routing_email_domain_proxy.go
@@ -3,10 +3,11 @@ package routing_email_domain
 import (
 	"context"
 	"fmt"
-	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
+
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *routingEmailDomainProxy
@@ -93,7 +94,7 @@ func getAllRoutingEmailDomainsFn(ctx context.Context, p *routingEmailDomainProxy
 		response   *platformclientv2.APIResponse
 	)
 
-	domains, resp, err := p.routingApi.GetRoutingEmailDomains(pageSize, 1, false, "")
+	domains, resp, err := p.routingApi.GetRoutingEmailDomains(pageSize, 1, false, "", "")
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to get routing email domains error: %s", err)
 	}
@@ -104,7 +105,7 @@ func getAllRoutingEmailDomainsFn(ctx context.Context, p *routingEmailDomainProxy
 	allDomains = append(allDomains, *domains.Entities...)
 
 	for pageNum := 2; pageNum <= *domains.PageCount; pageNum++ {
-		domains, resp, err := p.routingApi.GetRoutingEmailDomains(pageSize, pageNum, false, "")
+		domains, resp, err := p.routingApi.GetRoutingEmailDomains(pageSize, pageNum, false, "", "")
 		if err != nil {
 			return nil, resp, fmt.Errorf("failed to get routing email domains error: %s", err)
 		}
@@ -123,14 +124,20 @@ func getAllRoutingEmailDomainsFn(ctx context.Context, p *routingEmailDomainProxy
 }
 
 func createRoutingEmailDomainFn(ctx context.Context, p *routingEmailDomainProxy, routingEmailDomain *platformclientv2.Inbounddomain) (*platformclientv2.Inbounddomain, *platformclientv2.APIResponse, error) {
-	return p.routingApi.PostRoutingEmailDomains(*routingEmailDomain)
+	request := platformclientv2.Inbounddomaincreaterequest{
+		Id:               routingEmailDomain.Id,
+		SubDomain:        routingEmailDomain.SubDomain,
+		MailFromSettings: routingEmailDomain.MailFromSettings,
+		CustomSMTPServer: routingEmailDomain.CustomSMTPServer,
+	}
+	return p.routingApi.PostRoutingEmailDomains(request)
 }
 
 func getRoutingEmailDomainByIdFn(ctx context.Context, p *routingEmailDomainProxy, id string) (*platformclientv2.Inbounddomain, *platformclientv2.APIResponse, error) {
 	if domain := rc.GetCacheItem(p.routingEmailDomainCache, id); domain != nil {
 		return domain, nil, nil
 	}
-	return p.routingApi.GetRoutingEmailDomain(id)
+	return p.routingApi.GetRoutingEmailDomain(id, "")
 }
 
 func getRoutingEmailDomainIdByNameFn(ctx context.Context, p *routingEmailDomainProxy, name string) (string, *platformclientv2.APIResponse, bool, error) {

--- a/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain.go
+++ b/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllRoutingEmailDomains(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain_test.go
+++ b/genesyscloud/routing_email_domain/resource_genesyscloud_routing_email_domain_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingEmailDomainSub(t *testing.T) {
@@ -111,7 +111,7 @@ func testVerifyRoutingEmailDomainDestroyed(state *terraform.State) error {
 			if rs.Type != "genesyscloud_routing_email_domain" {
 				continue
 			}
-			_, resp, err := routingAPI.GetRoutingEmailDomain(rs.Primary.ID)
+			_, resp, err := routingAPI.GetRoutingEmailDomain(rs.Primary.ID, "")
 			if err != nil {
 				if util.IsStatus404(resp) {
 					continue

--- a/genesyscloud/routing_email_route/genesyscloud_routing_email_route_proxy.go
+++ b/genesyscloud/routing_email_route/genesyscloud_routing_email_route_proxy.go
@@ -6,7 +6,7 @@ import (
 	"log"
 	"reflect"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*
@@ -123,7 +123,7 @@ func getAllRoutingEmailRouteFn(ctx context.Context, p *routingEmailRouteProxy, d
 
 	var allDomains = make([]platformclientv2.Inbounddomain, 0)
 	for pageNum := 1; ; pageNum++ {
-		domains, resp, err := p.routingApi.GetRoutingEmailDomains(pageSize, pageNum, false, domainId)
+		domains, resp, err := p.routingApi.GetRoutingEmailDomains(pageSize, pageNum, false, domainId, "")
 		apiResponse = resp
 		if err != nil {
 			return nil, resp, fmt.Errorf("failed to get routing email domains: %s", err.Error())

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingEmailRoute(t *testing.T) {
@@ -368,7 +368,7 @@ func CleanupRoutingEmailDomains() {
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "")
+		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "", "")
 		if getErr != nil {
 			log.Printf("failed to get page %v of routing email domains: %v", pageNum, getErr)
 			return

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_unit_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_unit_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // TestUnitGetAllRoutingEmailRoutes verifies that errors are returned properly and most importantly that no nil pointer

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_language/genesyscloud_routing_language_proxy.go
+++ b/genesyscloud/routing_language/genesyscloud_routing_language_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *routingLanguageProxy

--- a/genesyscloud/routing_language/resource_genesyscloud_routing_language.go
+++ b/genesyscloud/routing_language/resource_genesyscloud_routing_language.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllRoutingLanguages(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_language/resource_genesyscloud_routing_language_test.go
+++ b/genesyscloud/routing_language/resource_genesyscloud_routing_language_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingLanguageBasic(t *testing.T) {

--- a/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 

--- a/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
+++ b/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/delay"
 )
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var bullseyeExpansionTypeTimeout = "TIMEOUT_SECONDS"

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_members.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_members.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var ctx = context.Background()

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_members_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_members_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // Build Functions

--- a/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_proxy.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_utils.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/genesyscloud_routing_queue_conditional_group_routing_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildConditionalGroupRouting(rules []interface{}) ([]platformclientv2.Conditionalgrouproutingrule, error) {

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_test.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing_unit_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestUnitBuildConditionalGroupRouting(t *testing.T) {

--- a/genesyscloud/routing_queue_outbound_email_address/genesyscloud_routing_queue_outbound_email_address_proxy.go
+++ b/genesyscloud/routing_queue_outbound_email_address/genesyscloud_routing_queue_outbound_email_address_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_test.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingQueueOutboundEmailAddress(t *testing.T) {
@@ -262,7 +262,7 @@ func cleanupRoutingEmailDomains() {
 
 	for pageNum := 1; ; pageNum++ {
 		const pageSize = 100
-		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "")
+		routingEmailDomains, _, getErr := routingAPI.GetRoutingEmailDomains(pageSize, pageNum, false, "", "")
 		if getErr != nil {
 			log.Printf("failed to get page %v of routing email domains: %v", pageNum, getErr)
 			return

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_unit_test.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_unit_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils.go
@@ -1,6 +1,6 @@
 package routing_queue_outbound_email_address
 
-import "github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+import "github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 func isQueueEmailAddressEmpty(qea *platformclientv2.Queueemailaddress) bool {
 	if qea == nil {

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils_unit_test.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address_utils_unit_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/routing_settings/genesyscloud_routing_settings_proxy.go
+++ b/genesyscloud/routing_settings/genesyscloud_routing_settings_proxy.go
@@ -3,7 +3,7 @@ package routing_settings
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *routingSettingsProxy

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllRoutingSettings(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_skill/genesyscloud_routing_skill_proxy.go
+++ b/genesyscloud/routing_skill/genesyscloud_routing_skill_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type getAllRoutingSkillsFunc func(ctx context.Context, p *routingSkillProxy, name string) (*[]platformclientv2.Routingskill, *platformclientv2.APIResponse, error)

--- a/genesyscloud/routing_skill/resource_genesyscloud_routing_skill.go
+++ b/genesyscloud/routing_skill/resource_genesyscloud_routing_skill.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func GetAllRoutingSkills(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_skill/resource_genesyscloud_routing_skill_test.go
+++ b/genesyscloud/routing_skill/resource_genesyscloud_routing_skill_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingSkillBasic(t *testing.T) {

--- a/genesyscloud/routing_skill_group/genesyscloud_routing_skill_group_init_test.go
+++ b/genesyscloud/routing_skill_group/genesyscloud_routing_skill_group_init_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud"
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"

--- a/genesyscloud/routing_skill_group/genesyscloud_routing_skill_group_proxy.go
+++ b/genesyscloud/routing_skill_group/genesyscloud_routing_skill_group_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type getAllRoutingSkillGroupsFunc func(ctx context.Context, p *routingSkillGroupsProxy, name string) (*[]platformclientv2.Skillgroupdefinition, *platformclientv2.APIResponse, error)

--- a/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group.go
+++ b/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllRoutingSkillGroups(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group_test.go
+++ b/genesyscloud/routing_skill_group/resource_genesyscloud_routing_skill_group_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func testAccCheckSkillConditions(resourcePath string, targetSkillConditionJson string) resource.TestCheckFunc {

--- a/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_proxy.go
+++ b/genesyscloud/routing_sms_addresses/genesyscloud_routing_sms_addresses_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // Type definitions for each func on our proxy so we can easily mock them out later

--- a/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
+++ b/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const ResourceType = "genesyscloud_routing_sms_address"

--- a/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses_test.go
+++ b/genesyscloud/routing_sms_addresses/resource_genesyscloud_routing_sms_addresses_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingSmsAddresses(t *testing.T) {

--- a/genesyscloud/routing_utilization/genesyscloud_routing_utilization_proxy.go
+++ b/genesyscloud/routing_utilization/genesyscloud_routing_utilization_proxy.go
@@ -3,7 +3,7 @@ package routing_utilization
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *routingUtilizationProxy

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
@@ -17,7 +17,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllRoutingUtilization(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingUtilizationBasic(t *testing.T) {

--- a/genesyscloud/routing_utilization/resource_routing_utilization_utils.go
+++ b/genesyscloud/routing_utilization/resource_routing_utilization_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func BuildSdkMediaUtilizations(d *schema.ResourceData) *map[string]platformclientv2.Mediautilization {

--- a/genesyscloud/routing_utilization_label/data_source_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/routing_utilization_label/data_source_genesyscloud_routing_utilization_label_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccDataSourceRoutingUtilizationLabel(t *testing.T) {

--- a/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_init_test.go
+++ b/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_init_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_proxy.go
+++ b/genesyscloud/routing_utilization_label/genesyscloud_routing_utilization_label_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *routingUtilizationLabelProxy

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllRoutingUtilizationLabels(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingUtilizationLabelBasic(t *testing.T) {

--- a/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_utils.go
+++ b/genesyscloud/routing_utilization_label/resource_genesyscloud_routing_utilization_label_utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func GenerateRoutingUtilizationLabelResource(resourceLabel string, name string, dependsOnResource string) string {

--- a/genesyscloud/routing_wrapupcode/genesyscloud_routing_wrapupcode_proxy.go
+++ b/genesyscloud/routing_wrapupcode/genesyscloud_routing_wrapupcode_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode.go
+++ b/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllRoutingWrapupCodes(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode_test.go
+++ b/genesyscloud/routing_wrapupcode/resource_genesyscloud_routing_wrapupcode_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceRoutingWrapupcode(t *testing.T) {

--- a/genesyscloud/scripts/data_source_genesyscloud_script.go
+++ b/genesyscloud/scripts/data_source_genesyscloud_script.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 

--- a/genesyscloud/scripts/genesyscloud_scripts_proxy.go
+++ b/genesyscloud/scripts/genesyscloud_scripts_proxy.go
@@ -15,7 +15,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/scripts/resource_genesyscloud_script.go
+++ b/genesyscloud/scripts/resource_genesyscloud_script.go
@@ -14,7 +14,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/genesyscloud/scripts/resource_genesyscloud_script_test.go
+++ b/genesyscloud/scripts/resource_genesyscloud_script_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceScriptBasic(t *testing.T) {

--- a/genesyscloud/station/genesyscloud_station_init_test.go
+++ b/genesyscloud/station/genesyscloud_station_init_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	gcloud "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud"
 	edgePhone "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_phone"

--- a/genesyscloud/station/genesyscloud_station_proxy.go
+++ b/genesyscloud/station/genesyscloud_station_proxy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // internalProxy holds a proxy instance that can be used throughout the package

--- a/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
+++ b/genesyscloud/task_management_workbin/genesyscloud_task_management_workbin_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin.go
+++ b/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin_test.go
+++ b/genesyscloud/task_management_workbin/resource_genesyscloud_task_management_workbin_test.go
@@ -13,7 +13,7 @@ import (
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem/genesyscloud_task_management_workitem_proxy.go
+++ b/genesyscloud/task_management_workitem/genesyscloud_task_management_workitem_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*
@@ -235,7 +235,7 @@ func getTaskManagementWorkitemByIdFn(ctx context.Context, p *taskManagementWorki
 		return workitem, nil, nil
 	}
 
-	return p.taskManagementApi.GetTaskmanagementWorkitem(id, "")
+	return p.taskManagementApi.GetTaskmanagementWorkitem(id, []string{})
 }
 
 // updateTaskManagementWorkitemFn is an implementation of the function to update a Genesys Cloud task management workitem

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_test.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_test.go
@@ -31,7 +31,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*
@@ -658,7 +658,7 @@ func testVerifyTaskManagementWorkitemDestroyed(state *terraform.State) error {
 			continue
 		}
 
-		worktype, resp, err := taskMgmtApi.GetTaskmanagementWorkitem(rs.Primary.ID, "")
+		worktype, resp, err := taskMgmtApi.GetTaskmanagementWorkitem(rs.Primary.ID, []string{})
 		if worktype != nil {
 			return fmt.Errorf("task management workitem (%s) still exists", rs.Primary.ID)
 		} else if util.IsStatus404(resp) {

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_unit_test.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_unit_test.go
@@ -17,7 +17,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_utils.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_utils.go
@@ -12,7 +12,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem_schema/genesyscloud_task_management_workitem_schema_proxy.go
+++ b/genesyscloud/task_management_workitem_schema/genesyscloud_task_management_workitem_schema_proxy.go
@@ -10,7 +10,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_test.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_test.go
@@ -16,7 +16,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_unit_test.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_unit_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_utils.go
+++ b/genesyscloud/task_management_workitem_schema/resource_genesyscloud_task_management_workitem_schema_utils.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const (

--- a/genesyscloud/task_management_worktype/genesyscloud_task_management_worktype_proxy.go
+++ b/genesyscloud/task_management_worktype/genesyscloud_task_management_worktype_proxy.go
@@ -6,7 +6,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_test.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_test.go
@@ -21,7 +21,7 @@ import (
 	workitemSchema "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/task_management_workitem_schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_utils.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_flow_datebased_rule/genesyscloud_task_management_datebased_rule_proxy.go
+++ b/genesyscloud/task_management_worktype_flow_datebased_rule/genesyscloud_task_management_datebased_rule_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	taskManagementWorktype "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/task_management_worktype"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_flow_datebased_rule/resource_genesyscloud_task_management_datebased_rule.go
+++ b/genesyscloud/task_management_worktype_flow_datebased_rule/resource_genesyscloud_task_management_datebased_rule.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_worktype_flow_datebased_rule/resource_genesyscloud_task_management_datebased_rule_test.go
+++ b/genesyscloud/task_management_worktype_flow_datebased_rule/resource_genesyscloud_task_management_datebased_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 

--- a/genesyscloud/task_management_worktype_flow_datebased_rule/resource_genesyscloud_task_management_datebased_rule_utils.go
+++ b/genesyscloud/task_management_worktype_flow_datebased_rule/resource_genesyscloud_task_management_datebased_rule_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_flow_onattributechange_rule/genesyscloud_task_management_onattributechange_rule_proxy.go
+++ b/genesyscloud/task_management_worktype_flow_onattributechange_rule/genesyscloud_task_management_onattributechange_rule_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	taskManagementWorktype "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/task_management_worktype"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_flow_onattributechange_rule/resource_genesyscloud_task_management_onattributechange_rule.go
+++ b/genesyscloud/task_management_worktype_flow_onattributechange_rule/resource_genesyscloud_task_management_onattributechange_rule.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_worktype_flow_onattributechange_rule/resource_genesyscloud_task_management_onattributechange_rule_test.go
+++ b/genesyscloud/task_management_worktype_flow_onattributechange_rule/resource_genesyscloud_task_management_onattributechange_rule_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 

--- a/genesyscloud/task_management_worktype_flow_onattributechange_rule/resource_genesyscloud_task_management_onattributechange_rule_utils.go
+++ b/genesyscloud/task_management_worktype_flow_onattributechange_rule/resource_genesyscloud_task_management_onattributechange_rule_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_flow_oncreate_rule/genesyscloud_task_management_oncreate_rule_proxy.go
+++ b/genesyscloud/task_management_worktype_flow_oncreate_rule/genesyscloud_task_management_oncreate_rule_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	taskManagementWorktype "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/task_management_worktype"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_flow_oncreate_rule/resource_genesyscloud_task_management_oncreate_rule.go
+++ b/genesyscloud/task_management_worktype_flow_oncreate_rule/resource_genesyscloud_task_management_oncreate_rule.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 

--- a/genesyscloud/task_management_worktype_flow_oncreate_rule/resource_genesyscloud_task_management_oncreate_rule_test.go
+++ b/genesyscloud/task_management_worktype_flow_oncreate_rule/resource_genesyscloud_task_management_oncreate_rule_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 

--- a/genesyscloud/task_management_worktype_flow_oncreate_rule/resource_genesyscloud_task_management_oncreate_rule_utils.go
+++ b/genesyscloud/task_management_worktype_flow_oncreate_rule/resource_genesyscloud_task_management_oncreate_rule_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_status/genesyscloud_task_management_worktype_status_proxy.go
+++ b/genesyscloud/task_management_worktype_status/genesyscloud_task_management_worktype_status_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	taskManagementWorktype "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/task_management_worktype"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status.go
+++ b/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_test.go
+++ b/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 

--- a/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_util.go
+++ b/genesyscloud/task_management_worktype_status/resource_genesyscloud_task_management_worktype_status_util.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // ModifyStatusIdStateValue will change the statusId before it is saved in the state file.

--- a/genesyscloud/task_management_worktype_status_transition/genesyscloud_task_management_worktype_status_transition_proxy.go
+++ b/genesyscloud/task_management_worktype_status_transition/genesyscloud_task_management_worktype_status_transition_proxy.go
@@ -11,7 +11,7 @@ import (
 	taskManagementWorktype "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/task_management_worktype"
 	platformUtils "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/platform"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_status_transition/resource_genesyscloud_task_management_worktype_status_transition.go
+++ b/genesyscloud/task_management_worktype_status_transition/resource_genesyscloud_task_management_worktype_status_transition.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/task_management_worktype_status_transition/resource_genesyscloud_task_management_worktype_status_transition_test.go
+++ b/genesyscloud/task_management_worktype_status_transition/resource_genesyscloud_task_management_worktype_status_transition_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/task_management_worktype_status_transition/resource_genesyscloud_task_management_worktype_status_transition_util.go
+++ b/genesyscloud/task_management_worktype_status_transition/resource_genesyscloud_task_management_worktype_status_transition_util.go
@@ -11,7 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // ModifyStatusIdStateValue will change the statusId before it is saved in the state file.

--- a/genesyscloud/team/genesyscloud_team_proxy.go
+++ b/genesyscloud/team/genesyscloud_team_proxy.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/team/resource_genesyscloud_team.go
+++ b/genesyscloud/team/resource_genesyscloud_team.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 

--- a/genesyscloud/team/resource_genesyscloud_team_test.go
+++ b/genesyscloud/team/resource_genesyscloud_team_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 

--- a/genesyscloud/team/resource_genesyscloud_team_unit_test.go
+++ b/genesyscloud/team/resource_genesyscloud_team_unit_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/team/resource_genesyscloud_team_utils.go
+++ b/genesyscloud/team/resource_genesyscloud_team_utils.go
@@ -13,7 +13,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/chunks"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // getTeamFromResourceData maps data from schema ResourceData object to a platformclientv2.Team

--- a/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_init_test.go
+++ b/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_init_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	archIvr "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/architect_ivr"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	didPool "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_did_pool"

--- a/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did/genesyscloud_telephony_providers_edges_did_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_init_test.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_init_test.go
@@ -5,7 +5,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"

--- a/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/genesyscloud_telephony_providers_edges_did_pool_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 // getAllDidPools retrieves all DID pools and is used for the exporter

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_test.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceDidPoolBasic(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_utils.go
+++ b/genesyscloud/telephony_providers_edges_did_pool/resource_genesyscloud_telephony_providers_edges_did_pool_utils.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type DidPoolStruct struct {

--- a/genesyscloud/telephony_providers_edges_edge_group/genesyscloud_telephony_providers_edges_edge_group_proxy.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/genesyscloud_telephony_providers_edges_edge_group_proxy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *edgeGroupProxy

--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func createEdgeGroup(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_test.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceEdgeGroup(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_utils.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group_utils.go
@@ -7,7 +7,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSdkTrunkBases(d *schema.ResourceData) *[]platformclientv2.Trunkbase {

--- a/genesyscloud/telephony_providers_edges_extension_pool/genesyscloud_telephony_providers_edges_extension_pool_proxy.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/genesyscloud_telephony_providers_edges_extension_pool_proxy.go
@@ -3,7 +3,7 @@ package telephony_providers_edges_extension_pool
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *extensionPoolProxy

--- a/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllExtensionPools(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_test.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceExtensionPoolBasic(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_utils.go
+++ b/genesyscloud/telephony_providers_edges_extension_pool/resource_genesyscloud_telephony_providers_edges_extension_pool_utils.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type ExtensionPoolStruct struct {

--- a/genesyscloud/telephony_providers_edges_linebasesettings/data_source_genesyscloud_telephony_providers_edges_linebasesettings.go
+++ b/genesyscloud/telephony_providers_edges_linebasesettings/data_source_genesyscloud_telephony_providers_edges_linebasesettings.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func dataSourceLineBaseSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_init_test.go
@@ -13,7 +13,7 @@ import (
 	edgeSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )

--- a/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_proxy.go
+++ b/genesyscloud/telephony_providers_edges_phone/genesyscloud_telephony_providers_edges_phone_proxy.go
@@ -8,7 +8,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllPhones(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourcePhoneBasic(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type PhoneConfig struct {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/data_source_genesyscloud_telephony_providers_edges_phonebasesettings.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/data_source_genesyscloud_telephony_providers_edges_phonebasesettings.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func dataSourcePhoneBaseSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/genesyscloud_telephony_providers_edges_phonebasesettings_proxy.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/genesyscloud_telephony_providers_edges_phonebasesettings_proxy.go
@@ -3,7 +3,7 @@ package telephony_providers_edges_phonebasesettings
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *phoneBaseProxy

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func createPhoneBaseSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_test.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourcePhoneBaseSettings(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_unit_test.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_unit_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_utils.go
+++ b/genesyscloud/telephony_providers_edges_phonebasesettings/resource_genesyscloud_telephony_providers_edges_phonebasesettings_utils.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func generatePhoneBaseSettingsDataSource(

--- a/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/data_source_genesyscloud_telephony_providers_edges_site_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site/genesyscloud_telephony_providers_edges_site_proxy.go
@@ -6,7 +6,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllSites(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_schema.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceSite(t *testing.T) {

--- a/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
+++ b/genesyscloud/telephony_providers_edges_site/resource_genesyscloud_telephony_providers_edges_site_utils.go
@@ -20,7 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/leekchan/timeutil"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/data_source_genesyscloud_telephony_providers_edges_site_outbound_route_test.go
@@ -11,7 +11,7 @@ import (
 	tbs "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_trunkbasesettings"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_init_test.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_init_test.go
@@ -13,7 +13,7 @@ import (
 	gcloud "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_proxy.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/genesyscloud_telephony_providers_edges_site_outbound_route_proxy.go
@@ -7,7 +7,7 @@ import (
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	telephonyProvidersEdgesSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllSitesAndOutboundRoutes(ctx context.Context, sdkConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_utils.go
+++ b/genesyscloud/telephony_providers_edges_site_outbound_route/resource_genesyscloud_telephony_providers_edges_site_outbound_route_utils.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildOutboundRoutes(d *schema.ResourceData) *platformclientv2.Outboundroutebase {

--- a/genesyscloud/telephony_providers_edges_trunk/data_source_genesyscloud_telephony_providers_edges_trunk.go
+++ b/genesyscloud/telephony_providers_edges_trunk/data_source_genesyscloud_telephony_providers_edges_trunk.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func dataSourceTrunkRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_trunk/genesyscloud_telephony_providers_edges_trunk_proxy.go
+++ b/genesyscloud/telephony_providers_edges_trunk/genesyscloud_telephony_providers_edges_trunk_proxy.go
@@ -3,7 +3,7 @@ package telephony_providers_edges_trunk
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 //generate a proxy for telephony_providers_edges_trunk

--- a/genesyscloud/telephony_providers_edges_trunk/resource_genesyscloud_telephony_providers_edges_trunk.go
+++ b/genesyscloud/telephony_providers_edges_trunk/resource_genesyscloud_telephony_providers_edges_trunk.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func createTrunk(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony_providers_edges_trunkbasesettings/data_source_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 

--- a/genesyscloud/telephony_providers_edges_trunkbasesettings/genesyscloud_telephony_providers_edges_trunkbasesettings_proxy.go
+++ b/genesyscloud/telephony_providers_edges_trunkbasesettings/genesyscloud_telephony_providers_edges_trunkbasesettings_proxy.go
@@ -8,7 +8,7 @@ import (
 
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *trunkbaseSettingProxy

--- a/genesyscloud/telephony_providers_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
+++ b/genesyscloud/telephony_providers_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func createTrunkBaseSettings(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {

--- a/genesyscloud/telephony_providers_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
+++ b/genesyscloud/telephony_providers_edges_trunkbasesettings/resource_genesyscloud_telephony_providers_edges_trunkbasesettings_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceTrunkBaseSettings(t *testing.T) {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -40,7 +40,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/mohae/deepcopy"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_utils_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_utils_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/hashicorp/hcl/v2/hclparse"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	architectFlow "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/architect_flow"
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 	obContactList "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/outbound_contact_list"

--- a/genesyscloud/user/data_source_genesyscloud_user.go
+++ b/genesyscloud/user/data_source_genesyscloud_user.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var (

--- a/genesyscloud/user/genesyscloud_user_proxy.go
+++ b/genesyscloud/user/genesyscloud_user_proxy.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 /*

--- a/genesyscloud/user/resource_genesyscloud_user.go
+++ b/genesyscloud/user/resource_genesyscloud_user.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type agentUtilizationWithLabels struct {

--- a/genesyscloud/user/resource_genesyscloud_user_test.go
+++ b/genesyscloud/user/resource_genesyscloud_user_test.go
@@ -24,7 +24,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceUserBasic(t *testing.T) {

--- a/genesyscloud/user/resource_genesyscloud_user_utils.go
+++ b/genesyscloud/user/resource_genesyscloud_user_utils.go
@@ -16,7 +16,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/nyaruka/phonenumbers"
 )
 

--- a/genesyscloud/user_roles/genesyscloud_user_roles_proxy.go
+++ b/genesyscloud/user_roles/genesyscloud_user_roles_proxy.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *userRolesProxy

--- a/genesyscloud/user_roles/resource_genesyscloud_user_roles_utils.go
+++ b/genesyscloud/user_roles/resource_genesyscloud_user_roles_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func flattenSubjectRoles(d *schema.ResourceData, p *userRolesProxy) (*schema.Set, *platformclientv2.APIResponse, error) {

--- a/genesyscloud/util/files/util_files.go
+++ b/genesyscloud/util/files/util_files.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type S3Uploader struct {

--- a/genesyscloud/util/resourcedata/resourcedata.go
+++ b/genesyscloud/util/resourcedata/resourcedata.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/leekchan/timeutil"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 const (

--- a/genesyscloud/util/util_basesetting_properties.go
+++ b/genesyscloud/util/util_basesetting_properties.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func BuildTelephonyProperties(d *schema.ResourceData) *map[string]interface{} {

--- a/genesyscloud/util/util_diagnostic_unit_test.go
+++ b/genesyscloud/util/util_diagnostic_unit_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/util/util_diagnostics.go
+++ b/genesyscloud/util/util_diagnostics.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type detailedDiagnosticInfo struct {

--- a/genesyscloud/util/util_divisions.go
+++ b/genesyscloud/util/util_divisions.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type JsonMap map[string]interface{}

--- a/genesyscloud/util/util_domainentities.go
+++ b/genesyscloud/util/util_domainentities.go
@@ -4,7 +4,7 @@ import (
 	lists "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func BuildSdkDomainEntityRef(d *schema.ResourceData, idAttr string) *platformclientv2.Domainentityref {

--- a/genesyscloud/util/util_retries.go
+++ b/genesyscloud/util/util_retries.go
@@ -17,7 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func WithRetries(ctx context.Context, timeout time.Duration, method func() *retry.RetryError) diag.Diagnostics {

--- a/genesyscloud/webdeployments_configuration/genesyscloud_webdeployments_configuration_proxy.go
+++ b/genesyscloud/webdeployments_configuration/genesyscloud_webdeployments_configuration_proxy.go
@@ -10,7 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *webDeploymentsConfigurationProxy

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllWebDeploymentConfigurations(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 type scCustomMessageConfig struct {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_journey.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_journey.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSelectorEventTriggers(triggers []interface{}) *[]platformclientv2.Selectoreventtrigger {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_messenger.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_messenger.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/lists"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildAppConversations(conversations []interface{}) *platformclientv2.Conversationappsettings {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_support_center.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_support_center.go
@@ -4,7 +4,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildSupportCenterHeroStyle(styles []interface{}) *platformclientv2.Supportcenterherostyle {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
@@ -8,7 +8,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func buildCobrowseSettings(d *schema.ResourceData) *platformclientv2.Cobrowsesettings {

--- a/genesyscloud/webdeployments_deployment/genesyscloud_webdeployments_deployment_proxy.go
+++ b/genesyscloud/webdeployments_deployment/genesyscloud_webdeployments_deployment_proxy.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 var internalProxy *webDeploymentsProxy

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func getAllWebDeployments(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func TestAccResourceWebDeploymentsDeployment(t *testing.T) {

--- a/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_utils.go
+++ b/genesyscloud/webdeployments_deployment/resource_genesyscloud_webdeployments_deployment_utils.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v165/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v171/platformclientv2"
 )
 
 func alwaysDifferent(k, old, new string, d *schema.ResourceData) bool {

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/leekchan/timeutil v0.0.0-20150802142658-28917288c48d
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/mozillazg/go-unidecode v0.2.0
-	github.com/mypurecloud/platform-client-sdk-go/v165 v165.1.0
+	github.com/mypurecloud/platform-client-sdk-go/v171 v171.0.0
 	github.com/nyaruka/phonenumbers v1.6.6
 	github.com/rjNemo/underscore v0.8.0
 	github.com/shirou/gopsutil/v4 v4.25.9

--- a/go.sum
+++ b/go.sum
@@ -213,8 +213,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mozillazg/go-unidecode v0.2.0 h1:vFGEzAH9KSwyWmXCOblazEWDh7fOkpmy/Z4ArmamSUc=
 github.com/mozillazg/go-unidecode v0.2.0/go.mod h1:zB48+/Z5toiRolOZy9ksLryJ976VIwmDmpQ2quyt1aA=
-github.com/mypurecloud/platform-client-sdk-go/v165 v165.1.0 h1:E8ye+nT8k8+eIoIPJUaYCxfIBhHRv5rKCNHbQ6o9h/Q=
-github.com/mypurecloud/platform-client-sdk-go/v165 v165.1.0/go.mod h1:PrDgIcUF/YPVCR2nJ4Mz9+aQ7xB6wJfKn4rZN3ocMno=
+github.com/mypurecloud/platform-client-sdk-go/v171 v171.0.0 h1:utJ5thXJnRVXh8Ds8I580UgWcSu+rbbeeY6l/d6xybk=
+github.com/mypurecloud/platform-client-sdk-go/v171 v171.0.0/go.mod h1:gsbqfP3SAwfl8yaN8L0Ty18pV7wzesRicjjmHH/XPSk=
 github.com/nyaruka/phonenumbers v1.6.6 h1:cZv5/vslJh65zuOrLjdVDHKHzVEwVuUsXAPQi3bjGJU=
 github.com/nyaruka/phonenumbers v1.6.6/go.mod h1:7gjs+Lchqm49adhAKB5cdcng5ZXgt6x7Jgvi0ZorUtU=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=


### PR DESCRIPTION
This PR updates [platform-client-sdk-go](https://github.com/MyPureCloud/platform-client-sdk-go) to v171 so it can be used to create Apple Integration resource in the next upcoming PR.