### PR TITLE
Fix swapped mutex Lock/Unlock in buildSanitizedResourceMaps (main)

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -1607,9 +1607,9 @@ func (g *GenesysCloudResourceExporter) buildSanitizedResourceMaps(exporters map[
 					ResourceID:    "*",
 					ResourceLabel: "GetAllFunction",
 				}
-				g.resourceErrorsMutex.Unlock()
-				g.resourceErrors[resourceType] = append(g.resourceErrors[resourceType], resourceError)
 				g.resourceErrorsMutex.Lock()
+				g.resourceErrors[resourceType] = append(g.resourceErrors[resourceType], resourceError)
+				g.resourceErrorsMutex.Unlock()
 				tflog.Error(g.ctx, fmt.Sprintf("%v", err[0].Summary))
 				tflog.Warn(g.ctx, fmt.Sprintf("Logging permission error for %s. Resuming export...", resourceType))
 				return


### PR DESCRIPTION
### Problem
The exporter crashes with fatal error: sync: Unlock of unlocked RWMutex when a permissions error is encountered during buildSanitizedResourceMaps with log_permission_errors enabled.

### Root Cause
In genesyscloud_resource_exporter.go, the resourceErrorsMutex.Unlock() and resourceErrorsMutex.Lock() calls were in the wrong order when appending to the resourceErrors map inside the permissions error handling path. Unlock() was called on a mutex that was never locked, causing a fatal panic.

### Fix
Swapped the Lock() and Unlock() calls to the correct order so the mutex is locked before writing to the shared map and unlocked after.

### Testing
This code path is only hit when an exporter encounters a 403/501 permissions error and log_permission_errors is set to true. This explains how we have only just now come across it.