### PR TITLE
Feature/add content location responseasset

### DIFF
--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset.go
@@ -98,6 +98,7 @@ func readRespManagementRespAsset(ctx context.Context, d *schema.ResourceData, me
 		}
 
 		resourcedata.SetNillableValue(d, "name", sdkAsset.Name)
+		resourcedata.SetNillableValue(d, "content_location", sdkAsset.ContentLocation)
 
 		log.Printf("Read Responsemanagement response asset %s %s", d.Id(), *sdkAsset.Name)
 

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_schema.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_schema.go
@@ -72,6 +72,13 @@ func ResourceResponseManagementResponseAsset() *schema.Resource {
 				Computed:    true,
 				ForceNew:    true,
 			},
+			"content_location": {
+				Description: "Location URL of the response asset file content.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
+			},
 			`name`: {
 				Description: "Name of the response asset. Can be optionally defined to replace the name given in the filename. Changing the name attribute will cause the existing response asset to be dropped and recreated with a new ID. It must not start with a dot and not end with a forward slash. The following characters are not allowed: \\{^}%`]\">[~<#|,",
 				Type:        schema.TypeString,

--- a/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_test.go
+++ b/genesyscloud/responsemanagement_responseasset/resource_genesyscloud_responsemanagement_responseasset_test.go
@@ -46,6 +46,7 @@ func TestAccResourceResponseManagementResponseAsset(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullPath, "filename", fullPath1),
 					resource.TestCheckResourceAttr(resourceFullPath, "name", fullPath1),
+					resource.TestCheckResourceAttrSet(resourceFullPath, "content_location"),
 					provider.TestDefaultHomeDivision(resourceFullPath),
 				),
 			},
@@ -55,6 +56,7 @@ func TestAccResourceResponseManagementResponseAsset(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullPath, "filename", fullPath2),
 					resource.TestCheckResourceAttr(resourceFullPath, "name", fullPath2),
+					resource.TestCheckResourceAttrSet(resourceFullPath, "content_location"),
 					resource.TestCheckResourceAttrPair(resourceFullPath, "division_id",
 						authDivision.ResourceType+"."+divisionResourceLabel, "id"),
 				),
@@ -66,6 +68,7 @@ func TestAccResourceResponseManagementResponseAsset(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullPath, "filename", fullPath2),
 					resource.TestCheckResourceAttr(resourceFullPath, "name", fullPath2),
+					resource.TestCheckResourceAttrSet(resourceFullPath, "content_location"),
 					provider.TestDefaultHomeDivision(resourceFullPath),
 				),
 			},
@@ -77,6 +80,7 @@ func TestAccResourceResponseManagementResponseAsset(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"filename",
 					"file_content_hash",
+					"content_location",
 				},
 			},
 		},
@@ -109,6 +113,7 @@ func TestAccResourceResponseManagementResponseAssetWithNameField(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullPath, "filename", fullPath1),
 					resource.TestCheckResourceAttr(resourceFullPath, "name", fileName1),
+					resource.TestCheckResourceAttrSet(resourceFullPath, "content_location"),
 					provider.TestDefaultHomeDivision(resourceFullPath),
 				),
 			},
@@ -118,6 +123,7 @@ func TestAccResourceResponseManagementResponseAssetWithNameField(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullPath, "filename", fullPath2),
 					resource.TestCheckResourceAttr(resourceFullPath, "name", fileName2),
+					resource.TestCheckResourceAttrSet(resourceFullPath, "content_location"),
 					resource.TestCheckResourceAttrPair(resourceFullPath, "division_id",
 						authDivision.ResourceType+"."+divisionResourceLabel, "id"),
 				),
@@ -129,6 +135,7 @@ func TestAccResourceResponseManagementResponseAssetWithNameField(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(resourceFullPath, "filename", fullPath2),
 					resource.TestCheckResourceAttr(resourceFullPath, "name", fileName2),
+					resource.TestCheckResourceAttrSet(resourceFullPath, "content_location"),
 					provider.TestDefaultHomeDivision(resourceFullPath),
 				),
 			},
@@ -140,6 +147,7 @@ func TestAccResourceResponseManagementResponseAssetWithNameField(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"filename",
 					"file_content_hash",
+					"content_location",
 				},
 			},
 		},
@@ -323,6 +331,7 @@ func TestAccResourceResponseManagementResponseAssetWithS3(t *testing.T) {
 				Config: GenerateResponseManagementResponseAssetResource(resourceLabel, s3URI, util.NullValue),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fullResourcePath, "filename", s3URI),
+					resource.TestCheckResourceAttrSet(fullResourcePath, "content_location"),
 					provider.TestDefaultHomeDivision(fullResourcePath),
 					// Store the initial resource ID
 					func(s *terraform.State) error {
@@ -363,6 +372,7 @@ func TestAccResourceResponseManagementResponseAssetWithS3(t *testing.T) {
 				Config: GenerateResponseManagementResponseAssetResource(resourceLabel, s3URI, util.NullValue),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fullResourcePath, "filename", s3URI),
+					resource.TestCheckResourceAttrSet(fullResourcePath, "content_location"),
 					provider.TestDefaultHomeDivision(fullResourcePath),
 					// Verify that the resource ID has changed due to file_content_hash change
 					func(s *terraform.State) error {
@@ -387,6 +397,7 @@ func TestAccResourceResponseManagementResponseAssetWithS3(t *testing.T) {
 				ImportStateVerifyIgnore: []string{
 					"file_content_hash",
 					"filename",
+					"content_location",
 				},
 			},
 		},


### PR DESCRIPTION
Exposed the content_location attribute as a computed field to allow users to retrieve the URL of a response asset. Also added TestCheckResourceAttrSet to the acceptance tests. Reason for implementation was to have an environment independent Terraform File to create Canned Responses with Asset URLS in <img> tags