### PR TITLE
Fixes exporter output bug when outputting both data and resources using the split by resource option

### DIFF
--- a/genesyscloud/tfexporter/json_exporter.go
+++ b/genesyscloud/tfexporter/json_exporter.go
@@ -108,7 +108,7 @@ func (j *JsonExporter) exportJSONConfig() diag.Diagnostics {
 				},
 			}
 
-			resourceJSONFilePath := filepath.Join(j.dirPath, fmt.Sprintf("%s.%s", resType, resourceJSONFileExt))
+			resourceJSONFilePath := filepath.Join(j.dirPath, fmt.Sprintf("data_%s.%s", resType, resourceJSONFileExt))
 			if resourceJSONFilePath == "" {
 				return diag.Errorf("Failed to create file path %s", resourceJSONFilePath)
 			}

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -82,6 +82,7 @@ func TestAccResourceTfExportIncludeFilterResourcesByRegEx(t *testing.T) {
 		},
 		strconv.Quote("json"),
 		util.FalseValue,
+		[]string{},
 		[]string{
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[0].OriginalResourceLabel),
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[1].OriginalResourceLabel),
@@ -143,6 +144,7 @@ func TestAccResourceTfExportIncludeFilterResourcesByRegExAndSanitizedLabels(t *t
 		},
 		strconv.Quote("json"),
 		util.FalseValue,
+		[]string{},
 		[]string{
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[0].OriginalResourceLabel),
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[1].OriginalResourceLabel),
@@ -216,6 +218,7 @@ func TestAccResourceTfExportIncludeFilterResourcesByRegExExclusiveToResource(t *
 		},
 		strconv.Quote("json"),
 		util.FalseValue,
+		[]string{},
 		[]string{
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[0].OriginalResourceLabel),
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[1].OriginalResourceLabel),
@@ -342,11 +345,13 @@ func TestAccResourceTfExportSplitFilesAsJSON(t *testing.T) {
 			filepath.Join(exportTestDir, "genesyscloud_user.tf.json"),
 			filepath.Join(exportTestDir, "genesyscloud_routing_wrapupcode.tf.json"),
 			filepath.Join(exportTestDir, "provider.tf.json"),
+			filepath.Join(exportTestDir, "data_genesyscloud_auth_division.tf.json"),
+			filepath.Join(exportTestDir, "data_genesyscloud_routing_queue.tf.json"),
 		}
 
 		queueResources = []QueueExport{
 			{OriginalResourceLabel: "test-queue-1", ExportedLabel: "test-queue-1-" + uuid.NewString() + uniquePostfix, Description: "This is a test queue", AcwTimeoutMs: 200000},
-			{OriginalResourceLabel: "test-queue-2", ExportedLabel: "test-queue-1-" + uuid.NewString() + uniquePostfix, Description: "This is a test queue too", AcwTimeoutMs: 200000},
+			{OriginalResourceLabel: "test-queue-2", ExportedLabel: "test-queue-2-" + uuid.NewString() + uniquePostfix, Description: "This is a test queue too", AcwTimeoutMs: 200000},
 		}
 
 		userResources = []UserExport{
@@ -377,9 +382,16 @@ func TestAccResourceTfExportSplitFilesAsJSON(t *testing.T) {
 			strconv.Quote("genesyscloud_routing_queue::" + uniquePostfix + "$"),
 			strconv.Quote("genesyscloud_user::" + uniquePostfix + "$"),
 			strconv.Quote("genesyscloud_routing_wrapupcode::" + uniquePostfix + "$"),
+			strconv.Quote(fmt.Sprintf("%s::^%s$", authDivision.ResourceType, divName)),
 		},
 		strconv.Quote("json"),
 		util.TrueValue,
+		// Replace With Data Source
+		[]string{
+			strconv.Quote("genesyscloud_routing_queue::" + queueResources[0].ExportedLabel + "$"),
+			strconv.Quote(fmt.Sprintf("%s::^%s$", authDivision.ResourceType, divName)),
+		},
+		// Depends On
 		[]string{
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[0].OriginalResourceLabel),
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[1].OriginalResourceLabel),
@@ -400,10 +412,31 @@ func TestAccResourceTfExportSplitFilesAsJSON(t *testing.T) {
 			{
 				Config: configWithExporter,
 				Check: resource.ComposeTestCheckFunc(
+					// Routing Queue Resource
 					validateFileCreated(expectedFilesPath[0]),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[0], "resource.genesyscloud_routing_queue."+queueResources[1].ExportedLabel, "name", queueResources[1].ExportedLabel),
+
+					// User Resource
 					validateFileCreated(expectedFilesPath[1]),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[1], "resource.genesyscloud_user."+resourceExporter.NewSanitizerProvider().S.SanitizeResourceBlockLabel(userResources[0].Email), "name", userResources[0].ExportedLabel),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[1], "resource.genesyscloud_user."+resourceExporter.NewSanitizerProvider().S.SanitizeResourceBlockLabel(userResources[1].Email), "name", userResources[1].ExportedLabel),
