### PR TITLE
Revert integration credentials name reference resolution (main)

### DIFF
--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_schema.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential_schema.go
@@ -7,8 +7,6 @@ package integration_credential
 // @description: Manages integrations with third-party services and systems. Provides the foundation for connecting Genesys Cloud to external APIs, enabling data exchange and workflow automation across platforms.
 
 import (
-	"strings"
-
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_register"
@@ -73,21 +71,7 @@ func ResourceIntegrationCredential() *schema.Resource {
 func IntegrationCredentialExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllCredentials),
-		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
-			"name": {
-				RefType: "genesyscloud_integration",
-				// The integration credential name is prefixed with 'Integration-' followed by a GUID reference to the
-				// parent integration resource. This function allows us to resolve this value so that it is exported as
-				//     "genesyscloud_integration_credential": {
-				//	     "Integration-Genesys_Cloud_Data_Actions": {
-				//         "name": "Integration-${genesyscloud_integration.Genesys_Cloud_Data_Actions.id}"
-				//       },
-				GetIdFunc: func(value string) string {
-					s, _ := strings.CutPrefix(value, "Integration-")
-					return s
-				},
-			},
-		},
+		RefAttrs:         map[string]*resourceExporter.RefAttrSettings{}, // No Reference
 		UnResolvableAttributes: map[string]*schema.Schema{
 			"fields": ResourceIntegrationCredential().Schema["fields"],
 		},

--- a/genesyscloud/resource_exporter/resource_exporter.go
+++ b/genesyscloud/resource_exporter/resource_exporter.go
@@ -59,12 +59,6 @@ type RefAttrSettings struct {
 
 	// Values that may be set that should not be treated as IDs
 	AltValues []string
-
-	// Function that retrieves the resource ID from the attribute value
-	// If nil, the attribute value is used as the ID. You can reference
-	// the genesyscloud_integration_credential resource to understand how
-	// it is used.
-	GetIdFunc func(value string) string
 }
 
 type ResourceInfo struct {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -2278,21 +2278,7 @@ func (g *GenesysCloudResourceExporter) sanitizeConfigMap(
 			}
 
 			if refSettings != nil {
-				refIdValue := val.(string)
-				var resolvedRefIdValue string
-
-				if refSettings.GetIdFunc != nil {
-					originalValue := val.(string)
-					refIdValue = refSettings.GetIdFunc(refIdValue)
-					resolvedRefIdValue = g.resolveReference(refSettings, refIdValue, exporters, exportingState)
-
-					// After resolving the reference (so it is not a GUID but is now a ${genesyscloud...id} ref)
-					// we need to replace the original value with the resolved reference
-					resolvedRefIdValue = strings.Replace(originalValue, refIdValue, resolvedRefIdValue, 1)
-				} else {
-					resolvedRefIdValue = g.resolveReference(refSettings, refIdValue, exporters, exportingState)
-				}
-				configMap[attributeConfigKey] = resolvedRefIdValue
+				configMap[attributeConfigKey] = g.resolveReference(refSettings, val.(string), exporters, exportingState)
 			} else {
 				configMap[attributeConfigKey] = escapeString(val.(string))
 			}


### PR DESCRIPTION
## Revert DEVTOOLING-1638 integration credential name reference resolution

### Description

Reverts the integration credential `name` field reference resolution introduced in `bd898ee05` (PR #2230). That change added a `RefAttr` on the `name` field of `genesyscloud_integration_credential` pointing to `genesyscloud_integration`, along with a `GetIdFunc` mechanism on `RefAttrSettings` to extract the integration GUID from the `Integration-<guid>` naming convention.

While the intent was correct — resolving the GUID so credentials maintain their parent association across org syncs — the resulting export produces a Terraform cycle error:

```text
Error: Cycle: genesyscloud_integration_credential.Integration-Genesys_Cloud_Data_Actions,
              genesyscloud_integration.Genesys_Cloud_Data_Actions
```

This is because `genesyscloud_integration` already references `genesyscloud_integration_credential` via `config.credentials.*`, and the new `name` reference creates the reverse edge. This cycle is fundamental and cannot be resolved with data source references or exporter-level dependency flags.

A separate bug (DEVTOOLING-1644) has been filed to address the underlying problem with a new `genesyscloud_integration_config` resource that breaks the config out of the integration resource, eliminating the cycle.

### Changes

- **`integration_credential/resource_genesyscloud_integration_credential_schema.go`** — Reverted `RefAttrs` back to empty map, removed `"strings"` import
- **`resource_exporter/resource_exporter.go`** — Removed `GetIdFunc` field from `RefAttrSettings`
- **`tfexporter/genesyscloud_resource_exporter.go`** — Reverted `GetIdFunc` handling in `sanitizeConfigMap` back to the original single-line `resolveReference` call

The `integration_custom_auth_action` changes from the same commit (`parent_integration_id` RefAttr and `DataSourceResolver`) are **not reverted** as they do not create a cycle.

### Testing

- `go build ./...` passes
- `TestUnitTestForExportCycles` passes (no cycles detected)
- All tfexporter unit tests pass
