### PR TITLE
Add suppport for WhatsApp in Messaging Campaigns (main)

### DIFF
--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign.go
@@ -107,6 +107,7 @@ func readOutboundMessagingcampaign(ctx context.Context, d *schema.ResourceData, 
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "dynamic_contact_queueing_settings", messagingCampaign.DynamicContactQueueingSettings, flattenDynamicContactQueueingSettingss)
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "email_config", messagingCampaign.EmailConfig, flattenEmailConfigs)
 		d.Set("sms_config", flattenSmsConfigs(messagingCampaign.SmsConfig))
+		d.Set("whats_app_config", flattenWhatsAppConfigs(messagingCampaign.WhatsAppConfig))
 
 		log.Printf("Read outbound messagingcampaign %s %s", d.Id(), *messagingCampaign.Name)
 		return cc.CheckState(d)

--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_schema.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_schema.go
@@ -123,6 +123,27 @@ var (
 		},
 	}
 
+	whatsAppConfigResource = &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			`whats_app_columns`: {
+				Description: `The contact list columns specifying the WhatsApp address(es) of the contact`,
+				Required:    true,
+				Type:        schema.TypeList,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			`whats_app_integration_id`: {
+				Description: `The WhatsApp integration used to send message to the contact.`,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+			`content_template_id`: {
+				Description: `The content template used to formulate the email to send to the contact.`,
+				Required:    true,
+				Type:        schema.TypeString,
+			},
+		},
+	}
+
 	ContactSortResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			`field_name`: {
@@ -287,7 +308,7 @@ func ResourceOutboundMessagingcampaign() *schema.Resource {
 				Type:         schema.TypeSet,
 				MaxItems:     1,
 				Elem:         emailConfigResource,
-				ExactlyOneOf: []string{"sms_config"},
+				ExactlyOneOf: []string{"email_config", "sms_config", "whats_app_config"},
 			},
 			`sms_config`: {
 				Description:  `Configuration for this messaging campaign to send SMS messages.`,
@@ -295,7 +316,15 @@ func ResourceOutboundMessagingcampaign() *schema.Resource {
 				Type:         schema.TypeSet,
 				MaxItems:     1,
 				Elem:         smsConfigResource,
-				ExactlyOneOf: []string{"email_config"},
+				ExactlyOneOf: []string{"email_config", "sms_config", "whats_app_config"},
+			},
+			`whats_app_config`: {
+				Description:  `Configuration for this messaging campaign to send WhatsApp messages.`,
+				Optional:     true,
+				Type:         schema.TypeSet,
+				MaxItems:     1,
+				Elem:         whatsAppConfigResource,
+				ExactlyOneOf: []string{"email_config", "sms_config", "whats_app_config"},
 			},
 		},
 	}
@@ -306,16 +335,18 @@ func OutboundMessagingcampaignExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllAuthOutboundMessagingcampaigns),
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
-			`division_id`:                             {RefType: "genesyscloud_auth_division"},
-			`contact_list_id`:                         {RefType: "genesyscloud_outbound_contact_list"},
-			`contact_list_filter_ids`:                 {RefType: "genesyscloud_outbound_contactlistfilter"},
-			`dnc_list_ids`:                            {RefType: "genesyscloud_outbound_dnclist"},
-			`callable_time_set_id`:                    {RefType: "genesyscloud_outbound_callabletimeset"},
-			`rule_set_ids`:                            {RefType: "genesyscloud_outbound_digitalruleset"},
-			`email_config.reply_to_address.route_id`:  {RefType: "genesyscloud_routing_email_route"},
-			`email_config.reply_to_address.domain_id`: {RefType: "genesyscloud_routing_email_domain"},
-			`sms_config.content_template_id`:          {RefType: "genesyscloud_responsemanagement_response"},
-			`email_config.content_template_id`:        {RefType: "genesyscloud_responsemanagement_response"},
+			`callable_time_set_id`:                      {RefType: "genesyscloud_outbound_callabletimeset"},
+			`contact_list_filter_ids`:                   {RefType: "genesyscloud_outbound_contactlistfilter"},
+			`contact_list_id`:                           {RefType: "genesyscloud_outbound_contact_list"},
+			`division_id`:                               {RefType: "genesyscloud_auth_division"},
+			`dnc_list_ids`:                              {RefType: "genesyscloud_outbound_dnclist"},
+			`email_config.content_template_id`:          {RefType: "genesyscloud_responsemanagement_response"},
+			`email_config.reply_to_address.domain_id`:   {RefType: "genesyscloud_routing_email_domain"},
+			`email_config.reply_to_address.route_id`:    {RefType: "genesyscloud_routing_email_route"},
+			`rule_set_ids`:                              {RefType: "genesyscloud_outbound_digitalruleset"},
+			`sms_config.content_template_id`:            {RefType: "genesyscloud_responsemanagement_response"},
+			`whats_app_config.content_template_id`:      {RefType: "genesyscloud_responsemanagement_response"},
+			`whats_app_config.whats_app_integration_id`: {RefType: "genesyscloud_conversations_messaging_integrations_whatsapp"},
 		},
 	}
 }

