### PR TITLE
fix: resolve nil pointer dereference in dependent consumer proxy tests

### DIFF
--- a/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy_test.go
+++ b/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy_test.go
@@ -206,9 +206,6 @@ func TestGetDependentConsumerProxy_Singleton(t *testing.T) {
 }
 
 func TestNewDependentConsumerProxy_ThreadSafe(t *testing.T) {
-	// Reset singleton for test
-	InternalProxy = nil
-
 	config := &platformclientv2.Configuration{}
 	done := make(chan *DependentConsumerProxy, 10)
 
@@ -233,9 +230,6 @@ func TestNewDependentConsumerProxy_ThreadSafe(t *testing.T) {
 }
 
 func TestGetDependentConsumerProxy_NilConfig(t *testing.T) {
-	// Reset singleton
-	InternalProxy = nil
-
 	proxy := GetDependentConsumerProxy(nil)
 
 	assert.NotNil(t, proxy)


### PR DESCRIPTION
Remove InternalProxy singleton resets from thread safety and nil config tests.
The sync.Once pattern prevents re-initialization after the first call, so
resetting InternalProxy to nil caused subsequent goroutines to access a nil
pointer when the Once guard skipped initialization.

The singleton pattern is working as designed - once initialized, all callers
receive the same instance regardless of subsequent configuration parameters.