### PR TITLE
Bug: genesyscloud_responsemanagement_response schema has 'namespace' field marked as Required

### DIFF
--- a/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_schema.go
+++ b/genesyscloud/responsemanagement_response/resource_genesyscloud_responsemanagement_response_schema.go
@@ -108,7 +108,7 @@ var (
 			},
 			`namespace`: {
 				Description: `The messaging template namespace.`,
-				Required:    true,
+				Optional:    true,
 				Type:        schema.TypeString,
 			},
 			`language`: {


### PR DESCRIPTION
**Resource:** genesyscloud_responsemanagement_response 

**Error:** The argument "messaging_template.0.whats_app.0.namespace" is required, but no definition was found. 

**Issue:** Though `namespace` attribute is not mandatory as per GC APIs, the provider has marked it as required, thus, leading for `terraform plan` to fail. 

**Fix:** `namespace` attribute has been marked Optional at `resource_genesyscloud_responsemanagement_response_schema.go` file 

**Reproduction Steps:**
- Export `genesyscloud_responsemanagement_response` resources using terraform with `export_format = json`
- Run `terraform plan (or) terraform apply`

**References:** 
- https://registry.terraform.io/providers/MyPureCloud/genesyscloud/latest/docs/resources/responsemanagement_response#nested-schema-for-messaging_templatewhats_app 

- https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-responsemanagement-responses 