--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_test.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_test.go
@@ -758,6 +758,20 @@ func generateOutboundMessagingCampaignEmailConfig(
 `, strings.Join(emailColumns, ", "), contentTemplateId, fromAddressDomainId, fromAddressLocalPart, replyToAddressDomainId, replyToAddressRouteId)
 }
 
+func generateOutboundMessagingCampaignWhatsAppConfig(
+	whatsAppColumns []string,
+	whatsAppIntegrationId string,
+	contentTemplateId string,
+) string {
+	return fmt.Sprintf(`
+	whats_app_config {
+		whats_app_columns        = [%s]
+		whats_app_integration_id = %s
+		content_template_id      = %s
+	}
+`, strings.Join(whatsAppColumns, ", "), whatsAppIntegrationId, contentTemplateId)
+}
+
 func generateDynamicContactQueueingSettings(sort string, filter string) string {
 	return fmt.Sprintf(`
 	dynamic_contact_queueing_settings {

--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_unit_test.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_unit_test.go
@@ -1,0 +1,295 @@
+package outbound_messagingcampaign
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v179/platformclientv2"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitBuildWhatsAppConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil for nil input", func(t *testing.T) {
+		result := buildWhatsAppConfigs(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("returns nil for empty set", func(t *testing.T) {
+		emptySet := schema.NewSet(schema.HashResource(whatsAppConfigResource), []interface{}{})
+		result := buildWhatsAppConfigs(emptySet)
+		assert.Nil(t, result)
+	})
+
+	t.Run("builds config with all fields", func(t *testing.T) {
+		configMap := map[string]interface{}{
+			"whats_app_columns":        []interface{}{"col1", "col2"},
+			"whats_app_integration_id": "integration-123",
+			"content_template_id":      "template-456",
+		}
+		configSet := schema.NewSet(schema.HashResource(whatsAppConfigResource), []interface{}{configMap})
+
+		result := buildWhatsAppConfigs(configSet)
+
+		assert.NotNil(t, result)
+		assert.NotNil(t, result.WhatsAppColumns)
+		assert.Equal(t, []string{"col1", "col2"}, *result.WhatsAppColumns)
+		assert.NotNil(t, result.WhatsAppIntegration)
+		assert.Equal(t, "integration-123", *result.WhatsAppIntegration.Id)
+		assert.NotNil(t, result.ContentTemplate)
+		assert.Equal(t, "template-456", *result.ContentTemplate.Id)
+	})
+}
+
+func TestUnitFlattenWhatsAppConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns nil for nil input", func(t *testing.T) {
+		result := flattenWhatsAppConfigs(nil)
+		assert.Nil(t, result)
+	})
+
+	t.Run("flattens config with all fields", func(t *testing.T) {
+		columns := []string{"col1", "col2"}
+		config := &platformclientv2.Whatsappconfig{
+			WhatsAppColumns:     &columns,
+			WhatsAppIntegration: &platformclientv2.Addressableentityref{Id: platformclientv2.String("integration-123")},
+			ContentTemplate:     &platformclientv2.Domainentityref{Id: platformclientv2.String("template-456")},
+		}
+
+		result := flattenWhatsAppConfigs(config)
+
+		assert.NotNil(t, result)
+		assert.Equal(t, 1, result.Len())
+		resultMap := result.List()[0].(map[string]interface{})
+		assert.Equal(t, "integration-123", resultMap["whats_app_integration_id"])
+		assert.Equal(t, "template-456", resultMap["content_template_id"])
+	})
+
+	t.Run("handles nil nested fields", func(t *testing.T) {
+		config := &platformclientv2.Whatsappconfig{}
+
+		result := flattenWhatsAppConfigs(config)
+
+		assert.NotNil(t, result)
+		assert.Equal(t, 1, result.Len())
+	})
+}
+
+func TestUnitBuildAndFlattenWhatsAppConfigsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	configMap := map[string]interface{}{
+		"whats_app_columns":        []interface{}{"phoneCol"},
+		"whats_app_integration_id": "int-abc",
+		"content_template_id":      "tmpl-xyz",
+	}
+	configSet := schema.NewSet(schema.HashResource(whatsAppConfigResource), []interface{}{configMap})
+
+	built := buildWhatsAppConfigs(configSet)
+	flattened := flattenWhatsAppConfigs(built)
+
+	assert.NotNil(t, flattened)
+	assert.Equal(t, 1, flattened.Len())
+	resultMap := flattened.List()[0].(map[string]interface{})
+	assert.Equal(t, "int-abc", resultMap["whats_app_integration_id"])
+	assert.Equal(t, "tmpl-xyz", resultMap["content_template_id"])
+}
+
+func TestUnitMessagingCampaignWhatsAppCreate(t *testing.T) {
+	var (
+		campaignId       = uuid.NewString()
+		campaignName     = "Test WhatsApp Campaign"
+		contactListId    = uuid.NewString()
+		integrationId    = uuid.NewString()
+		templateId       = uuid.NewString()
+		messagesPerMin   = 10
+		campaignStatus   = "off"
+		whatsAppColumns  = []string{"whatsappCol"}
+		version          = 1
+	)
+
+	proxy := &outboundMessagingcampaignProxy{}
+
+	proxy.createOutboundMessagingcampaignAttr = func(ctx context.Context, p *outboundMessagingcampaignProxy, campaign *platformclientv2.Messagingcampaign) (*platformclientv2.Messagingcampaign, *platformclientv2.APIResponse, error) {
+		assert.Equal(t, campaignName, *campaign.Name)
+		assert.NotNil(t, campaign.WhatsAppConfig)
+		assert.Equal(t, integrationId, *campaign.WhatsAppConfig.WhatsAppIntegration.Id)
+		assert.Equal(t, templateId, *campaign.WhatsAppConfig.ContentTemplate.Id)
+		assert.Equal(t, whatsAppColumns, *campaign.WhatsAppConfig.WhatsAppColumns)
+
+		campaign.Id = &campaignId
+		campaign.Version = &version
+		return campaign, nil, nil
+	}
+
+	proxy.getOutboundMessagingcampaignByIdAttr = func(ctx context.Context, p *outboundMessagingcampaignProxy, id string) (*platformclientv2.Messagingcampaign, *platformclientv2.APIResponse, error) {
+		assert.Equal(t, campaignId, id)
+		return &platformclientv2.Messagingcampaign{
+			Id:                &campaignId,
+			Name:              &campaignName,
+			CampaignStatus:    &campaignStatus,
+			MessagesPerMinute: &messagesPerMin,
+			ContactList:       &platformclientv2.Domainentityref{Id: &contactListId},
+			Version:           &version,
+			WhatsAppConfig: &platformclientv2.Whatsappconfig{
+				WhatsAppColumns:     &whatsAppColumns,
+				WhatsAppIntegration: &platformclientv2.Addressableentityref{Id: &integrationId},
+				ContentTemplate:     &platformclientv2.Domainentityref{Id: &templateId},
+			},
+		}, &platformclientv2.APIResponse{StatusCode: http.StatusOK}, nil
+	}
+
+	internalProxy = proxy
+	defer func() { internalProxy = nil }()
+
+	ctx := context.Background()
+	gCloud := &provider.ProviderMeta{ClientConfig: &platformclientv2.Configuration{}}
+
+	resourceSchema := ResourceOutboundMessagingcampaign().Schema
+	resourceDataMap := buildMessagingCampaignWhatsAppResourceMap(campaignName, contactListId, campaignStatus, messagesPerMin, integrationId, templateId, whatsAppColumns)
+
+	d := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
+	d.SetId(campaignId)
+
+	diag := createOutboundMessagingcampaign(ctx, d, gCloud)
+	assert.Equal(t, false, diag.HasError())
+	assert.Equal(t, campaignId, d.Id())
+}
+
+func TestUnitMessagingCampaignWhatsAppRead(t *testing.T) {
+	var (
+		campaignId      = uuid.NewString()
+		campaignName    = "Test WhatsApp Campaign"
+		contactListId   = uuid.NewString()
+		integrationId   = uuid.NewString()
+		templateId      = uuid.NewString()
+		messagesPerMin  = 10
+		campaignStatus  = "off"
+		whatsAppColumns = []string{"whatsappCol"}
+		version         = 1
+	)
+
+	proxy := &outboundMessagingcampaignProxy{}
+
+	proxy.getOutboundMessagingcampaignByIdAttr = func(ctx context.Context, p *outboundMessagingcampaignProxy, id string) (*platformclientv2.Messagingcampaign, *platformclientv2.APIResponse, error) {
+		assert.Equal(t, campaignId, id)
+		return &platformclientv2.Messagingcampaign{
+			Id:                &campaignId,
+			Name:              &campaignName,
+			CampaignStatus:    &campaignStatus,
+			MessagesPerMinute: &messagesPerMin,
+			ContactList:       &platformclientv2.Domainentityref{Id: &contactListId},
+			Version:           &version,
+			WhatsAppConfig: &platformclientv2.Whatsappconfig{
+				WhatsAppColumns:     &whatsAppColumns,
+				WhatsAppIntegration: &platformclientv2.Addressableentityref{Id: &integrationId},
+				ContentTemplate:     &platformclientv2.Domainentityref{Id: &templateId},
+			},
+		}, &platformclientv2.APIResponse{StatusCode: http.StatusOK}, nil
+	}
+
+	internalProxy = proxy
+	defer func() { internalProxy = nil }()
+
+	ctx := context.Background()
+	gCloud := &provider.ProviderMeta{ClientConfig: &platformclientv2.Configuration{}}
+
+	resourceSchema := ResourceOutboundMessagingcampaign().Schema
+	resourceDataMap := buildMessagingCampaignWhatsAppResourceMap(campaignName, contactListId, campaignStatus, messagesPerMin, integrationId, templateId, whatsAppColumns)
+
+	d := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
+	d.SetId(campaignId)
+
+	diag := readOutboundMessagingcampaign(ctx, d, gCloud)
+	assert.Equal(t, false, diag.HasError())
+	assert.Equal(t, campaignId, d.Id())
+	assert.Equal(t, campaignName, d.Get("name").(string))
+	assert.Equal(t, campaignStatus, d.Get("campaign_status").(string))
+	assert.Equal(t, messagesPerMin, d.Get("messages_per_minute").(int))
+}
+
+func TestUnitMessagingCampaignWhatsAppUpdate(t *testing.T) {
+	var (
+		campaignId         = uuid.NewString()
+		campaignName       = "Updated WhatsApp Campaign"
+		contactListId      = uuid.NewString()
+		integrationId      = uuid.NewString()
+		templateId         = uuid.NewString()
+		messagesPerMin     = 20
+		campaignStatus     = "off"
+		whatsAppColumns    = []string{"whatsappCol"}
+		version            = 2
+	)
+
+	proxy := &outboundMessagingcampaignProxy{}
+
+	proxy.getOutboundMessagingcampaignByIdAttr = func(ctx context.Context, p *outboundMessagingcampaignProxy, id string) (*platformclientv2.Messagingcampaign, *platformclientv2.APIResponse, error) {
+		return &platformclientv2.Messagingcampaign{
+			Id:                &campaignId,
+			Name:              &campaignName,
+			CampaignStatus:    &campaignStatus,
+			MessagesPerMinute: &messagesPerMin,
+			ContactList:       &platformclientv2.Domainentityref{Id: &contactListId},
+			Version:           &version,
+			WhatsAppConfig: &platformclientv2.Whatsappconfig{
+				WhatsAppColumns:     &whatsAppColumns,
+				WhatsAppIntegration: &platformclientv2.Addressableentityref{Id: &integrationId},
+				ContentTemplate:     &platformclientv2.Domainentityref{Id: &templateId},
+			},
+		}, &platformclientv2.APIResponse{StatusCode: http.StatusOK}, nil
+	}
+
+	proxy.updateOutboundMessagingcampaignAttr = func(ctx context.Context, p *outboundMessagingcampaignProxy, id string, campaign *platformclientv2.Messagingcampaign) (*platformclientv2.Messagingcampaign, *platformclientv2.APIResponse, error) {
+		assert.Equal(t, campaignId, id)
+		assert.NotNil(t, campaign.WhatsAppConfig)
+		assert.Equal(t, integrationId, *campaign.WhatsAppConfig.WhatsAppIntegration.Id)
+		assert.Equal(t, templateId, *campaign.WhatsAppConfig.ContentTemplate.Id)
+		assert.Equal(t, version, *campaign.Version)
+
+		campaign.Id = &campaignId
+		return campaign, nil, nil
+	}
+
+	internalProxy = proxy
+	defer func() { internalProxy = nil }()
+
+	ctx := context.Background()
+	gCloud := &provider.ProviderMeta{ClientConfig: &platformclientv2.Configuration{}}
+
+	resourceSchema := ResourceOutboundMessagingcampaign().Schema
+	resourceDataMap := buildMessagingCampaignWhatsAppResourceMap(campaignName, contactListId, campaignStatus, messagesPerMin, integrationId, templateId, whatsAppColumns)
+
+	d := schema.TestResourceDataRaw(t, resourceSchema, resourceDataMap)
+	d.SetId(campaignId)
+
+	diag := updateOutboundMessagingcampaign(ctx, d, gCloud)
+	assert.Equal(t, false, diag.HasError())
+	assert.Equal(t, campaignId, d.Id())
+}
+
+func buildMessagingCampaignWhatsAppResourceMap(name, contactListId, campaignStatus string, messagesPerMin int, integrationId, templateId string, whatsAppColumns []string) map[string]interface{} {
+	columns := make([]interface{}, len(whatsAppColumns))
+	for i, c := range whatsAppColumns {
+		columns[i] = c
+	}
+	return map[string]interface{}{
+		"name":                name,
+		"contact_list_id":     contactListId,
+		"campaign_status":     campaignStatus,
+		"messages_per_minute": messagesPerMin,
+		"always_running":      false,
+		"whats_app_config": []interface{}{
+			map[string]interface{}{
+				"whats_app_columns":        columns,
+				"whats_app_integration_id": integrationId,
+				"content_template_id":      templateId,
+			},
+		},
+	}
+}

