### PR TITLE
[MRMO-240] Added new fields to ResourceExporter to support replication of singleton resources in MRMO

### DIFF
--- a/docs/resources/greeting.md
+++ b/docs/resources/greeting.md
@@ -2,7 +2,7 @@
 page_title: "genesyscloud_greeting Resource - terraform-provider-genesyscloud"
 subcategory: ""
 description: |-
-Genesys Cloud Greeting
+  Genesys Cloud Greeting
 ---
 # genesyscloud_greeting (Resource)
 
@@ -16,6 +16,13 @@ The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Cl
 * [GET /api/v2/greetings](https://apicentral.genesys.cloud/api-explorer#get-api-v2-greetings)
 * [PUT /api/v2/greetings/{greetingId}](https://apicentral.genesys.cloud/api-explorer#put-api-v2-greetings--greetingId-)
 * [DELETE /api/v2/greetings/{greetingId}](https://apicentral.genesys.cloud/api-explorer#delete-api-v2-greetings--greetingId-)
+## Permissions and Scopes
+
+The following OAuth scopes are required to use this resource:
+
+* `greetings`
+* `greetings:readonly`
+
 
 ## Example Usage
 
@@ -55,3 +62,4 @@ Optional:
 - `duration_milliseconds` (Number) Greeting audio file duration in milliseconds.
 - `self_uri` (String) Greeting audio file self URI.
 - `size_bytes` (Number) Greeting audio file size in bytes.
+

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
@@ -37,7 +37,7 @@ func getAuthConversationsMessagingSupportedcontentDefaults(ctx context.Context, 
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get conversations messaging supportedcontent default: %s", err), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "supported_content_default"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "supported_content_default"}
 
 	return resources, nil
 }

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default.go
@@ -37,7 +37,7 @@ func getAuthConversationsMessagingSupportedcontentDefaults(ctx context.Context, 
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get conversations messaging supportedcontent default: %s", err), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "supported_content_default"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "supported_content_default"}
 
 	return resources, nil
 }

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default_schema.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default_schema.go
@@ -17,10 +17,7 @@ resource_genesycloud_conversations_messaging_supportedcontent_default_schema.go 
 4.  The resource exporter configuration for the conversations_messaging_supportedcontent_default exporter.
 */
 
-const (
-	ResourceType       = "genesyscloud_conversations_messaging_supportedcontent_default"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_conversations_messaging_supportedcontent_default"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -56,7 +53,7 @@ func ConversationsMessagingSupportedcontentDefaultExporter() *resourceExporter.R
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAuthConversationsMessagingSupportedcontentDefaults),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
 			"content_id": {
 				RefType: "genesyscloud_conversations_messaging_supportedcontent",

--- a/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default_schema.go
+++ b/genesyscloud/conversations_messaging_supportedcontent_default/resource_genesyscloud_conversations_messaging_supportedcontent_default_schema.go
@@ -17,7 +17,10 @@ resource_genesycloud_conversations_messaging_supportedcontent_default_schema.go 
 4.  The resource exporter configuration for the conversations_messaging_supportedcontent_default exporter.
 */
 
-const ResourceType = "genesyscloud_conversations_messaging_supportedcontent_default"
+const (
+	ResourceType       = "genesyscloud_conversations_messaging_supportedcontent_default"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -52,6 +55,8 @@ func ResourceConversationsMessagingSupportedcontentDefault() *schema.Resource {
 func ConversationsMessagingSupportedcontentDefaultExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAuthConversationsMessagingSupportedcontentDefaults),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
 			"content_id": {
 				RefType: "genesyscloud_conversations_messaging_supportedcontent",

--- a/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings.go
+++ b/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings.go
@@ -41,7 +41,7 @@ func getAllConversationsSettings(ctx context.Context, clientConfig *platformclie
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "conversations_settings"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "conversations_settings"}
 	return resources, nil
 }
 

--- a/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings.go
+++ b/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings.go
@@ -41,7 +41,7 @@ func getAllConversationsSettings(ctx context.Context, clientConfig *platformclie
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "conversations_settings"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "conversations_settings"}
 	return resources, nil
 }
 

--- a/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings_schema.go
+++ b/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings_schema.go
@@ -8,7 +8,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const ResourceType = "genesyscloud_conversations_settings"
+const (
+	ResourceType       = "genesyscloud_conversations_settings"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -74,5 +77,7 @@ func ResourceConversationsSettings() *schema.Resource {
 func ConversationsSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllConversationsSettings),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 	}
 }

--- a/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings_schema.go
+++ b/genesyscloud/conversations_settings/resource_genesyscloud_conversations_settings_schema.go
@@ -8,10 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const (
-	ResourceType       = "genesyscloud_conversations_settings"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_conversations_settings"
 
 // SetRegistrar registers all of the resources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -78,6 +75,6 @@ func ConversationsSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllConversationsSettings),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 	}
 }

--- a/genesyscloud/greeting/genesyscloud_greeting_proxy.go
+++ b/genesyscloud/greeting/genesyscloud_greeting_proxy.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 	"sync"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v176/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v179/platformclientv2"
 )
 
 var internalProxy *greetingProxy

--- a/genesyscloud/greeting/resource_genesyscloud_greeting.go
+++ b/genesyscloud/greeting/resource_genesyscloud_greeting.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v176/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v179/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"

--- a/genesyscloud/greeting/resource_genesyscloud_greeting_test.go
+++ b/genesyscloud/greeting/resource_genesyscloud_greeting_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v176/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v179/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 )

--- a/genesyscloud/greeting/resource_genesyscloud_greeting_utils.go
+++ b/genesyscloud/greeting/resource_genesyscloud_greeting_utils.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v176/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v179/platformclientv2"
 )
 
 func getOrganizationGreetingFromResourceData(d *schema.ResourceData) platformclientv2.Greeting {

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
@@ -44,7 +44,7 @@ func getAllAuthIdpAdfss(ctx context.Context, clientConfig *platformclientv2.Conf
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP ADFS error: %s", err), resp)
 	}
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "adfs"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "adfs"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs.go
@@ -44,7 +44,7 @@ func getAllAuthIdpAdfss(ctx context.Context, clientConfig *platformclientv2.Conf
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP ADFS error: %s", err), resp)
 	}
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "adfs"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "adfs"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_schema.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_schema.go
@@ -24,10 +24,7 @@ resource_genesycloud_idp_adfs_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_adfs datasource.
 4.  The resource exporter configuration for the idp_adfs exporter.
 */
-const (
-	ResourceType       = "genesyscloud_idp_adfs"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_idp_adfs"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -111,7 +108,7 @@ func IdpAdfsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpAdfss),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_schema.go
+++ b/genesyscloud/idp_adfs/resource_genesyscloud_idp_adfs_schema.go
@@ -24,7 +24,10 @@ resource_genesycloud_idp_adfs_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_adfs datasource.
 4.  The resource exporter configuration for the idp_adfs exporter.
 */
-const ResourceType = "genesyscloud_idp_adfs"
+const (
+	ResourceType       = "genesyscloud_idp_adfs"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -107,6 +110,8 @@ func ResourceIdpAdfs() *schema.Resource {
 func IdpAdfsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpAdfss),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
@@ -45,7 +45,7 @@ func getAllAuthIdpGenerics(ctx context.Context, clientConfig *platformclientv2.C
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Generic error: %s", getErr), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "generic"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "generic"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic.go
@@ -45,7 +45,7 @@ func getAllAuthIdpGenerics(ctx context.Context, clientConfig *platformclientv2.C
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Generic error: %s", getErr), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "generic"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "generic"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_schema.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_schema.go
@@ -25,10 +25,7 @@ resource_genesycloud_idp_generic_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_generic datasource.
 4.  The resource exporter configuration for the idp_generic exporter.
 */
-const (
-	ResourceType       = "genesyscloud_idp_generic"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_idp_generic"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -141,7 +138,7 @@ func IdpGenericExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpGenerics),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_schema.go
+++ b/genesyscloud/idp_generic/resource_genesyscloud_idp_generic_schema.go
@@ -25,7 +25,10 @@ resource_genesycloud_idp_generic_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_generic datasource.
 4.  The resource exporter configuration for the idp_generic exporter.
 */
-const ResourceType = "genesyscloud_idp_generic"
+const (
+	ResourceType       = "genesyscloud_idp_generic"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -137,6 +140,8 @@ func ResourceIdpGeneric() *schema.Resource {
 func IdpGenericExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpGenerics),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
@@ -45,7 +45,7 @@ func getAllAuthIdpGsuites(ctx context.Context, clientConfig *platformclientv2.Co
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP GSuite error: %s", err), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "gsuite"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "gsuite"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite.go
@@ -45,7 +45,7 @@ func getAllAuthIdpGsuites(ctx context.Context, clientConfig *platformclientv2.Co
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP GSuite error: %s", err), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "gsuite"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "gsuite"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_schema.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_schema.go
@@ -25,10 +25,7 @@ resource_genesycloud_idp_gsuite_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_gsuite datasource.
 4.  The resource exporter configuration for the idp_gsuite exporter.
 */
-const (
-	ResourceType       = "genesyscloud_idp_gsuite"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_idp_gsuite"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -114,7 +111,7 @@ func IdpGsuiteExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpGsuites),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_schema.go
+++ b/genesyscloud/idp_gsuite/resource_genesyscloud_idp_gsuite_schema.go
@@ -25,7 +25,10 @@ resource_genesycloud_idp_gsuite_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_gsuite datasource.
 4.  The resource exporter configuration for the idp_gsuite exporter.
 */
-const ResourceType = "genesyscloud_idp_gsuite"
+const (
+	ResourceType       = "genesyscloud_idp_gsuite"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -110,6 +113,8 @@ func ResourceIdpGsuite() *schema.Resource {
 func IdpGsuiteExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpGsuites),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
@@ -45,7 +45,7 @@ func getAllAuthIdpOktas(ctx context.Context, clientConfig *platformclientv2.Conf
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP okta error: %s", err), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "okta"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "okta"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta.go
@@ -45,7 +45,7 @@ func getAllAuthIdpOktas(ctx context.Context, clientConfig *platformclientv2.Conf
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP okta error: %s", err), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "okta"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "okta"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_schema.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_schema.go
@@ -25,10 +25,7 @@ resource_genesycloud_idp_okta_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_okta datasource.
 4.  The resource exporter configuration for the idp_okta exporter.
 */
-const (
-	ResourceType       = "genesyscloud_idp_okta"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_idp_okta"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -114,7 +111,7 @@ func IdpOktaExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpOktas),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_schema.go
+++ b/genesyscloud/idp_okta/resource_genesyscloud_idp_okta_schema.go
@@ -25,7 +25,10 @@ resource_genesycloud_idp_okta_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_okta datasource.
 4.  The resource exporter configuration for the idp_okta exporter.
 */
-const ResourceType = "genesyscloud_idp_okta"
+const (
+	ResourceType       = "genesyscloud_idp_okta"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -110,6 +113,8 @@ func ResourceIdpOkta() *schema.Resource {
 func IdpOktaExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpOktas),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
@@ -45,7 +45,7 @@ func getAllAuthIdpOnelogins(ctx context.Context, clientConfig *platformclientv2.
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Onelogin error: %s", err), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "onelogin"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "onelogin"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin.go
@@ -45,7 +45,7 @@ func getAllAuthIdpOnelogins(ctx context.Context, clientConfig *platformclientv2.
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Onelogin error: %s", err), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "onelogin"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "onelogin"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_schema.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_schema.go
@@ -25,7 +25,10 @@ resource_genesycloud_idp_onelogin_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_onelogin datasource.
 4.  The resource exporter configuration for the idp_onelogin exporter.
 */
-const ResourceType = "genesyscloud_idp_onelogin"
+const (
+	ResourceType       = "genesyscloud_idp_onelogin"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -110,6 +113,8 @@ func ResourceIdpOnelogin() *schema.Resource {
 func IdpOneloginExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpOnelogins),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_schema.go
+++ b/genesyscloud/idp_onelogin/resource_genesyscloud_idp_onelogin_schema.go
@@ -25,10 +25,7 @@ resource_genesycloud_idp_onelogin_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_onelogin datasource.
 4.  The resource exporter configuration for the idp_onelogin exporter.
 */
-const (
-	ResourceType       = "genesyscloud_idp_onelogin"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_idp_onelogin"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -114,7 +111,7 @@ func IdpOneloginExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpOnelogins),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
@@ -45,7 +45,7 @@ func getAllAuthIdpPings(ctx context.Context, clientConfig *platformclientv2.Conf
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Ping error: %s", err), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "ping"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "ping"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping.go
@@ -45,7 +45,7 @@ func getAllAuthIdpPings(ctx context.Context, clientConfig *platformclientv2.Conf
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Ping error: %s", err), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "ping"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "ping"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_schema.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_schema.go
@@ -24,10 +24,7 @@ resource_genesycloud_idp_ping_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_ping datasource.
 4.  The resource exporter configuration for the idp_ping exporter.
 */
-const (
-	ResourceType       = "genesyscloud_idp_ping"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_idp_ping"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -111,7 +108,7 @@ func IdpPingExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpPings),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_schema.go
+++ b/genesyscloud/idp_ping/resource_genesyscloud_idp_ping_schema.go
@@ -24,7 +24,10 @@ resource_genesycloud_idp_ping_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_ping datasource.
 4.  The resource exporter configuration for the idp_ping exporter.
 */
-const ResourceType = "genesyscloud_idp_ping"
+const (
+	ResourceType       = "genesyscloud_idp_ping"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -107,6 +110,8 @@ func ResourceIdpPing() *schema.Resource {
 func IdpPingExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthIdpPings),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{
 			// TODO: Add any reference attributes here
 		},

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
@@ -41,7 +41,7 @@ func getAllIdpSalesforce(ctx context.Context, clientConfig *platformclientv2.Con
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Salesforce error: %s", getErr), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "salesforce"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "salesforce"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce.go
@@ -41,7 +41,7 @@ func getAllIdpSalesforce(ctx context.Context, clientConfig *platformclientv2.Con
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get IDP Salesforce error: %s", getErr), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "salesforce"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "salesforce"}
 	return resources, nil
 }
 

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_schema.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_schema.go
@@ -25,10 +25,7 @@ resource_genesycloud_idp_salesforce_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_salesforce datasource.
 4.  The resource exporter configuration for the idp_salesforce exporter.
 */
-const (
-	ResourceType       = "genesyscloud_idp_salesforce"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_idp_salesforce"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -111,7 +108,7 @@ func IdpSalesforceExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllIdpSalesforce),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No references
 	}
 }

--- a/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_schema.go
+++ b/genesyscloud/idp_salesforce/resource_genesyscloud_idp_salesforce_schema.go
@@ -25,7 +25,10 @@ resource_genesycloud_idp_salesforce_schema.go holds four functions within it:
 3.  The datasource schema definitions for the idp_salesforce datasource.
 4.  The resource exporter configuration for the idp_salesforce exporter.
 */
-const ResourceType = "genesyscloud_idp_salesforce"
+const (
+	ResourceType       = "genesyscloud_idp_salesforce"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -107,6 +110,8 @@ func ResourceIdpSalesforce() *schema.Resource {
 func IdpSalesforceExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllIdpSalesforce),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No references
 	}
 }

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
@@ -40,7 +40,7 @@ func getAllOrganizationAuthenticationSettings(ctx context.Context, clientConfig 
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s resource due to error: %s", ResourceType, err), resp)
 	}
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: ResourceType}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: ResourceType}
 	return resources, nil
 }
 

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings.go
@@ -40,7 +40,7 @@ func getAllOrganizationAuthenticationSettings(ctx context.Context, clientConfig 
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s resource due to error: %s", ResourceType, err), resp)
 	}
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: ResourceType}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: ResourceType}
 	return resources, nil
 }
 

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_schema.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_schema.go
@@ -18,10 +18,7 @@ resource_genesycloud_organization_authentication_settings_schema.go holds four f
 3.  The datasource schema definitions for the organization_authentication_settings datasource.
 4.  The resource exporter configuration for the organization_authentication_settings exporter.
 */
-const (
-	ResourceType       = "genesyscloud_organization_authentication_settings"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_organization_authentication_settings"
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(l registrar.Registrar) {
@@ -160,7 +157,7 @@ func OrganizationAuthenticationSettingsExporter() *resourceExporter.ResourceExpo
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllOrganizationAuthenticationSettings),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{},
 		AllowZeroValues: []string{
 			"timeout_settings.idle_token_timeout_seconds",

--- a/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_schema.go
+++ b/genesyscloud/organization_authentication_settings/resource_genesyscloud_organization_authentication_settings_schema.go
@@ -18,7 +18,10 @@ resource_genesycloud_organization_authentication_settings_schema.go holds four f
 3.  The datasource schema definitions for the organization_authentication_settings datasource.
 4.  The resource exporter configuration for the organization_authentication_settings exporter.
 */
-const ResourceType = "genesyscloud_organization_authentication_settings"
+const (
+	ResourceType       = "genesyscloud_organization_authentication_settings"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(l registrar.Registrar) {
@@ -156,6 +159,8 @@ func ResourceOrganizationAuthenticationSettings() *schema.Resource {
 func OrganizationAuthenticationSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllOrganizationAuthenticationSettings),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{},
 		AllowZeroValues: []string{
 			"timeout_settings.idle_token_timeout_seconds",

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
@@ -38,7 +38,7 @@ func getAllOutboundSettings(ctx context.Context, clientConfig *platformclientv2.
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "outbound_settings"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "outbound_settings"}
 	return resources, nil
 }
 

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings.go
@@ -38,7 +38,7 @@ func getAllOutboundSettings(ctx context.Context, clientConfig *platformclientv2.
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "outbound_settings"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "outbound_settings"}
 	return resources, nil
 }
 

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_schema.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_schema.go
@@ -24,7 +24,10 @@ resource_genesycloud_outbound_settings_schema.go holds four functions within it:
 3.  The datasource schema definitions for the outbound_settings datasource.
 4.  The resource exporter configuration for the outbound_settings exporter.
 */
-const ResourceType = "genesyscloud_outbound_settings"
+const (
+	ResourceType       = "genesyscloud_outbound_settings"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all the resources, datasources and exporters in the package
 func SetRegistrar(l registrar.Registrar) {
@@ -162,6 +165,8 @@ func ResourceOutboundSettings() *schema.Resource {
 func OutboundSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllOutboundSettings),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No references
 	}
 }

--- a/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_schema.go
+++ b/genesyscloud/outbound_settings/resource_genesyscloud_outbound_settings_schema.go
@@ -24,10 +24,7 @@ resource_genesycloud_outbound_settings_schema.go holds four functions within it:
 3.  The datasource schema definitions for the outbound_settings datasource.
 4.  The resource exporter configuration for the outbound_settings exporter.
 */
-const (
-	ResourceType       = "genesyscloud_outbound_settings"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_outbound_settings"
 
 // SetRegistrar registers all the resources, datasources and exporters in the package
 func SetRegistrar(l registrar.Registrar) {
@@ -166,7 +163,7 @@ func OutboundSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllOutboundSettings),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No references
 	}
 }

--- a/genesyscloud/outbound_wrapupcode_mappings/geneysyscloud_wrapupcode_mappings_schema.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/geneysyscloud_wrapupcode_mappings_schema.go
@@ -17,10 +17,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const (
-	ResourceType       = "genesyscloud_outbound_wrapupcodemappings"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_outbound_wrapupcodemappings"
 
 var (
 	flagsSchema = &schema.Schema{
@@ -56,7 +53,7 @@ func OutboundWrapupCodeMappingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getOutboundWrapupCodeMappings),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
 			`mappings.wrapup_code_id`: {
 				RefType: `genesyscloud_routing_wrapupcode`,

--- a/genesyscloud/outbound_wrapupcode_mappings/geneysyscloud_wrapupcode_mappings_schema.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/geneysyscloud_wrapupcode_mappings_schema.go
@@ -17,7 +17,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const ResourceType = "genesyscloud_outbound_wrapupcodemappings"
+const (
+	ResourceType       = "genesyscloud_outbound_wrapupcodemappings"
+	singletonExportKey = ResourceType
+)
 
 var (
 	flagsSchema = &schema.Schema{
@@ -52,6 +55,8 @@ func SetRegistrar(l registrar.Registrar) {
 func OutboundWrapupCodeMappingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getOutboundWrapupCodeMappings),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
 			`mappings.wrapup_code_id`: {
 				RefType: `genesyscloud_routing_wrapupcode`,

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
@@ -45,7 +45,7 @@ func getOutboundWrapupCodeMappings(ctx context.Context, clientConfig *platformcl
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "wrapupcodemappings"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "wrapupcodemappings"}
 	return resources, nil
 }
 

--- a/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
+++ b/genesyscloud/outbound_wrapupcode_mappings/resource_genesyscloud_outbound_wrapupcodemappings.go
@@ -45,7 +45,7 @@ func getOutboundWrapupCodeMappings(ctx context.Context, clientConfig *platformcl
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "wrapupcodemappings"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "wrapupcodemappings"}
 	return resources, nil
 }
 

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -123,6 +123,13 @@ type ResourceExporter struct {
 	// Label will be sanitized with part of the ID appended, so it is not required that they be unique
 	GetResourcesFunc GetAllResourcesFunc
 
+	// IsSingleton indicates the exporter manages a single org-wide resource instance.
+	// ExportId is required when IsSingleton is true
+	IsSingleton bool
+
+	// ExportId is the singleton key used in the ResourceIDMetaMap returned by GetAllResourcesFunc.
+	ExportId string
+
 	// A map of resource attributes to types that they reference
 	// Attributes in nested objects can be defined with a '.' separator
 	RefAttrs map[string]*RefAttrSettings
@@ -193,6 +200,11 @@ func (r *ResourceExporter) LoadSanitizedResourceMap(ctx context.Context, resourc
 		return err
 	}
 
+	result, err = r.normalizeSingletonResourceMap(resourceType, result)
+	if err != nil {
+		return err
+	}
+
 	if r.FilterResource != nil {
 		result = r.FilterResource(result, resourceType, filter)
 	}
@@ -206,6 +218,36 @@ func (r *ResourceExporter) LoadSanitizedResourceMap(ctx context.Context, resourc
 	sanitizer.S.Sanitize(r.SanitizedResourceMap)
 
 	return nil
+}
+
+func (r *ResourceExporter) normalizeSingletonResourceMap(resourceType string, result ResourceIDMetaMap) (ResourceIDMetaMap, diag.Diagnostics) {
+	if !r.IsSingleton {
+		return result, nil
+	}
+
+	if r.ExportId == "" {
+		return nil, diag.Errorf("singleton exporter %s is missing ExportId", resourceType)
+	}
+
+	if len(result) == 0 {
+		return result, nil
+	}
+
+	if len(result) > 1 {
+		return nil, diag.Errorf("singleton exporter %s returned %d resources; expected at most 1", resourceType, len(result))
+	}
+
+	if _, ok := result[r.ExportId]; ok {
+		return result, nil
+	}
+
+	normalized := make(ResourceIDMetaMap, 1)
+	for _, meta := range result {
+		normalized[r.ExportId] = meta
+		break
+	}
+
+	return normalized, nil
 }
 
 // Thread-safe methods for accessing SanitizedResourceMap

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
@@ -57,7 +57,7 @@ func getAllRoutingSettings(ctx context.Context, clientConfig *platformclientv2.C
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s transcription due to error: %s", ResourceType, err), resp)
 	}
 
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "routing_settings"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "routing_settings"}
 	return resources, nil
 }
 

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings.go
@@ -57,7 +57,7 @@ func getAllRoutingSettings(ctx context.Context, clientConfig *platformclientv2.C
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s transcription due to error: %s", ResourceType, err), resp)
 	}
 
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "routing_settings"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "routing_settings"}
 	return resources, nil
 }
 

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings_schema.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings_schema.go
@@ -14,7 +14,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-var ResourceType = "genesyscloud_routing_settings"
+const (
+	ResourceType       = "genesyscloud_routing_settings"
+	singletonExportKey = ResourceType
+)
 
 func SetRegistrar(regInstance registrar.Registrar) {
 	regInstance.RegisterResource(ResourceType, ResourceRoutingSettings())
@@ -104,5 +107,7 @@ func ResourceRoutingSettings() *schema.Resource {
 func RoutingSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllRoutingSettings),
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 	}
 }

--- a/genesyscloud/routing_settings/resource_genesyscloud_routing_settings_schema.go
+++ b/genesyscloud/routing_settings/resource_genesyscloud_routing_settings_schema.go
@@ -14,10 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-const (
-	ResourceType       = "genesyscloud_routing_settings"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_routing_settings"
 
 func SetRegistrar(regInstance registrar.Registrar) {
 	regInstance.RegisterResource(ResourceType, ResourceRoutingSettings())
@@ -108,6 +105,6 @@ func RoutingSettingsExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllRoutingSettings),
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 	}
 }

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
@@ -36,7 +36,7 @@ func getAllRoutingUtilization(ctx context.Context, clientConfig *platformclientv
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
-	resources["0"] = &resourceExporter.ResourceMeta{BlockLabel: "routing_utilization"}
+	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "routing_utilization"}
 	return resources, nil
 }
 

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
@@ -36,7 +36,7 @@ func getAllRoutingUtilization(ctx context.Context, clientConfig *platformclientv
 		}
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get %s due to error: %s", ResourceType, err), resp)
 	}
-	resources[singletonExportKey] = &resourceExporter.ResourceMeta{BlockLabel: "routing_utilization"}
+	resources[ResourceType] = &resourceExporter.ResourceMeta{BlockLabel: "routing_utilization"}
 	return resources, nil
 }
 

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
@@ -8,17 +8,21 @@ package routing_utilization
 
 import (
 	"fmt"
+	"strings"
+	"time"
+
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_register"
-	"strings"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-const ResourceType = "genesyscloud_routing_utilization"
+const (
+	ResourceType       = "genesyscloud_routing_utilization"
+	singletonExportKey = ResourceType
+)
 
 // SetRegistrar registers all the resources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -154,5 +158,7 @@ func RoutingUtilizationExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllRoutingUtilization),
 		AllowZeroValues:  []string{"maximum_capacity"},
+		IsSingleton:      true,
+		ExportId:         singletonExportKey,
 	}
 }

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
@@ -19,10 +19,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-const (
-	ResourceType       = "genesyscloud_routing_utilization"
-	singletonExportKey = ResourceType
-)
+const ResourceType = "genesyscloud_routing_utilization"
 
 // SetRegistrar registers all the resources and exporters in the package
 func SetRegistrar(regInstance registrar.Registrar) {
@@ -159,6 +156,6 @@ func RoutingUtilizationExporter() *resourceExporter.ResourceExporter {
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllRoutingUtilization),
 		AllowZeroValues:  []string{"maximum_capacity"},
 		IsSingleton:      true,
-		ExportId:         singletonExportKey,
+		ExportId:         ResourceType,
 	}
 }

--- a/public/data/resource_permissions-latest.json
+++ b/public/data/resource_permissions-latest.json
@@ -482,6 +482,22 @@
       ]
     },
     {
+      "resource_type": "genesyscloud_conversations_settings",
+      "resource_name": "conversations_settings",
+      "permissions": [
+        "conversation:settings:edit",
+        "conversation:settings:view"
+      ],
+      "scopes": [
+        "conversations",
+        "conversations:readonly"
+      ],
+      "endpoints": [
+        "GET /api/v2/conversations/settings",
+        "PATCH /api/v2/conversations/settings"
+      ]
+    },
+    {
       "resource_type": "genesyscloud_employeeperformance_externalmetrics_definitions",
       "resource_name": "employeeperformance_externalmetrics_definitions",
       "permissions": [
@@ -659,12 +675,30 @@
       ]
     },
     {
+      "resource_type": "genesyscloud_greeting",
+      "resource_name": "greeting",
+      "permissions": [],
+      "scopes": [
+        "greetings",
+        "greetings:readonly"
+      ],
+      "endpoints": [
+        "POST /api/v2/greetings",
+        "GET /api/v2/greetings/{greetingId}",
+        "GET /api/v2/greetings",
+        "PUT /api/v2/greetings/{greetingId}",
+        "DELETE /api/v2/greetings/{greetingId}"
+      ]
+    },
+    {
       "resource_type": "genesyscloud_group",
       "resource_name": "group",
       "permissions": [
         "directory:group:add",
         "directory:group:delete",
-        "directory:group:edit"
+        "directory:group:edit",
+        "voicemail:groupPolicy:edit",
+        "voicemail:groupPolicy:view"
       ],
       "scopes": [
         "groups",
@@ -1881,7 +1915,8 @@
       "resource_type": "genesyscloud_routing_email_route",
       "resource_name": "routing_email_route",
       "permissions": [
-        "routing:email:manage"
+        "routing:email:manage",
+        "routing:email:view"
       ],
       "scopes": [
         "routing",


### PR DESCRIPTION
Changes every singleton resource to set the key to its ResourceIdMetaMap in GetAllResourceFunc to a more stable const value (ResourceType), rather than the hardcoded "0" string used before.

This same value is exposed by the ResourceExporter as `ExportId` along with the `IsSingleton` flag so MRMO knows what id to filter on when exporting, and if this value changes in the future it shouldn't break MRMO.