### PR TITLE
Implemented potential workaround to default ring issue

### DIFF
--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -359,7 +359,7 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 - `acw_wrapup_prompt` (String) This field controls how the UI prompts the agent for a wrapup (MANDATORY | OPTIONAL | MANDATORY_TIMEOUT | MANDATORY_FORCED_TIMEOUT | AGENT_REQUESTED). Defaults to `MANDATORY_TIMEOUT`.
 - `agent_owned_routing` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--agent_owned_routing))
 - `auto_answer_only` (Boolean) Specifies whether the configured whisper should play for all ACD calls, or only for those which are auto-answered. Defaults to `true`.
-- `bullseye_rings` (Block List, Max: 5) The bullseye ring settings for the queue. (see [below for nested schema](#nestedblock--bullseye_rings))
+- `bullseye_rings` (Block List, Max: 6) The bullseye ring settings for the queue. (see [below for nested schema](#nestedblock--bullseye_rings))
 - `calling_party_name` (String) The name to use for caller identification for outbound calls from this queue.
 - `calling_party_number` (String) The phone number to use for caller identification for outbound calls from this queue.
 - `canned_response_libraries` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--canned_response_libraries))
@@ -423,6 +423,10 @@ Required:
 
 Optional:
 
+- `is_default_ring` (Boolean) Indicates whether this ring is the default ring for the queue. Only the ring at the last index of the list can be the default ring.
+							You can only provide six rings if the last ring is the default ring, otherwise the maximum is five. The last ring is always the default ring.
+							Since it is possible to associate a group with the hidden default ring, you can set this field to true specify that it is the default ring.
+							This field exists to temporarily work around an API issue. We do not recommend associating groups with default rings. Defaults to `false`.
 - `member_groups` (Block Set) (see [below for nested schema](#nestedblock--bullseye_rings--member_groups))
 - `skills_to_remove` (Set of String) Skill IDs to remove on ring exit.
 

--- a/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
@@ -54,7 +54,7 @@ func hydrateRoutingQueueCacheFn(c *rc.DataSourceCache, ctx context.Context) erro
 		return fmt.Errorf("failed to get routing queues. Error: %s | API Response: %s", err.Error(), resp)
 	}
 
-	if queues != nil || len(*queues) != 0 {
+	if queues != nil && len(*queues) > 0 {
 		allQueues = append(allQueues, *queues...)
 	}
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -484,7 +484,7 @@ func ResourceRoutingQueue() *schema.Resource {
 				Description: "The bullseye ring settings for the queue.",
 				Type:        schema.TypeList,
 				Optional:    true,
-				MaxItems:    5,
+				MaxItems:    6,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"expansion_timeout_seconds": {
@@ -503,6 +503,15 @@ func ResourceRoutingQueue() *schema.Resource {
 							Type:     schema.TypeSet,
 							Optional: true,
 							Elem:     memberGroupResource,
+						},
+						"is_default_ring": {
+							Description: `Indicates whether this ring is the default ring for the queue. Only the ring at the last index of the list can be the default ring.
+							You can only provide six rings if the last ring is the default ring, otherwise the maximum is five. The last ring is always the default ring.
+							Since it is possible to associate a group with the hidden default ring, you can set this field to true specify that it is the default ring.
+							This field exists to temporarily work around an API issue. We do not recommend associating groups with default rings.`,
+							Type:     schema.TypeBool,
+							Optional: true,
+							Default:  false,
 						},
 					},
 				},


### PR DESCRIPTION
Proposed solution: During read/export, setting the field `is_default_ring` to true if the ring is the last one in the array (which indicates it as the default.) On create, we then check if any of the bullseye rings have this field set to true. If yes, we will create the queue and then update bullseye config after to allow us to control which ring is the default. If no, we will create the queue as normal, allowing the API to automatically add a default ring. 

This PR is not ready because some of the tests are failing with a plan not empty error. This would need to be addressed before releasing. 