--- a/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_utils.go
+++ b/genesyscloud/outbound_messagingcampaign/resource_genesyscloud_outbound_messagingcampaign_utils.go
@@ -37,6 +37,7 @@ func getOutboundMessagingcampaignFromResourceData(d *schema.ResourceData) platfo
 		DynamicContactQueueingSettings: buildDynamicContactQueueingSettingss(d.Get("dynamic_contact_queueing_settings").([]interface{})),
 		SmsConfig:                      buildSmsConfigs(d.Get("sms_config").(*schema.Set)),
 		EmailConfig:                    buildEmailConfigs(d.Get("email_config").(*schema.Set)),
+		WhatsAppConfig:                 buildWhatsAppConfigs(d.Get("whats_app_config").(*schema.Set)),
 	}
 }
 
@@ -324,6 +325,51 @@ func flattenSmsConfigs(smsconfig *platformclientv2.Smsconfig) *schema.Set {
 	smsconfigSet.Add(smsconfigMap)
 
 	return smsconfigSet
+}
+
+// buildWhatsAppConfigs maps a *schema.Set into a Genesys Cloud *platformclientv2.Whatsappconfig
+func buildWhatsAppConfigs(whatsAppConfigs *schema.Set) *platformclientv2.Whatsappconfig {
+	if whatsAppConfigs == nil || whatsAppConfigs.Len() < 1 {
+		return nil
+	}
+	whatsAppConfigList := whatsAppConfigs.List()
+	if len(whatsAppConfigList) == 0 {
+		return nil
+	}
+	var sdkWhatsAppConfig platformclientv2.Whatsappconfig
+	whatsAppConfigMap := whatsAppConfigList[0].(map[string]interface{})
+	resourcedata.BuildSDKStringArrayValueIfNotNil(&sdkWhatsAppConfig.WhatsAppColumns, whatsAppConfigMap, "whats_app_columns")
+	if integrationId := whatsAppConfigMap["whats_app_integration_id"].(string); integrationId != "" {
+		sdkWhatsAppConfig.WhatsAppIntegration = &platformclientv2.Addressableentityref{Id: &integrationId}
+	}
+	if contentTemplateId := whatsAppConfigMap["content_template_id"].(string); contentTemplateId != "" {
+		sdkWhatsAppConfig.ContentTemplate = &platformclientv2.Domainentityref{Id: &contentTemplateId}
+	}
+	return &sdkWhatsAppConfig
+}
+
+// flattenWhatsAppConfigs maps a Genesys Cloud *platformclientv2.Whatsappconfig into a *schema.Set
+func flattenWhatsAppConfigs(whatsAppConfig *platformclientv2.Whatsappconfig) *schema.Set {
+	if whatsAppConfig == nil {
+		return nil
+	}
+	whatsAppConfigSet := schema.NewSet(schema.HashResource(whatsAppConfigResource), []interface{}{})
+	whatsAppConfigMap := make(map[string]interface{})
+	if whatsAppConfig.WhatsAppColumns != nil {
+		columns := make([]interface{}, len(*whatsAppConfig.WhatsAppColumns))
+		for i, col := range *whatsAppConfig.WhatsAppColumns {
+			columns[i] = col
+		}
+		whatsAppConfigMap["whats_app_columns"] = columns
+	}
+	if whatsAppConfig.WhatsAppIntegration != nil && whatsAppConfig.WhatsAppIntegration.Id != nil {
+		whatsAppConfigMap["whats_app_integration_id"] = *whatsAppConfig.WhatsAppIntegration.Id
+	}
+	if whatsAppConfig.ContentTemplate != nil && whatsAppConfig.ContentTemplate.Id != nil {
+		whatsAppConfigMap["content_template_id"] = *whatsAppConfig.ContentTemplate.Id
+	}
+	whatsAppConfigSet.Add(whatsAppConfigMap)
+	return whatsAppConfigSet
 }
 
 func validateSmsconfig(smsconfig *schema.Set) error {


### PR DESCRIPTION
## Add WhatsApp config support to `genesyscloud_outbound_messagingcampaign`

NOTE: This is requested to go out as a hotfix in support of the MEC1 initiative

### Description

Adds support for the `whats_app_config` block on the `genesyscloud_outbound_messagingcampaign` resource, enabling messaging campaigns to send WhatsApp messages in addition to the existing SMS and email channels.

### Changes

#### Schema (`resource_genesyscloud_outbound_messagingcampaign_schema.go`)
- Added `whatsAppConfigResource` schema definition with three fields:
  - `whats_app_columns` (Required, TypeList) — contact list columns specifying WhatsApp addresses
  - `whats_app_integration_id` (Required, TypeString) — the WhatsApp integration to use
  - `content_template_id` (Required, TypeString) — the content template for the message
- Added `whats_app_config` attribute to the resource schema with `ExactlyOneOf` validation alongside `email_config` and `sms_config`
- Updated `ExactlyOneOf` on `email_config` and `sms_config` to include `whats_app_config`
- Added exporter `RefAttrs` for `whats_app_config.content_template_id` and `whats_app_config.whats_app_integration_id`

#### CRUD operations (`resource_genesyscloud_outbound_messagingcampaign.go`)
- Added `whats_app_config` flattening in the read function to persist WhatsApp config to Terraform state

#### Utils (`resource_genesyscloud_outbound_messagingcampaign_utils.go`)
- Added `WhatsAppConfig` field to `getOutboundMessagingcampaignFromResourceData` for create/update payloads
- Added `buildWhatsAppConfigs` — converts Terraform `*schema.Set` to SDK `*platformclientv2.Whatsappconfig`
  - Maps `whats_app_columns` → `WhatsAppColumns`
  - Maps `whats_app_integration_id` → `WhatsAppIntegration` (`*Addressableentityref`)
  - Maps `content_template_id` → `ContentTemplate` (`*Domainentityref`)
- Added `flattenWhatsAppConfigs` — converts SDK `*platformclientv2.Whatsappconfig` back to `*schema.Set`
  - Uses `[]interface{}` for `whats_app_columns` to ensure compatibility with Terraform's `schema.Set` hashing

#### Tests (`resource_genesyscloud_outbound_messagingcampaign_unit_test.go` — new file)
- `TestUnitBuildWhatsAppConfigs` — nil input, empty set, and full field mapping
- `TestUnitFlattenWhatsAppConfigs` — nil input, full field flattening, nil nested fields
- `TestUnitBuildAndFlattenWhatsAppConfigsRoundTrip` — verifies build→flatten preserves all values
- `TestUnitMessagingCampaignWhatsAppCreate` — mocks proxy to verify create sends correct `WhatsAppConfig` to the API
- `TestUnitMessagingCampaignWhatsAppRead` — mocks proxy to verify read populates state correctly from API response
- `TestUnitMessagingCampaignWhatsAppUpdate` — mocks proxy to verify update sends correct `WhatsAppConfig` with version

#### Test helpers (`resource_genesyscloud_outbound_messagingcampaign_test.go`)
- Added `generateOutboundMessagingCampaignWhatsAppConfig` HCL config generator for use in acceptance tests

### Testing

All 6 unit tests pass (10 sub-tests):

```
PASS: TestUnitBuildWhatsAppConfigs (3 sub-tests)
PASS: TestUnitFlattenWhatsAppConfigs (3 sub-tests)
PASS: TestUnitBuildAndFlattenWhatsAppConfigsRoundTrip
PASS: TestUnitMessagingCampaignWhatsAppCreate
PASS: TestUnitMessagingCampaignWhatsAppRead
PASS: TestUnitMessagingCampaignWhatsAppUpdate
```

No acceptance test was added because the underlying `genesyscloud_conversations_messaging_integrations_whatsapp` resource requires a specially configured test org (its own acceptance test is skipped for the same reason).

### Usage Example

```hcl
resource "genesyscloud_outbound_messagingcampaign" "example" {
  name                = "WhatsApp Campaign"
  contact_list_id     = genesyscloud_outbound_contact_list.example.id
  campaign_status     = "off"
  messages_per_minute = 10
  always_running      = false

  whats_app_config {
    whats_app_columns        = ["whatsappNumber"]
    whats_app_integration_id = genesyscloud_conversations_messaging_integrations_whatsapp.example.id
    content_template_id      = genesyscloud_responsemanagement_response.example.id
  }
}
```
