### PR TITLE
Fix/add extra exporter references for the genesyscloud_webdeployment_configuration resource type (main)

### DIFF
--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
@@ -1080,9 +1080,11 @@ func WebDeploymentConfigurationExporter() *resourceExporter.ResourceExporter {
 			"authentication_settings": {"integration_id"},
 		},
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
-			"authentication_settings.integration_id": {RefType: "genesyscloud_integration"},
-			"enabled_categories.category_id":         {RefType: "genesyscloud_knowledge_category"},
-			"apps.knowledge.knowlege_base_id":        {RefType: "genesyscloud_knowledge_knowledgebase"},
+			"authentication_settings.integration_id":        {RefType: "genesyscloud_integration"},
+			"messenger.apps.knowledge.knowledge_base_id":    {RefType: "genesyscloud_knowledge_knowledgebase"},
+			"support_center.enabled_categories.category_id": {RefType: "genesyscloud_knowledge_category"},
+			"support_center.knowledge_base_id":              {RefType: "genesyscloud_knowledge_knowledgebase"},
+			"support_center.label_filter.label_ids":         {RefType: "genesyscloud_knowledge_label"},
 		},
 	}
 }


### PR DESCRIPTION
NOTE: Please pull this in as a hotfix for the MEC1 initiative @HemanthDogiparthi12 

Fix/add extra exporter references for the genesyscloud_webdeployment_configuration resource type

This is from real world feedback from the MEC1 migration initiative