### PR TITLE
Fixes DEVTOOLING-1590 by ensuring the idle_token_timeout_seconds field is only set when the enable_idle_token_timeout is true

### DIFF
--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_unit_test.go
@@ -174,7 +174,7 @@ func TestGetTimeOutSettingsFromResourceData(t *testing.T) {
 		expected *platformclientv2.Idletokentimeout
 	}{
 		{
-			name: "Valid timeout settings",
+			name: "Valid timeout settings (enabled)",
 			input: map[string]interface{}{
 				"timeout_settings": []interface{}{
 					map[string]interface{}{
@@ -186,6 +186,20 @@ func TestGetTimeOutSettingsFromResourceData(t *testing.T) {
 			expected: &platformclientv2.Idletokentimeout{
 				EnableIdleTokenTimeout:  platformclientv2.Bool(true),
 				IdleTokenTimeoutSeconds: platformclientv2.Int(3600),
+			},
+		},
+		{
+			name: "Valid timeout settings (disabled)",
+			input: map[string]interface{}{
+				"timeout_settings": []interface{}{
+					map[string]interface{}{
+						"enable_idle_token_timeout":  false,
+						"idle_token_timeout_seconds": 0,
+					},
+				},
+			},
+			expected: &platformclientv2.Idletokentimeout{
+				EnableIdleTokenTimeout: platformclientv2.Bool(false),
 			},
 		},
 		{
@@ -238,16 +252,28 @@ func TestGetTimeOutSettingsFromResourceData(t *testing.T) {
 				t.Fatal("expected non-nil result")
 			}
 
-			if *result.EnableIdleTokenTimeout != *tt.expected.EnableIdleTokenTimeout {
-				t.Errorf("EnableIdleTokenTimeout: expected %v, got %v",
-					*tt.expected.EnableIdleTokenTimeout,
-					*result.EnableIdleTokenTimeout)
+			if tt.expected.EnableIdleTokenTimeout != nil {
+				if *result.EnableIdleTokenTimeout != *tt.expected.EnableIdleTokenTimeout {
+					t.Errorf("EnableIdleTokenTimeout: expected %v, got %v",
+						*tt.expected.EnableIdleTokenTimeout,
+						*result.EnableIdleTokenTimeout)
+				}
+			} else {
+				if result.EnableIdleTokenTimeout != nil {
+					t.Errorf("expected nil EnableIdleTokenTimeout, got %v", *result.EnableIdleTokenTimeout)
+				}
 			}
 
-			if *result.IdleTokenTimeoutSeconds != *tt.expected.IdleTokenTimeoutSeconds {
-				t.Errorf("IdleTokenTimeoutSeconds: expected %v, got %v",
-					*tt.expected.IdleTokenTimeoutSeconds,
-					*result.IdleTokenTimeoutSeconds)
+			if tt.expected.IdleTokenTimeoutSeconds != nil {
+				if *result.IdleTokenTimeoutSeconds != *tt.expected.IdleTokenTimeoutSeconds {
+					t.Errorf("IdleTokenTimeoutSeconds: expected %v, got %v",
+						*tt.expected.IdleTokenTimeoutSeconds,
+						*result.IdleTokenTimeoutSeconds)
+				}
+			} else {
+				if result.IdleTokenTimeoutSeconds != nil {
+					t.Errorf("expected nil IdleTokenTimeoutSeconds, got %v", *result.IdleTokenTimeoutSeconds)
+				}
 			}
 		})
 	}
@@ -261,7 +287,7 @@ func TestFlattenTimeOutSettings(t *testing.T) {
 		expected []interface{}
 	}{
 		{
-			name: "Valid timeout settings",
+			name: "Valid timeout settings (enabled)",
 			input: &platformclientv2.Idletokentimeout{
 				EnableIdleTokenTimeout:  platformclientv2.Bool(true),
 				IdleTokenTimeoutSeconds: platformclientv2.Int(3600),
@@ -270,6 +296,19 @@ func TestFlattenTimeOutSettings(t *testing.T) {
 				map[string]interface{}{
 					"enable_idle_token_timeout":  true,
 					"idle_token_timeout_seconds": 3600,
+				},
+			},
+		},
+		{
+			name: "Valid timeout settings (disabled)",
+			input: &platformclientv2.Idletokentimeout{
+				EnableIdleTokenTimeout:  platformclientv2.Bool(false),
+				IdleTokenTimeoutSeconds: platformclientv2.Int(0),
+			},
+			expected: []interface{}{
+				map[string]interface{}{
+					"enable_idle_token_timeout":  false,
+					"idle_token_timeout_seconds": 0,
 				},
 			},
 		},

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_utils.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_utils.go
@@ -34,10 +34,13 @@ func getTimeOutSettingsFromResourceData(d *schema.ResourceData) *platformclientv
 	timeOutData := d.Get("timeout_settings").([]interface{})
 	if len(timeOutData) > 0 {
 		if timeOutMap, ok := timeOutData[0].(map[string]interface{}); ok {
-			return &platformclientv2.Idletokentimeout{
-				EnableIdleTokenTimeout:  platformclientv2.Bool(timeOutMap["enable_idle_token_timeout"].(bool)),
-				IdleTokenTimeoutSeconds: platformclientv2.Int(timeOutMap["idle_token_timeout_seconds"].(int)),
+			idleTokenTimeout := &platformclientv2.Idletokentimeout{
+				EnableIdleTokenTimeout: platformclientv2.Bool(timeOutMap["enable_idle_token_timeout"].(bool)),
 			}
+			if *idleTokenTimeout.EnableIdleTokenTimeout {
+				idleTokenTimeout.IdleTokenTimeoutSeconds = platformclientv2.Int(timeOutMap["idle_token_timeout_seconds"].(int))
+			}
+			return idleTokenTimeout
 		}
 	}
 	return nil


### PR DESCRIPTION
Fixes DEVTOOLING-1590 by ensuring the idle_token_timeout_seconds field is only set when the enable_idle_token_timeout is true