### PR TITLE
fix: echo back trunk base fields from API on edge group update to avoid modification error

### DIFF
--- a/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
+++ b/genesyscloud/telephony_providers_edges_edge_group/resource_genesyscloud_telephony_providers_edges_edge_group.go
@@ -68,11 +68,10 @@ func updateEdgeGroup(ctx context.Context, d *schema.ResourceData, meta interface
 	id := d.Id()
 
 	edgeGroup := &platformclientv2.Edgegroup{
-		Id:              &id,
-		Name:            &name,
-		Managed:         &managed,
-		Hybrid:          &hybrid,
-		PhoneTrunkBases: buildSdkTrunkBases(d),
+		Id:      &id,
+		Name:    &name,
+		Managed: &managed,
+		Hybrid:  &hybrid,
 	}
 
 	if description != "" {
@@ -91,6 +90,13 @@ func updateEdgeGroup(ctx context.Context, d *schema.ResourceData, meta interface
 			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to read edge group %s error: %s", d.Id(), getErr), resp)
 		}
 		edgeGroup.Version = edgeGroupFromApi.Version
+		edgeGroup.EdgeTrunkBaseAssignment = edgeGroupFromApi.EdgeTrunkBaseAssignment
+
+		if d.HasChange("phone_trunk_base_ids") {
+			edgeGroup.PhoneTrunkBases = buildSdkTrunkBases(d)
+		} else {
+			edgeGroup.PhoneTrunkBases = edgeGroupFromApi.PhoneTrunkBases
+		}
 
 		log.Printf("Updating edge group %s", name)
 		_, resp, putErr := edgeGroupProxy.updateEdgeGroup(ctx, d.Id(), *edgeGroup)


### PR DESCRIPTION
## Problem

Updating any field (e.g. description) on `genesyscloud_telephony_providers_edges_edge_group` fails with:
`EDGE_TRUNK_BASE_ASSIGNMENT_MODIFICATION_NOT_ALLOWED`

The `updateEdgeGroup` function was always including `PhoneTrunkBases` (built from Terraform state with bare IDs) in the PUT request, even when unchanged. It also never included the required `EdgeTrunkBaseAssignment` field. A recent API-side validation on the Genesys Cloud backend now rejects this.

## Fix

- Echo back `EdgeTrunkBaseAssignment` from the GET response into the PUT payload (required field that was never sent before)
- Echo back `PhoneTrunkBases` from the GET response when `phone_trunk_base_ids` hasn't changed, so the API doesn't see it as a modification
- Only build `PhoneTrunkBases` from Terraform state when `phone_trunk_base_ids` has actually changed

## Testing

Reproduced and verified on DCA environment. Description-only updates now return 200 instead of 400.