### PR TITLE
Bugfix - Function Data Action

### DIFF
--- a/docs/resources/integration_action.md
+++ b/docs/resources/integration_action.md
@@ -95,11 +95,13 @@ resource "genesyscloud_integration_action" "example_action" {
 }
 
 # Example with function configuration
-# Note: function_config is only required for function data actions (when category = "Genesys Cloud Data Action")
+# Note: function_config is only required for function data actions.
+# A function data action is detected when the category contains "function data action" (case-insensitive, underscores and hyphens treated as spaces).
+# Examples: "Genesys Cloud Function Data Action", "function_data_action", "function-data-action", "Custom Function Data Action"
 # For regular integration actions, this section can be omitted
 resource "genesyscloud_integration_action" "example_function_action" {
   name                   = "Example Function Action"
-  category               = "Genesys Cloud Data Action"
+  category               = "Genesys Cloud Function Data Action"
   integration_id         = genesyscloud_integration.example_gc_data_integration.id
   secure                 = true
   config_timeout_seconds = 20
@@ -143,7 +145,7 @@ resource "genesyscloud_integration_action" "example_function_action" {
 
 ### Required
 
-- `category` (String) Category of action. Can be up to 256 characters long.
+- `category` (String) Category of action. Can be up to 256 characters long. If the category contains 'function data action' (case-insensitive, underscores and hyphens treated as spaces), the action will be treated as a function data action and requires function_config to be set.
 - `contract_input` (String) JSON Schema that defines the body of the request that the client (edge/architect/postman) is sending to the service, on the /execute path. Changing the contract_input attribute will cause the existing integration_action to be dropped and recreated with a new ID.
 - `contract_output` (String) JSON schema that defines the transformed, successful result that will be sent back to the caller. Changing the contract_output attribute will cause the existing integration_action to be dropped and recreated with a new ID.
 - `integration_id` (String) The ID of the integration this action is associated with. Changing the integration_id attribute will cause the existing integration_action to be dropped and recreated with a new ID.

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
@@ -111,6 +111,7 @@ func createIntegrationAction(ctx context.Context, d *schema.ResourceData, meta i
 func containsFunctionDataAction(s string) bool {
 	normalized := strings.ToLower(s)
 	normalized = strings.ReplaceAll(normalized, "_", " ")
+	normalized = strings.ReplaceAll(normalized, "-", " ")
 	return strings.Contains(normalized, "function data action")
 }
 

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_schema.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_schema.go
@@ -142,7 +142,7 @@ func ResourceIntegrationAction() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 256),
 			},
 			"category": {
-				Description:  "Category of action. Can be up to 256 characters long.",
+				Description:  "Category of action. Can be up to 256 characters long. If the category contains 'function data action' (case-insensitive, underscores and hyphens treated as spaces), the action will be treated as a function data action and requires function_config to be set.",
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 256),


### PR DESCRIPTION
Problem: errorMessage: API Error: 400 - Bad Request with errorCode: "ACTION.PROCESSING" on Terraform runs
Root cause: Returned nil instead of resp, breaking retry logic
Fix: Return resp to allow IsStatus400() to detect retriable errors
Bonus: Updated docs for function data action category detection and extended regex pattern