### PR TITLE
Add a retry mechanism when calling GetAll*() functions

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -1599,16 +1599,41 @@ func (g *GenesysCloudResourceExporter) buildSanitizedResourceMaps(exporters map[
 			tflog.Info(g.ctx, fmt.Sprintf("Getting all resources for type %s", resourceType))
 			exporter.FilterResource = g.resourceFilter
 
-			err := exporter.LoadSanitizedResourceMap(ctx, resourceType, filter)
+			// Retry the GetAll functions at least three times (in case of transient errors)
+			maxRetries := 3
+			var err diag.Diagnostics
+			for attempt := 0; attempt < maxRetries; attempt++ {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+				err := exporter.LoadSanitizedResourceMap(ctx, resourceType, filter)
 
-			// Used in tests
-			if mockError != nil {
-				err = mockError
-			}
-			if errors.ContainsPermissionsErrorOnly(err) && logErrors {
-				tflog.Error(g.ctx, fmt.Sprintf("%v", err[0].Summary))
-				tflog.Warn(g.ctx, fmt.Sprintf("Logging permission error for %s. Resuming export...", resourceType))
-				return
+				// Used in tests
+				if mockError != nil {
+					err = mockError
+				}
+				// Don't retry permissions errors
+				if errors.ContainsPermissionsErrorOnly(err) && logErrors {
+					tflog.Error(g.ctx, fmt.Sprintf("%v", err[0].Summary))
+					tflog.Warn(g.ctx, fmt.Sprintf("Logging permission error for %s. Resuming export...", resourceType))
+					return
+				}
+				if err == nil {
+					break
+				}
+
+				if attempt < maxRetries-1 {
+					backoff := time.Duration(1<<attempt) * time.Second
+					tflog.Warn(g.ctx, fmt.Sprintf("Failed to load resources for %s (attempt %d/%d). Retrying in %v. Error: %v",
+						resourceType, attempt+1, maxRetries, backoff, err))
+					select {
+					case <-time.After(backoff):
+					case <-ctx.Done():
+						return
+					}
+				}
 			}
 			if err != nil {
 				if !logErrors {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -1608,7 +1608,7 @@ func (g *GenesysCloudResourceExporter) buildSanitizedResourceMaps(exporters map[
 					return
 				default:
 				}
-				err := exporter.LoadSanitizedResourceMap(ctx, resourceType, filter)
+				err = exporter.LoadSanitizedResourceMap(ctx, resourceType, filter)
 
 				// Used in tests
 				if mockError != nil {


### PR DESCRIPTION
We have seen transient issues with the exporter trying to run GetAll*() for a given resource type and getting a transient failure. This fix will add a retry mechanism that retries the listing call up to three times before failing.

This should address issues we have seen with some API endpoints in mec1:

```
{"@level":"error","@message":"Error: Failed to get page of schedule groups error: failed to get schedule group: API Error: 408 - A request timed out. (6b4f4201-fd34-4104-b774-03f05cca53e2)","@module":"tofu.ui","@timestamp":"2026-03-17T17:50:23.917545Z","diagnostic":{"severity":"error","summary":"Failed to get page of schedule groups error: failed to get schedule group: API Error: 408 - A request timed out. (6b4f4201-fd34-4104-b774-03f05cca53e2)","detail":"{\"resourceType\":\"genesyscloud_architect_schedulegroups\",\"method\":\"GET\",\"path\":\"/api/v2/architect/schedulegroups\",\"statusCode\":408,\"errorMessage\":\"API Error: 408 - A request timed out. (6b4f4201-fd34-4104-b774-03f05cca53e2)\",\"correlationId\":\"6b4f4201-fd34-4104-b774-03f05cca53e2\"}","address":"genesyscloud_tf_export.export","range":{"filename":"export.tf","start":{"line":1,"column":44,"byte":43},"end":{"line":1,"column":45,"byte":44}},"snippet":{"context":"resource \"genesyscloud_tf_export\" \"export\"","code":"resource \"genesyscloud_tf_export\" \"export\" {","start_line":1,"highlight_start_offset":43,"highlight_end_offset":44,"values":[]}},"type":"diagnostic"}
```