### PR TITLE
Fixes DEVTOOLING-1638 by resolving references for integration types (main)

### DIFF
--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_schema.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_schema.go
@@ -7,6 +7,8 @@ package integration_credential
 // @description: Manages integrations with third-party services and systems. Provides the foundation for connecting Genesys Cloud to external APIs, enabling data exchange and workflow automation across platforms.
 
 import (
+	"strings"
+
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_register"
@@ -71,7 +73,21 @@ func ResourceIntegrationCredential() *schema.Resource {
 func IntegrationCredentialExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllCredentials),
-		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No Reference
+		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
+			"name": {
+				RefType: "genesyscloud_integration",
+				// The integration credential name is prefixed with 'Integration-' followed by a GUID reference to the
+				// parent integration resource. This function allows us to resolve this value so that it is exported as
+				//     "genesyscloud_integration_credential": {
+				//	     "Integration-Genesys_Cloud_Data_Actions": {
+				//         "name": "Integration-${genesyscloud_integration.Genesys_Cloud_Data_Actions.id}"
+				//       },
+				GetIdFunc: func(value string) string {
+					s, _ := strings.CutPrefix(value, "Integration-")
+					return s
+				},
+			},
+		},
 		UnResolvableAttributes: map[string]*schema.Schema{
 			"fields": ResourceIntegrationCredential().Schema["fields"],
 		},

--- a/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_schema.go
+++ b/genesyscloud/integration_custom_auth_action/resource_genesyscloud_integration_custom_auth_action_schema.go
@@ -134,7 +134,11 @@ func IntegrationCustomAuthActionExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllModifiedCustomAuthActions),
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
-			"integration_id": {RefType: "genesyscloud_integration"},
+			"integration_id":        {RefType: "genesyscloud_integration"},
+			"parent_integration_id": {RefType: "genesyscloud_integration"},
+		},
+		DataSourceResolver: map[*resourceExporter.DataAttr]*resourceExporter.ResourceAttr{
+			{Attr: "parent_integration_id"}: {Attr: "integration_id"},
 		},
 	}
 }

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -59,6 +59,12 @@ type RefAttrSettings struct {
 
 	// Values that may be set that should not be treated as IDs
 	AltValues []string
+
+	// Function that retrieves the resource ID from the attribute value
+	// If nil, the attribute value is used as the ID. You can reference
+	// the genesyscloud_integration_credential resource to understand how
+	// it is used.
+	GetIdFunc func(value string) string
 }
 
 type ResourceInfo struct {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -2277,7 +2277,21 @@ func (g *GenesysCloudResourceExporter) sanitizeConfigMap(
 			}
 
 			if refSettings != nil {
-				configMap[attributeConfigKey] = g.resolveReference(refSettings, val.(string), exporters, exportingState)
+				refIdValue := val.(string)
+				var resolvedRefIdValue string
+
+				if refSettings.GetIdFunc != nil {
+					originalValue := val.(string)
+					refIdValue = refSettings.GetIdFunc(refIdValue)
+					resolvedRefIdValue = g.resolveReference(refSettings, refIdValue, exporters, exportingState)
+
+					// After resolving the reference (so it is not a GUID but is now a ${genesyscloud...id} ref)
+					// we need to replace the original value with the resolved reference
+					resolvedRefIdValue = strings.Replace(originalValue, refIdValue, resolvedRefIdValue, 1)
+				} else {
+					resolvedRefIdValue = g.resolveReference(refSettings, refIdValue, exporters, exportingState)
+				}
+				configMap[attributeConfigKey] = resolvedRefIdValue
 			} else {
 				configMap[attributeConfigKey] = escapeString(val.(string))
 			}


### PR DESCRIPTION
NOTE: This is intended to be pulled in as a hotfix @HemanthDogiparthi12 

## Fix: Exporter reference resolution for integration custom auth actions and integration credentials

### Changes

#### 1. Fix custom auth action data source reference resolution during export

**Problem:** When exporting `genesyscloud_integration_custom_auth_action` as a data source, the `parent_integration_id` attribute contained a raw UUID instead of a proper Terraform reference (e.g., `${data.genesyscloud_integration.my_integration.id}`).

**Root Cause:** During export, `DataSourceResolver` runs first and renames the resource attribute `integration_id` to the data source attribute `parent_integration_id`. `RefAttrs` runs later to resolve IDs into Terraform references, but it only had a key for `"integration_id"` — by that point the attribute had already been renamed, so reference resolution was silently skipped.

**Fix:** Added `"parent_integration_id"` to the `RefAttrs` map in `IntegrationCustomAuthActionExporter` so reference resolution works for both the resource and data source attribute names.

#### 2. Add `GetIdFunc` to `RefAttrSettings` for integration credential name resolution

**Problem:** The `genesyscloud_integration_credential` resource stores its `name` attribute in the format `Integration-{integration_guid}`. During export, the exporter's `RefAttrs` tried to resolve this value as a reference to `genesyscloud_integration`, but the lookup failed because the `SanitizedResourceMap` is keyed by the raw integration GUID, not the prefixed string.

**Fix:** Added a `GetIdFunc` field to `RefAttrSettings` that allows a custom function to extract the actual resource ID from an attribute value before performing the reference lookup. The `IntegrationCredentialExporter` uses this to strip the `Integration-` prefix from the `name` value, enabling proper resolution to a Terraform reference like `Integration-${genesyscloud_integration.my_integration.id}`.

---

Essentially, we go from:

```
    "genesyscloud_integration_credential": {
      "Integration-Genesys_Cloud_Data_Actions": {
        "name": "Integration-5ac0e44a-3390-479f-8352-3b21f3655e23"
      },
      ...
    },
    "genesyscloud_integration_custom_auth_action": {
      "DEV-Web_Services_Data_Actions__Auth_": {
        "parent_integration_id": null
      },
      ...
    }
```

to

```
    "genesyscloud_integration_credential": {
      "Integration-Genesys_Cloud_Data_Actions": {
        "name": "Integration-${data.genesyscloud_integration.Genesys_Cloud_Data_Actions.id}"
      },
      ...
    },
    "genesyscloud_integration_custom_auth_action": {
      "DEV-Web_Services_Data_Actions__Auth_": {
        "parent_integration_id": "${data.genesyscloud_integration.DEV-Web_Services_Data_Actions_Preferred_Language_.id}"
      },
      ...
    }
  }
```
