### PR TITLE
add exporting state

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -2602,12 +2602,7 @@ func (g *GenesysCloudResourceExporter) resolveReference(refSettings *resourceExp
 		g.buildSecondDeps[refSettings.RefType] = []string{refID}
 	}
 
-	if exportingState {
-		// Don't remove unmatched IDs when exporting state. This will keep existing config in an org
-		return refID
-	}
-	// No match found. Remove the value from the config since we do not have a reference to use
-	return ""
+	return refID
 }
 
 func (g *GenesysCloudResourceExporter) resourceIdExists(refID string, existingResources []resourceExporter.ResourceInfo) bool {


### PR DESCRIPTION
there is hard coupling between include_state_file attribute and resolvereference , which doesnt make much sense .
I feel there is no harm in flushing out the guid if we are unable to resolve the reference during export  instead of sending in empty strings  which gives us a wrong depiction of the exported resource.