### PR TITLE
DEVTOOLING-1585 - Provider crash when applying multiple genesyscloud_tf_export resources at once

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -28,6 +28,8 @@ The following permissions are required to use this resource:
 * `directory:group:add`
 * `directory:group:delete`
 * `directory:group:edit`
+* `voicemail:groupPolicy:edit`
+* `voicemail:groupPolicy:view`
 
 The following OAuth scopes are required to use this resource:
 

--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -21,6 +21,7 @@ The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Cl
 The following permissions are required to use this resource:
 
 * `routing:email:manage`
+* `routing:email:view`
 
 The following OAuth scopes are required to use this resource:
 

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -57,7 +57,8 @@ var (
 	// Attrs which can be exported in jsonencode objects are populated with a UID
 	// The same UID is stored as the key in attributesDecoded, with the value being the jsonencode representation of the json string.
 	// When the bytes are being written to the file, the UID is found and replaced with the unquoted jsonencode object
-	attributesDecoded = make(map[string]string)
+	attributesDecoded      = make(map[string]string)
+	attributesDecodedMutex sync.Mutex // Global mutex to protect concurrent access to attributesDecoded
 
 	providerDataSources map[string]*schema.Resource
 	providerResources   map[string]*schema.Resource
@@ -2319,9 +2320,9 @@ func (g *GenesysCloudResourceExporter) sanitizeConfigMap(
 					configMap[attributeConfigKey] = vStr
 				} else {
 					uid := uuid.NewString()
-					g.attributesDecodedMutex.Lock()
+					attributesDecodedMutex.Lock()
 					attributesDecoded[uid] = decodedData
-					g.attributesDecodedMutex.Unlock()
+					attributesDecodedMutex.Unlock()
 					configMap[attributeConfigKey] = uid
 				}
 			}

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -140,7 +140,6 @@ type GenesysCloudResourceExporter struct {
 	resourceStateMutex         sync.Mutex
 	resourceTypesMapsMutex     sync.RWMutex
 	unresolvedAttrsMutex       sync.Mutex
-	attributesDecodedMutex     sync.Mutex
 
 	// .. Int
 	maxConcurrentOps int // New field to control concurrency

--- a/genesyscloud/tfexporter/hcl_exporter.go
+++ b/genesyscloud/tfexporter/hcl_exporter.go
@@ -217,16 +217,7 @@ func createHCLVariablesBlock(unresolvedAttrs []unresolvableAttributeInfo) []byte
 func postProcessHclBytes(resource []byte) []byte {
 	resourceStr := string(resource)
 
-	// Create a copy of attributesDecoded map with mutex protection to avoid concurrent map iteration and map write
-	attributesDecodedMutex.Lock()
-	attributesDecodedCopy := make(map[string]string, len(attributesDecoded))
-	for k, v := range attributesDecoded {
-		attributesDecodedCopy[k] = v
-	}
-	attributesDecodedMutex.Unlock()
-
-	// Iterate over the copy instead of the original map
-	for placeholderId, val := range attributesDecodedCopy {
+	for placeholderId, val := range attributesDecoded {
 		resourceStr = strings.Replace(resourceStr, fmt.Sprintf("\"%s\"", placeholderId), val, -1)
 	}
 

--- a/genesyscloud/tfexporter/hcl_exporter.go
+++ b/genesyscloud/tfexporter/hcl_exporter.go
@@ -2,11 +2,12 @@ package tfexporter
 
 import (
 	"fmt"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"os"
 	"path/filepath"
 	"sort"
 	"strings"
+
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -215,7 +216,17 @@ func createHCLVariablesBlock(unresolvedAttrs []unresolvableAttributeInfo) []byte
 
 func postProcessHclBytes(resource []byte) []byte {
 	resourceStr := string(resource)
-	for placeholderId, val := range attributesDecoded {
+
+	// Create a copy of attributesDecoded map with mutex protection to avoid concurrent map iteration and map write
+	attributesDecodedMutex.Lock()
+	attributesDecodedCopy := make(map[string]string, len(attributesDecoded))
+	for k, v := range attributesDecoded {
+		attributesDecodedCopy[k] = v
+	}
+	attributesDecodedMutex.Unlock()
+
+	// Iterate over the copy instead of the original map
+	for placeholderId, val := range attributesDecodedCopy {
 		resourceStr = strings.Replace(resourceStr, fmt.Sprintf("\"%s\"", placeholderId), val, -1)
 	}
 

--- a/genesyscloud/tfexporter/json_exporter.go
+++ b/genesyscloud/tfexporter/json_exporter.go
@@ -305,6 +305,20 @@ func writeConfig(jsonMap map[string]interface{}, path string) diag.Diagnostics {
 
 func postProcessJsonBytes(resource []byte) []byte {
 	resourceStr := string(resource)
+
+	// Create a copy of attributesDecoded map with mutex protection to avoid concurrent map iteration and map write
+	attributesDecodedMutex.Lock()
+	attributesDecodedCopy := make(map[string]string, len(attributesDecoded))
+	for k, v := range attributesDecoded {
+		attributesDecodedCopy[k] = v
+	}
+	attributesDecodedMutex.Unlock()
+
+	// Iterate over the copy instead of the original map
+	for placeholderId, val := range attributesDecodedCopy {
+		resourceStr = strings.Replace(resourceStr, fmt.Sprintf("\"%s\"", placeholderId), val, -1)
+	}
+
 	resourceStr = correctDependsOn(resourceStr, false)
 	return []byte(resourceStr)
 }

--- a/genesyscloud/tfexporter/json_exporter.go
+++ b/genesyscloud/tfexporter/json_exporter.go
@@ -306,16 +306,7 @@ func writeConfig(jsonMap map[string]interface{}, path string) diag.Diagnostics {
 func postProcessJsonBytes(resource []byte) []byte {
 	resourceStr := string(resource)
 
-	// Create a copy of attributesDecoded map with mutex protection to avoid concurrent map iteration and map write
-	attributesDecodedMutex.Lock()
-	attributesDecodedCopy := make(map[string]string, len(attributesDecoded))
-	for k, v := range attributesDecoded {
-		attributesDecodedCopy[k] = v
-	}
-	attributesDecodedMutex.Unlock()
-
-	// Iterate over the copy instead of the original map
-	for placeholderId, val := range attributesDecodedCopy {
+	for placeholderId, val := range attributesDecoded {
 		resourceStr = strings.Replace(resourceStr, fmt.Sprintf("\"%s\"", placeholderId), val, -1)
 	}
 


### PR DESCRIPTION
Added a global mutex (attributesDecodedMutex) to protect the attributesDecoded map. Modified postProcessHclBytes() to create a copy of the map under mutex protection and iterate over the copy instead of the original.