+
+					// Routing Wrapupcode Resource
 					validateFileCreated(expectedFilesPath[2]),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[2], "resource.genesyscloud_routing_wrapupcode."+wrapupCodeResources[0].Name, "name", wrapupCodeResources[0].Name),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[2], "resource.genesyscloud_routing_wrapupcode."+wrapupCodeResources[1].Name, "name", wrapupCodeResources[1].Name),
+
+					// Provider
 					validateFileCreated(expectedFilesPath[3]),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[3], "terraform.required_providers.genesyscloud", "source", "genesys.com/mypurecloud/genesyscloud"),
+
+					// Auth Division Data Resource
+					validateFileCreated(expectedFilesPath[4]),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[4], "data.genesyscloud_auth_division."+divName, "name", divName),
+
+					// Routing Queue Data Resource
+					validateFileCreated(expectedFilesPath[5]),
+					util.ValidateJSONFileKeyValue(expectedFilesPath[5], "data.genesyscloud_routing_queue."+queueResources[0].ExportedLabel, "name", queueResources[0].ExportedLabel),
 				),
 			},
 		},
@@ -882,6 +915,7 @@ func TestAccResourceTfExportIncludeFilterResourcesByType(t *testing.T) {
 		},
 		strconv.Quote("json"),
 		util.FalseValue,
