### PR TITLE
Bug/devtooling 1539 - mismatch on attribute knowledge_document.0.label_names.0

### DIFF
--- a/genesyscloud/resource_exporter/resource_exporter_custom.go
+++ b/genesyscloud/resource_exporter/resource_exporter_custom.go
@@ -240,13 +240,12 @@ func KnowledgeDocumentLabelNamesResolver(configMap map[string]interface{}, expor
 		if !ok {
 			continue
 		}
-		log.Printf("labelName: %s", name)
-		log.Printf("exporter.SanitizedResourceMap: %v", exporter.SanitizedResourceMap)
 
 		for _, labelResource := range exporter.SanitizedResourceMap {
-			log.Printf("labelResource.BlockLabel: %s", labelResource.BlockLabel)
-			log.Printf("labelResource.OriginalLabel: %s", labelResource.OriginalLabel)
-			if strings.HasSuffix(labelResource.BlockLabel, "_"+name) {
+
+			// OriginalLabel preserves the original format (with spaces) which matches the labelName format
+			// whereas BlockLabel is sanitized
+			if strings.HasSuffix(labelResource.OriginalLabel, "_"+name) {
 				resolvedNames = append(resolvedNames, fmt.Sprintf("${genesyscloud_knowledge_label.%s.knowledge_label[0].name}", labelResource.BlockLabel))
 				break
 			}


### PR DESCRIPTION
BlockLabel is sanitized that means if labelName has spaces in between; the BlockLabel will add underscores, whereas OriginalLabel attribute preserves the original format with spaces that matches the labelName format.