### PR TITLE
NO-JIRA - Optional Field for Rules in Outbound DigitalRuleSets

### DIFF
--- a/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_schema.go
+++ b/genesyscloud/outbound_digitalruleset/resource_genesyscloud_outbound_digitalruleset_schema.go
@@ -513,7 +513,7 @@ func ResourceOutboundDigitalruleset() *schema.Resource {
 			},
 			`rules`: {
 				Description: `The list of rules.`,
-				Required:    true,
+				Optional:    true,
 				Type:        schema.TypeList,
 				Elem:        digitalRuleResource,
 			},


### PR DESCRIPTION
The API supports digitalrulesets without any rules. This should be an optional field to align with the API:

```
gc outbound digitalrulesets list -a -p ignite-cx3-3                                                                                                                               ─╯
[
  {
    "id": "b9795457-4c8c-4859-a9ca-2c823fe4b5ad",
    "name": "Test Digital RuleSet - 13",
    "dateCreated": "2025-11-18T02:44:15.063Z",
    "version": 1,
    "contactList": {
      "id": "87f90b59-c9ca-4e8d-a812-73584ed5b88e",
      "name": "Example Contact List",
      "selfUri": "/api/v2/outbound/contactlists/87f90b59-c9ca-4e8d-a812-73584ed5b88e"
    },
    "rules": [
      {
        "id": "d4669a24-35e4-477e-b800-125758525890",
        "name": "Rule-1",
        "order": 0,
        "category": "PreContact",
        "conditions": [
          {
            "inverted": true,
            "contactColumnConditionSettings": {
              "columnName": "Work",
              "operator": "Equals",
              "value": "\"XYZ\"",
              "valueType": "String"
            }
          }
        ],
        "actions": [
          {
            "doNotSendActionSettings": {}
          }
        ]
      }
    ],
    "selfUri": "/api/v2/outbound/digitalrulesets/b9795457-4c8c-4859-a9ca-2c823fe4b5ad"
  },
  {
    "id": "eaf012d4-a67d-4ac5-9d5c-0b85d836034d",
    "name": "test2",
    "dateCreated": "2026-03-12T21:47:17.535Z",
    "version": 1,
    "selfUri": "/api/v2/outbound/digitalrulesets/eaf012d4-a67d-4ac5-9d5c-0b85d836034d"
  }
]
```

This is important for BCP, as an export can export a digitalruleset without any rules, but when it is validated for import, the process fails because the `Required` attribute indicates at least one rule must to be set.