+		[]string{},
 		[]string{
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[0].OriginalResourceLabel),
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[1].OriginalResourceLabel),
@@ -1472,6 +1506,7 @@ func TestAccResourceSurveyFormsPublishedAndUnpublished(t *testing.T) {
 					strconv.Quote("json"), // export_as_hcl
 					util.FalseValue,
 					[]string{},
+					[]string{},
 				),
 				Check: resource.ComposeTestCheckFunc(
 					validatePublishedAndUnpublishedExported(configPath),
@@ -1523,6 +1558,7 @@ func TestAccResourceExportManagedSitesAsData(t *testing.T) {
 					},
 					strconv.Quote("json"), // export_format attribute
 					util.FalseValue,
+					[]string{},
 					[]string{},
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -1586,6 +1622,7 @@ func TestAccResourceTfExportSplitFilesAsHCL(t *testing.T) {
 		},
 		strconv.Quote("hcl"),
 		util.TrueValue,
+		[]string{},
 		[]string{
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[0].OriginalResourceLabel),
 			strconv.Quote("genesyscloud_routing_queue." + queueResources[1].OriginalResourceLabel),
@@ -1692,6 +1729,7 @@ resource "genesyscloud_architect_user_prompt" "%s" {
 					},
 					strconv.Quote("json"), // export_format attribute
 					util.FalseValue,
+					[]string{},
 					[]string{
 						strconv.Quote("genesyscloud_architect_user_prompt." + dPromptResourceLabel),
 						strconv.Quote("genesyscloud_architect_user_prompt." + hPromptResourceLabel),
@@ -2042,7 +2080,7 @@ func TestAccResourceTfExportArchitectFlowExporterLegacyAndNew(t *testing.T) {
 
 		exportedFlowResourceLabel               = systemFlowType + "_" + systemFlowNameSanitized
 		pathToExportedTerraformConfig           = filepath.Join(exportTestDir, defaultTfJSONFile)
-		exportedFlowResourceFullPath            = architectFlow.ResourceType + "." + exportedFlowResourceLabel
+		exportedFlowResourceFullPath            = "resource." + architectFlow.ResourceType + "." + exportedFlowResourceLabel
 		expectedFilepathValueWithLegacyExporter = fmt.Sprintf("${var.genesyscloud_flow_%s_%s_filepath}", systemFlowType, systemFlowNameSanitized)
 		expectedFilepathValueWithNewExporter    = filepath.Join(architectFlow.ExportSubDirectoryName, fmt.Sprintf("%s-%s-%s.yaml", systemFlowNameSanitized, systemFlowType, systemFlowId))
 	)
@@ -2072,7 +2110,7 @@ func TestAccResourceTfExportArchitectFlowExporterLegacyAndNew(t *testing.T) {
 					resource.TestCheckResourceAttr(exportFullPath, "use_legacy_architect_flow_exporter", util.TrueValue),
 					validateFileCreated(filepath.Join(exportTestDir, "terraform.tfvars")),
 					validateFileNotCreated(filepath.Join(exportTestDir, architectFlow.ExportSubDirectoryName)),
-					validateExportedResourceAttributeValue(pathToExportedTerraformConfig, exportedFlowResourceFullPath, "filepath", expectedFilepathValueWithLegacyExporter),
+					util.ValidateJSONFileKeyValue(pathToExportedTerraformConfig, exportedFlowResourceFullPath, "filepath", expectedFilepathValueWithLegacyExporter),
 				),
 			},
 			{
@@ -2091,7 +2129,7 @@ func TestAccResourceTfExportArchitectFlowExporterLegacyAndNew(t *testing.T) {
 					validateFileNotCreated(filepath.Join(exportTestDir, "terraform.tfvars")),
 					validateFileCreated(pathToFolderHoldingExportedFlows),
 					validateFileCreated(filepath.Join(pathToFolderHoldingExportedFlows, exportedSystemFlowFileName)),
-					validateExportedResourceAttributeValue(pathToExportedTerraformConfig, exportedFlowResourceFullPath, "filepath", expectedFilepathValueWithNewExporter),
+					util.ValidateJSONFileKeyValue(pathToExportedTerraformConfig, exportedFlowResourceFullPath, "filepath", expectedFilepathValueWithNewExporter),
 				),
 			},
 		},

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_utils_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_utils_test.go
@@ -534,6 +534,7 @@ func generateTfExportByIncludeFilterResources(
 	includeFilterResources []string,
 	exportFormat string,
 	splitByResource string,
+	replaceWithDatasource []string,
 	dependencies []string,
 ) string {
 	return fmt.Sprintf(`resource "genesyscloud_tf_export" "%s" {
@@ -542,9 +543,10 @@ func generateTfExportByIncludeFilterResources(
 		include_filter_resources = [%s]
 		export_format = %s
 		split_files_by_resource = %s
+		replace_with_datasource = [%s]
 		depends_on = [%s]
 	}
-	`, resourceLabel, directory, includeState, strings.Join(includeFilterResources, ","), exportFormat, splitByResource, strings.Join(dependencies, ","))
+	`, resourceLabel, directory, includeState, strings.Join(includeFilterResources, ","), exportFormat, splitByResource, strings.Join(replaceWithDatasource, ","), strings.Join(dependencies, ","))
 }
 
 func generateTfExportByFlowDependsOnResources(
@@ -763,7 +765,7 @@ func validateCompressedConfigFiles(dirName string, file *zip.File) error {
 
 func validateConfigFile(path string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
-		result, err := loadJsonFileToMap(path)
+		result, err := util.LoadJsonFileToMap(path)
 		if err != nil {
 			return err
 		}
@@ -1013,7 +1015,7 @@ func validateStateFileHasPublishedAndUnpublished(filename string) resource.TestC
 			return fmt.Errorf("failed to find file %s", filename)
 		}
 
-		stateData, err := loadJsonFileToMap(filename)
+		stateData, err := util.LoadJsonFileToMap(filename)
 		if err != nil {
 			return err
 		}
@@ -1093,7 +1095,7 @@ func validateStateFileAsData(filename, siteName string) resource.TestCheckFunc {
 			return fmt.Errorf("failed to find file %s", filename)
 		}
 
-		stateData, err := loadJsonFileToMap(filename)
+		stateData, err := util.LoadJsonFileToMap(filename)
 		if err != nil {
 			return err
 		}
@@ -1148,7 +1150,7 @@ func validatePublishedAndUnpublishedExported(configFile string) resource.TestChe
 
 		// Load the JSON content of the export file
 		log.Println("Loading export config into map variable")
-		exportData, err := loadJsonFileToMap(configFile)
+		exportData, err := util.LoadJsonFileToMap(configFile)
 		if err != nil {
 			return err
 		}
@@ -1178,51 +1180,6 @@ func validatePublishedAndUnpublishedExported(configFile string) resource.TestChe
 	}
 }
 
-func validateExportedResourceAttributeValue[T comparable](configFile, resourcePath, attr string, value T) resource.TestCheckFunc {
-	return func(state *terraform.State) error {
-		items := strings.Split(resourcePath, ".")
-		resourceType := items[0]
-		resourceLabel := items[1]
-
-		_, err := os.ReadFile(configFile)
-		if err != nil {
-			return fmt.Errorf("failed to read file %s: %v", configFile, err)
-		}
-
-		// Load the JSON content of the export file
-		log.Println("Loading export config into map variable")
-		exportData, err := loadJsonFileToMap(configFile)
-		if err != nil {
-			return err
-		}
-
-		resourceMap, ok := exportData["resource"].(map[string]any)
-		if !ok {
-			return fmt.Errorf("could not find resource block in exported file %s", configFile)
-		}
-
-		resources, ok := resourceMap[resourceType].(map[string]any)
-		if !ok {
-			return fmt.Errorf("no %s resources exported", resourceType)
-		}
-
-		exportedResource, ok := resources[resourceLabel].(map[string]any)
-		if !ok {
-			return fmt.Errorf("no resource %s exported", resourcePath)
-		}
-
-		exportedValue, ok := exportedResource[attr].(T)
-		if !ok {
-			return fmt.Errorf("field %s not exported in resource %s config", attr, resourcePath)
-		}
-
-		if exportedValue != value {
-			return fmt.Errorf("expected %s to equal %v, got %v", attr, value, exportedValue)
-		}
-		return nil
-	}
-}
-
 // validateExportManagedSitesAsData verifies that the default managed site 'PureCloud Voice - AWS' is exported as a data source
 func validateExportManagedSitesAsData(filename, siteName string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
@@ -1234,7 +1191,7 @@ func validateExportManagedSitesAsData(filename, siteName string) resource.TestCh
 
 		// Load the JSON content of the export file
 		log.Println("Loading export config into map variable")
-		exportData, err := loadJsonFileToMap(filename)
+		exportData, err := util.LoadJsonFileToMap(filename)
 		if err != nil {
 			return err
 		}
@@ -1277,7 +1234,7 @@ func validatePromptsExported(filename string, expectedPrompts []string) resource
 		}
 
 		log.Println("Loading export config into map variable")
-		exportData, err := loadJsonFileToMap(filename + "/genesyscloud.tf.json")
+		exportData, err := util.LoadJsonFileToMap(filename + "/genesyscloud.tf.json")
 		if err != nil {
 			return fmt.Errorf("failed to unmarshal JSON from file %s: %s", filename, err)
 		}
@@ -1336,7 +1293,7 @@ func validateExportedCampaignScriptIds(
 		}
 
 		log.Println("Loading export config into map variable")
-		exportData, err := loadJsonFileToMap(filename)
+		exportData, err := util.LoadJsonFileToMap(filename)
 		if err != nil {
 			return err
 		}
@@ -1404,25 +1361,6 @@ func validateNumberOfExportedDataSources(filename string) resource.TestCheckFunc
 	}
 }
 
-func loadJsonFileToMap(filename string) (map[string]interface{}, error) {
-	var data map[string]interface{}
-
-	jsonFile, err := os.Open(filename)
-	if err != nil {
-		return nil, fmt.Errorf("failed to open export file at path %s: %v", filename, err)
-	}
-	defer func(jsonFile *os.File) {
-		_ = jsonFile.Close()
-	}(jsonFile)
-
-	byteValue, _ := io.ReadAll(jsonFile)
-	if err := json.Unmarshal(byteValue, &data); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal json exportData to map variable: %v", err)
-	}
-
-	return data, nil
-}
-
 func testUserPromptAudioFileExport(filePath, resourceType, resourceLabel, exportDir, nameAttrRef string) resource.TestCheckFunc {
 	return func(state *terraform.State) error {
 		raw, err := getResourceDefinition(filePath, resourceType)
@@ -1473,7 +1411,7 @@ func verifyLabelsExistInExportedStateFile(filename, relevantResourceType string,
 			return fmt.Errorf("failed to find file %s", filename)
 		}
 
-		stateData, err := loadJsonFileToMap(filename)
+		stateData, err := util.LoadJsonFileToMap(filename)
 		if err != nil {
 			return err
 		}
@@ -1496,7 +1434,7 @@ func verifyLabelsExistInExportedTfConfig(filename, relevantResourceType string, 
 			return fmt.Errorf("failed to find file %s", filename)
 		}
 
-		stateData, err := loadJsonFileToMap(filename)
+		stateData, err := util.LoadJsonFileToMap(filename)
 		if err != nil {
 			return err
 		}

--- a/genesyscloud/tfexporter/tf_exporter_resource_test.go
+++ b/genesyscloud/tfexporter/tf_exporter_resource_test.go
@@ -373,10 +373,12 @@ func (r *registerTestInstance) registerTestExporters() {
 
 func (r *registerTestInstance) registerTestDataSources() {
 	providerDataSources["genesyscloud_auth_division_home"] = gcloud.DataSourceAuthDivisionHome()
+	providerDataSources[authDivision.ResourceType] = authDivision.DataSourceAuthDivision()
 	providerDataSources[scripts.ResourceType] = scripts.DataSourceScript()
 	providerDataSources[edgeSite.ResourceType] = edgeSite.DataSourceSite()
 	providerDataSources[cMessagingSettings.ResourceType] = cMessagingSettings.DataSourceConversationsMessagingSettings()
 	providerDataSources[tbs.ResourceType] = tbs.DataSourceTrunkBaseSettings()
+	providerDataSources[routingQueue.ResourceType] = routingQueue.DataSourceRoutingQueue()
 	providerDataSources[routingWrapupcode.ResourceType] = routingWrapupcode.DataSourceRoutingWrapupCode()
 	providerDataSources[outboundRoute.ResourceType] = outboundRoute.DataSourceSiteOutboundRoute()
 	providerDataSources[guide.ResourceType] = guide.DataSourceGuide()

--- a/genesyscloud/util/test_utils.go
+++ b/genesyscloud/util/test_utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math/rand"
 	"os"
 	"strconv"
@@ -124,6 +125,46 @@ func ValidateResourceAttributeInArray(arrayResourceName string, arrayFieldName, 
 		}
 
 		return fmt.Errorf("%s %s not found for resource %s in state", arrayFieldName, sourceValue, sourceID)
+	}
+}
+
+func ValidateJSONFileKeyValue[T comparable](configFile, resourcePath, attr string, value T) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		items := strings.Split(resourcePath, ".")
+
+		_, err := os.ReadFile(configFile)
+		if err != nil {
+			return fmt.Errorf("failed to read file %s: %v", configFile, err)
+		}
+
+		// Load the JSON content of the export file
+		log.Println("Loading export config into map variable")
+		exportJsonData, err := LoadJsonFileToMap(configFile)
+		if err != nil {
+			return err
+		}
+
+		var exportedDataAttr map[string]interface{} = exportJsonData
+
+		for _, attrKey := range items {
+			// Drill down into the nested structure using the attribute keys
+			if nextLevel, ok := exportedDataAttr[attrKey].(map[string]interface{}); ok {
+				exportedDataAttr = nextLevel
+			} else {
+				// If the key doesn't exist or isn't a map, return an error
+				return fmt.Errorf("attribute %s not found in path %s from exported data at %s", attrKey, resourcePath, configFile)
+			}
+		}
+
+		exportedValue, ok := exportedDataAttr[attr].(T)
+		if !ok {
+			return fmt.Errorf("field %s not exported in resource %s config", attr, resourcePath)
+		}
+
+		if exportedValue != value {
+			return fmt.Errorf("expected %s to equal %v, got %v", attr, value, exportedValue)
+		}
+		return nil
 	}
 }
 

--- a/genesyscloud/util/util_json.go
+++ b/genesyscloud/util/util_json.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"reflect"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -120,4 +122,23 @@ func MapToJson(m *map[string]interface{}) (string, error) {
 		return "", fmt.Errorf("failed to marshal %v: %v", *m, err)
 	}
 	return string(j), nil
+}
+
+func LoadJsonFileToMap(filename string) (map[string]interface{}, error) {
+	var data map[string]interface{}
+
+	jsonFile, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("failed to open export file at path %s: %v", filename, err)
+	}
+	defer func(jsonFile *os.File) {
+		_ = jsonFile.Close()
+	}(jsonFile)
+
+	byteValue, _ := io.ReadAll(jsonFile)
+	if err := json.Unmarshal(byteValue, &data); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal json exportData to map variable: %v", err)
+	}
+
+	return data, nil
 }

--- a/genesyscloud/util/util_json.go
+++ b/genesyscloud/util/util_json.go
@@ -135,7 +135,10 @@ func LoadJsonFileToMap(filename string) (map[string]interface{}, error) {
 		_ = jsonFile.Close()
 	}(jsonFile)
 
-	byteValue, _ := io.ReadAll(jsonFile)
+	byteValue, err := io.ReadAll(jsonFile)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read export file at path %s: %v", filename, err)
+	}
 	if err := json.Unmarshal(byteValue, &data); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal json exportData to map variable: %v", err)
 	}


### PR DESCRIPTION
## Fix: Data source files overwrite resource files when using split_files_by_resource with JSON export

### Problem

When exporting with `split_files_by_resource = true` and `export_format = "json"`, if a resource type was exported as both a resource and a data source (via `replace_with_datasource`), the data source JSON file would overwrite the resource JSON file. This happened because both used the same filename: `{resource_type}.tf.json`.

For example, if `genesyscloud_routing_queue` had some instances exported as resources and others replaced with data sources, both would write to `genesyscloud_routing_queue.tf.json`, with the second write silently overwriting the first.

### Root Cause

In `json_exporter.go`, the data source file path was generated using the same pattern as the resource file path:

```go
resourceJSONFilePath := filepath.Join(j.dirPath, fmt.Sprintf("%s.%s", resType, resourceJSONFileExt))
```

### Fix

Prefixed data source filenames with `data_` to avoid collisions:

```go
resourceJSONFilePath := filepath.Join(j.dirPath, fmt.Sprintf("data_%s.%s", resType, resourceJSONFileExt))
```

This produces filenames like `data_genesyscloud_routing_queue.tf.json` for data sources, keeping them separate from the resource file `genesyscloud_routing_queue.tf.json`.

### Test improvements

- Updated `TestAccResourceTfExportSplitFilesAsJSON` to export resources alongside data sources (using `replace_with_datasource`) and validate that both resource and data source files are created with correct content
- Added `ValidateJSONFileKeyValue` to `util/test_utils.go` — a generic, reusable test helper that validates a value at an arbitrary dot-delimited path within a JSON file, replacing the previous `validateExportedResourceAttributeValue` which was hardcoded to the `resource.{type}.{label}` path structure
- Moved `LoadJsonFileToMap` from the test file to `util/util_json.go` so it can be shared across packages
- Registered `genesyscloud_auth_division` and `genesyscloud_routing_queue` data sources in the test init to support the new test scenarios
- Fixed a copy-paste bug in the test where `test-queue-2` was using `test-queue-1-` as its exported label prefix

---

Note: This was found during MEC1 migration, but NOT needed for a hotfix