### PR TITLE
DEVTOOLING-1482 -  Fixed missing "user_id" property

### DIFF
--- a/genesyscloud/external_user/resource_genesyscloud_externalusers_identity.go
+++ b/genesyscloud/external_user/resource_genesyscloud_externalusers_identity.go
@@ -167,10 +167,20 @@ func getAllHelperExternalUser(ctx context.Context, externalUserproxy *externalUs
 		if err != nil || externalUseList == nil {
 			return nil, response, err
 		}
-		for _, externalUser := range *externalUseList {
 
+		// Create a user identifier for the block label
+		userIdentifier := userId
+		if eachUser.Email != nil && *eachUser.Email != "" {
+			userIdentifier = *eachUser.Email
+		} else if eachUser.Name != nil && *eachUser.Name != "" {
+			userIdentifier = *eachUser.Name
+		}
+
+		for _, externalUser := range *externalUseList {
 			id := createCompoundKey(userId, *externalUser.AuthorityName, *externalUser.ExternalKey)
-			resources[id] = &resourceExporter.ResourceMeta{BlockLabel: id}
+			// Create a descriptive block label using user identifier and authority name
+			blockLabel := fmt.Sprintf("%s_%s", userIdentifier, *externalUser.AuthorityName)
+			resources[id] = &resourceExporter.ResourceMeta{BlockLabel: blockLabel}
 		}
 
 	}


### PR DESCRIPTION
genesyscloud_externalusers_identity export is no longer missing "user_id" property