### PR TITLE
DEVTOOLING-1480 - fix null pointer because of a missing return

### DIFF
--- a/genesyscloud/provider/sdk_client_pool.go
+++ b/genesyscloud/provider/sdk_client_pool.go
@@ -1000,6 +1000,10 @@ func GetAllWithPooledClient(method GetAllConfigFunc) resourceExporter.GetAllReso
 		clientConfig, err := mrmo.GetClientConfig()
 		if err != nil {
 			log.Printf("[WARN] Error getting client config: %s", err.Error())
+			log.Printf("[DEBUG] Returning error from GetAllWithPooledClient")
+			return func(ctx context.Context) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
+				return nil, diag.FromErr(err)
+			}
 		}
 		return func(ctx context.Context) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
 			return method(ctx, clientConfig)


### PR DESCRIPTION
The issue happens when:
1. `MRMO_CXASCODE_INTEGRATION_ENABLED` is enabled for testing (which means that we didn't activate MRMO), or 
2. The MRMO service is enabled but not activated somehow. 

In each of the scenarios, the [clientConfig](https://github.com/MyPureCloud/terraform-provider-genesyscloud/blob/dd93646b9ef0d88c4054248834c7947e6f1307f0/genesyscloud/provider/sdk_client_pool.go#L1000) variable will equal to `nil` and the err checking will be triggered. The main thing to observe here is that when handling the error we are not returning from the function, so in the next lines we are trying to return a clientConfig variable which is assigned to `nil`.

The solution: I added a debug message and returned the error when triggered.

Testing: I enabled `MRMO_CXASCODE_INTEGRATION_ENABLED` and tried to create a `genesyscloud_tf_export` resource, this failed with the debug message I added in the code, and we don't have the error shown in the ticket anymore!