### PR TITLE
No-Jira Enable dependency resolution for include-by-id exports (dev)

### DIFF
--- a/genesyscloud/mrmo/exporter/main.go
+++ b/genesyscloud/mrmo/exporter/main.go
@@ -35,7 +35,7 @@ func Export(ctx context.Context, input ExportInput, clientConfig *platformclient
 	exportResourceConfig := createExportResourceData(tfexporter.ResourceTfExport().Schema, input)
 
 	log.Println("Creating the genesyscloud resource exporter")
-	gcResourceExporter, newExporterDiags := tfexporter.NewGenesysCloudResourceExporter(ctx, exportResourceConfig, providerMeta, tfexporter.IncludeResources)
+	gcResourceExporter, newExporterDiags := tfexporter.NewGenesysCloudResourceExporter(ctx, exportResourceConfig, providerMeta, tfexporter.IncludeResources, tfexporter.AllowDependencyResolution)
 	if newExporterDiags != nil {
 		diags = append(diags, newExporterDiags...)
 	}

--- a/genesyscloud/tfexporter/export_common.go
+++ b/genesyscloud/tfexporter/export_common.go
@@ -31,6 +31,7 @@ const (
 // Common Exporter interface to abstract away whether we are using HCL or JSON as our exporter
 type Exporter func() diag.Diagnostics
 type ExporterFilterType int64
+type ExporterDependencyResolutionDecision bool
 type ExporterResourceTypeFilter func(exports map[string]*resourceExporter.ResourceExporter, filter []string) map[string]*resourceExporter.ResourceExporter
 type ExporterResourceFilter func(resourceIdMetaMap resourceExporter.ResourceIDMetaMap, resourceType string, filter []string) resourceExporter.ResourceIDMetaMap
 
@@ -39,6 +40,11 @@ const (
 	IncludeResources
 	IncludeResourcesById
 	ExcludeResources
+)
+
+const (
+	AllowDependencyResolution    ExporterDependencyResolutionDecision = true
+	DisallowDependencyResolution ExporterDependencyResolutionDecision = false
 )
 
 func IncludeFilterByResourceType(exports map[string]*resourceExporter.ResourceExporter, filter []string) map[string]*resourceExporter.ResourceExporter {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -199,7 +199,7 @@ func configureExporterType(ctx context.Context, d *schema.ResourceData, gre *Gen
 	}
 }
 
-func NewGenesysCloudResourceExporter(ctx context.Context, d *schema.ResourceData, meta interface{}, filterType ExporterFilterType, allowDependencyResolution ExporterDependencyResolutionDecision) (*GenesysCloudResourceExporter, diag.Diagnostics) {
+func NewGenesysCloudResourceExporter(ctx context.Context, d *schema.ResourceData, meta interface{}, filterType ExporterFilterType, exporterDependencyResolutionDecision ExporterDependencyResolutionDecision) (*GenesysCloudResourceExporter, diag.Diagnostics) {
 	if providerResources == nil {
 		providerResources, providerDataSources = rRegistrar.GetResources()
 	}
@@ -208,7 +208,7 @@ func NewGenesysCloudResourceExporter(ctx context.Context, d *schema.ResourceData
 		splitFilesByResource: d.Get("split_files_by_resource").(bool),
 		logPermissionErrors:  d.Get("log_permission_errors").(bool),
 		exportComputed:       d.Get("export_computed").(bool),
-		addDependsOn:         computeDependsOn(d.Get("enable_dependency_resolution").(bool), allowDependencyResolution),
+		addDependsOn:         computeDependsOn(d.Get("enable_dependency_resolution").(bool), exporterDependencyResolutionDecision),
 		filterType:           filterType,
 		includeStateFile:     d.Get("include_state_file").(bool),
 		ignoreCyclicDeps:     d.Get("ignore_cyclic_deps").(bool),
@@ -288,8 +288,8 @@ func identifyExportFormat(d *schema.ResourceData) string {
 	}
 	return strings.ToLower(d.Get("export_format").(string))
 }
-func computeDependsOn(enableDependencyResolution bool, allowDependencyResolution ExporterDependencyResolutionDecision) bool {
-	return enableDependencyResolution && bool(allowDependencyResolution)
+func computeDependsOn(enableDependencyResolution bool, exporterDependencyResolutionDecision ExporterDependencyResolutionDecision) bool {
+	return enableDependencyResolution && bool(exporterDependencyResolutionDecision)
 }
 
 func (g *GenesysCloudResourceExporter) Export() (diagErr diag.Diagnostics) {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -288,6 +288,7 @@ func identifyExportFormat(d *schema.ResourceData) string {
 	}
 	return strings.ToLower(d.Get("export_format").(string))
 }
+
 func computeDependsOn(enableDependencyResolution bool, exporterDependencyResolutionDecision ExporterDependencyResolutionDecision) bool {
 	return enableDependencyResolution && bool(exporterDependencyResolutionDecision)
 }

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -199,7 +199,7 @@ func configureExporterType(ctx context.Context, d *schema.ResourceData, gre *Gen
 	}
 }
 
-func NewGenesysCloudResourceExporter(ctx context.Context, d *schema.ResourceData, meta interface{}, filterType ExporterFilterType) (*GenesysCloudResourceExporter, diag.Diagnostics) {
+func NewGenesysCloudResourceExporter(ctx context.Context, d *schema.ResourceData, meta interface{}, filterType ExporterFilterType, allowDependencyResolution ExporterDependencyResolutionDecision) (*GenesysCloudResourceExporter, diag.Diagnostics) {
 	if providerResources == nil {
 		providerResources, providerDataSources = rRegistrar.GetResources()
 	}
@@ -208,7 +208,7 @@ func NewGenesysCloudResourceExporter(ctx context.Context, d *schema.ResourceData
 		splitFilesByResource: d.Get("split_files_by_resource").(bool),
 		logPermissionErrors:  d.Get("log_permission_errors").(bool),
 		exportComputed:       d.Get("export_computed").(bool),
-		addDependsOn:         computeDependsOn(d),
+		addDependsOn:         computeDependsOn(d.Get("enable_dependency_resolution").(bool), allowDependencyResolution),
 		filterType:           filterType,
 		includeStateFile:     d.Get("include_state_file").(bool),
 		ignoreCyclicDeps:     d.Get("ignore_cyclic_deps").(bool),
@@ -288,17 +288,8 @@ func identifyExportFormat(d *schema.ResourceData) string {
 	}
 	return strings.ToLower(d.Get("export_format").(string))
 }
-func computeDependsOn(d *schema.ResourceData) bool {
-	addDependsOn := d.Get("enable_dependency_resolution").(bool)
-	if addDependsOn {
-		if exportableResourceTypes, ok := d.GetOk("include_filter_resources"); ok {
-			filter := lists.InterfaceListToStrings(exportableResourceTypes.([]interface{}))
-			addDependsOn = len(filter) > 0
-		} else {
-			addDependsOn = false
-		}
-	}
-	return addDependsOn
+func computeDependsOn(enableDependencyResolution bool, allowDependencyResolution ExporterDependencyResolutionDecision) bool {
+	return enableDependencyResolution && bool(allowDependencyResolution)
 }
 
 func (g *GenesysCloudResourceExporter) Export() (diagErr diag.Diagnostics) {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
@@ -180,45 +180,22 @@ func TestUnitTfExportRemoveZeroValuesFunc(t *testing.T) {
 
 // TestUnitComputeDependsOn will test computeDependsOn function
 func TestUnitComputeDependsOn(t *testing.T) {
-
-	createResourceData := func(enableDependencyResolution bool, includeFilterResources []interface{}) *schema.ResourceData {
-
-		resourceSchema := map[string]*schema.Schema{
-			"enable_dependency_resolution": {
-				Type:     schema.TypeBool,
-				Optional: true,
-				Default:  false,
-			},
-			"include_filter_resources": {
-				Type:     schema.TypeList,
-				Elem:     &schema.Schema{Type: schema.TypeString},
-				Optional: true,
-			},
-		}
-
-		data := schema.TestResourceDataRaw(t, resourceSchema, map[string]interface{}{
-			"enable_dependency_resolution": enableDependencyResolution,
-			"include_filter_resources":     includeFilterResources,
-		})
-		return data
-	}
-
 	tests := []struct {
 		enableDependencyResolution bool
-		includeFilterResources     []interface{}
+		allowDependencyResolution  ExporterDependencyResolutionDecision
 		expected                   bool
 	}{
-		{true, []interface{}{"resource1", "resource2"}, true},
-		{true, []interface{}{}, false},
-		{false, []interface{}{"resource1"}, false},
-		{false, []interface{}{}, false},
+		{true, ExporterDependencyResolutionDecision(true), true},
+		{true, ExporterDependencyResolutionDecision(false), false},
+		{false, ExporterDependencyResolutionDecision(true), false},
+		{false, ExporterDependencyResolutionDecision(false), false},
 	}
 
 	for _, test := range tests {
-		data := createResourceData(test.enableDependencyResolution, test.includeFilterResources)
-		result := computeDependsOn(data)
+		result := computeDependsOn(test.enableDependencyResolution, test.allowDependencyResolution)
 		if result != test.expected {
-			t.Errorf("computeDependsOn(%v, %v) = %v; want %v", test.enableDependencyResolution, test.includeFilterResources, result, test.expected)
+			t.Errorf("computeDependsOn(%v, %v) = %v; want %v",
+				test.enableDependencyResolution, test.allowDependencyResolution, result, test.expected)
 		}
 	}
 }
@@ -594,7 +571,7 @@ func setupGenesysCloudResourceExporter(t *testing.T) *GenesysCloudResourceExport
 		ClientConfig: platformclientv2.GetDefaultConfiguration(),
 		Domain:       "mypurecloud.com",
 	}
-	g, diagErr := NewGenesysCloudResourceExporter(context.TODO(), resourceData, providerMeta, IncludeResources)
+	g, diagErr := NewGenesysCloudResourceExporter(context.TODO(), resourceData, providerMeta, IncludeResources, AllowDependencyResolution)
 	if diagErr != nil {
 		t.Errorf("%v", diagErr)
 	}

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
@@ -204,7 +204,7 @@ func createTfExport(ctx context.Context, d *schema.ResourceData, meta interface{
 	tfExporterState.ActivateExporterState()
 
 	if _, ok := d.GetOk("include_filter_resources"); ok {
-		gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, IncludeResources)
+		gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, IncludeResources, AllowDependencyResolution)
 		diagErr := gre.Export()
 		if diagErr.HasError() {
 			return diagErr
@@ -215,7 +215,7 @@ func createTfExport(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	if _, ok := d.GetOk("include_filter_resources_by_id"); ok {
-		gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, IncludeResourcesById)
+		gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, IncludeResourcesById, AllowDependencyResolution)
 		diagErr := gre.Export()
 		if diagErr.HasError() {
 			return diagErr
@@ -226,7 +226,7 @@ func createTfExport(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	if _, ok := d.GetOk("exclude_filter_resources"); ok {
-		gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, ExcludeResources)
+		gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, ExcludeResources, DisallowDependencyResolution)
 		diagErr := gre.Export()
 		if diagErr.HasError() {
 			return diagErr
@@ -237,7 +237,7 @@ func createTfExport(ctx context.Context, d *schema.ResourceData, meta interface{
 	}
 
 	//Dealing with the traditional resource
-	gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, LegacyInclude)
+	gre, _ := NewGenesysCloudResourceExporter(ctx, d, meta, LegacyInclude, DisallowDependencyResolution)
 	diagErr := gre.Export()
 	if diagErr.HasError() {
 		return diagErr


### PR DESCRIPTION
## Enable dependency resolution for include-by-id exports

### Summary

Enables dependency resolution for `include_filter_resources_by_id` exports by refactoring `computeDependsOn()` to decouple the dependency resolution decision from `include_filter_resources` presence.

### Motivation

Previously, `computeDependsOn` was coupled to `*schema.ResourceData` and internally checked for `include_filter_resources` to decide whether dependency resolution was allowed. This meant `include_filter_resources_by_id` exports could never resolve dependencies, even when `enable_dependency_resolution` was set to `true`. This change makes the decision explicit at the call site, enabling dependency resolution for both include paths.

### Changes

- **`export_common.go`**: Added `ExporterDependencyResolutionDecision` type with named constants `AllowDependencyResolution` and `DisallowDependencyResolution`.
- **`genesyscloud_resource_exporter.go`**:
  - `NewGenesysCloudResourceExporter` now accepts an `ExporterDependencyResolutionDecision` parameter.
  - `computeDependsOn` simplified to a pure function: `enableDependencyResolution && bool(allowDependencyResolution)`.
- **`resource_genesyscloud_tf_export.go`**: `createTfExport` passes `AllowDependencyResolution` for include and include-by-id paths, `DisallowDependencyResolution` for exclude and legacy paths.
- **`genesyscloud_resource_exporter_test.go`**: `TestUnitComputeDependsOn` simplified to test the pure function directly, removing `schema.ResourceData` construction. `setupGenesysCloudResourceExporter` updated with the new parameter.
