### PR TITLE
NO-JIRA Fix: User-defined exclude_attributes silently ignored during dependency resolution exports

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -352,7 +352,7 @@ func (g *GenesysCloudResourceExporter) Export() (diagErr diag.Diagnostics) {
 	// (enable_dependency_resolution=true), resource types may be discovered
 	// after the initial populateConfigExcluded call, meaning their exclusions
 	// were never applied to the exporter instances used during sanitization.
-	g.removeUserDefinedExcludedAttributesFromConfigMaps()
+	diagErr = append(diagErr, g.removeUserDefinedExcludedAttributesFromConfigMaps()...)
 
 	// Step #7 Write the terraform state file along with either the HCL or JSON
 	diagErr = append(diagErr, g.generateOutputFiles()...)
@@ -2551,18 +2551,19 @@ func (g *GenesysCloudResourceExporter) sanitizeConfigArray(
 // This ensures exclusions work regardless of when a resource type was discovered
 // during dependency resolution. Hardcoded ExcludedAttributes defined in resource
 // schemas are handled separately by IsAttributeExcluded during sanitizeConfigMap.
-func (g *GenesysCloudResourceExporter) removeUserDefinedExcludedAttributesFromConfigMaps() {
+func (g *GenesysCloudResourceExporter) removeUserDefinedExcludedAttributesFromConfigMaps() (diags diag.Diagnostics) {
 	excludedAttrs, ok := g.d.GetOk("exclude_attributes")
 	if !ok {
-		return
+		return diag.Errorf("Error retrieving \"exclude_attributes\" value: %v", ok)
 	}
 
 	// Parse exclude_attributes into a map of resourceType -> []attributes
-	exclusionsByType := make(map[string][]string) // exact type -> attrs
+	exclusionsByType := make(map[string][]string)  // exact type -> attrs
 	exclusionPatterns := make(map[string][]string) // regex pattern -> attrs
 	for _, excluded := range lists.InterfaceListToStrings(excludedAttrs.([]interface{})) {
 		resourceIdx := strings.Index(excluded, ".")
 		if resourceIdx == -1 || len(excluded) == resourceIdx {
+			tflog.Warn(g.ctx, fmt.Sprintf("Skipping invalid exclude_attributes entry (missing attribute path): %s", excluded))
 			continue
 		}
 		resourceTypePattern := excluded[:resourceIdx]
@@ -2578,7 +2579,10 @@ func (g *GenesysCloudResourceExporter) removeUserDefinedExcludedAttributesFromCo
 	// Apply to resourceTypesMaps
 	g.resourceTypesMapsMutex.Lock()
 	for resourceType, blockMaps := range g.resourceTypesMaps {
-		attrsToExclude := g.getExcludedAttrsForType(resourceType, exclusionsByType, exclusionPatterns)
+		attrsToExclude, diagErr := g.getExcludedAttrsForType(resourceType, exclusionsByType, exclusionPatterns)
+		if diagErr != nil {
+			return diagErr
+		}
 		if len(attrsToExclude) == 0 {
 			continue
 		}
@@ -2587,17 +2591,21 @@ func (g *GenesysCloudResourceExporter) removeUserDefinedExcludedAttributesFromCo
 		}
 	}
 	g.resourceTypesMapsMutex.Unlock()
+	return nil
 }
 
 // getExcludedAttrsForType returns the list of attribute paths to exclude for a given resource type.
-func (g *GenesysCloudResourceExporter) getExcludedAttrsForType(resourceType string, exactMap map[string][]string, patternMap map[string][]string) []string {
+func (g *GenesysCloudResourceExporter) getExcludedAttrsForType(resourceType string, exactMap map[string][]string, patternMap map[string][]string) ([]string, diag.Diagnostics) {
 	attrs := exactMap[resourceType]
 	for pattern, patternAttrs := range patternMap {
-		if match, _ := regexp.MatchString(pattern, resourceType); match {
+		if match, err := regexp.MatchString(pattern, resourceType); match {
+			if err != nil {
+				return nil, diag.Errorf("Error compiling regexp pattern %s for excluded attributes", pattern)
+			}
 			attrs = append(attrs, patternAttrs...)
 		}
 	}
-	return attrs
+	return attrs, nil
 }
 
 // removeExcludedAttrsFromMap nils out excluded attributes from a config map, supporting nested paths.

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -347,6 +347,13 @@ func (g *GenesysCloudResourceExporter) Export() (diagErr diag.Diagnostics) {
 		return diagErr
 	}
 
+	// Step #6.5 Apply excluded attributes to the final config maps.
+	// This is done here as a final pass because during dependency resolution
+	// (enable_dependency_resolution=true), resource types may be discovered
+	// after the initial populateConfigExcluded call, meaning their exclusions
+	// were never applied to the exporter instances used during sanitization.
+	g.removeUserDefinedExcludedAttributesFromConfigMaps()
+
 	// Step #7 Write the terraform state file along with either the HCL or JSON
 	diagErr = append(diagErr, g.generateOutputFiles()...)
 	if diagErr.HasError() {
@@ -465,12 +472,6 @@ func (g *GenesysCloudResourceExporter) retrieveExporters() (diagErr diag.Diagnos
 	g.exporters = &exports
 	g.exportersMutex.Unlock()
 
-	// Assign excluded attributes to the config Map
-	if excludedAttrs, ok := g.d.GetOk("exclude_attributes"); ok {
-		if diagErr := g.populateConfigExcluded(*g.exporters, lists.InterfaceListToStrings(excludedAttrs.([]interface{}))); diagErr != nil {
-			return diagErr
-		}
-	}
 	return nil
 }
 
@@ -1662,14 +1663,7 @@ func mergeExporters(m1, m2 map[string]*resourceExporter.ResourceExporter) *map[s
 		if exists {
 			for id, value := range v.SanitizedResourceMap {
 				result[k].SanitizedResourceMap[id] = value
-
 			}
-			if result[k].ExcludedAttributes != nil {
-				result[k].ExcludedAttributes = append(result[k].ExcludedAttributes, v.ExcludedAttributes...)
-			} else {
-				result[k].ExcludedAttributes = v.ExcludedAttributes
-			}
-
 		} else {
 			result[k] = v
 		}
@@ -2552,50 +2546,88 @@ func (g *GenesysCloudResourceExporter) sanitizeConfigArray(
 	return result
 }
 
-func (g *GenesysCloudResourceExporter) populateConfigExcluded(exporters map[string]*resourceExporter.ResourceExporter, configExcluded []string) diag.Diagnostics {
-	for _, excluded := range configExcluded {
-		matchFound := false
+// removeUserDefinedExcludedAttributesFromConfigMaps applies the user-configured
+// exclude_attributes directly to the final resourceTypesMaps before output.
+// This ensures exclusions work regardless of when a resource type was discovered
+// during dependency resolution. Hardcoded ExcludedAttributes defined in resource
+// schemas are handled separately by IsAttributeExcluded during sanitizeConfigMap.
+func (g *GenesysCloudResourceExporter) removeUserDefinedExcludedAttributesFromConfigMaps() {
+	excludedAttrs, ok := g.d.GetOk("exclude_attributes")
+	if !ok {
+		return
+	}
+
+	// Parse exclude_attributes into a map of resourceType -> []attributes
+	exclusionsByType := make(map[string][]string) // exact type -> attrs
+	exclusionPatterns := make(map[string][]string) // regex pattern -> attrs
+	for _, excluded := range lists.InterfaceListToStrings(excludedAttrs.([]interface{})) {
 		resourceIdx := strings.Index(excluded, ".")
-		if resourceIdx == -1 {
-			return diag.Errorf("Invalid excluded_attribute %s", excluded)
+		if resourceIdx == -1 || len(excluded) == resourceIdx {
+			continue
 		}
-
-		if len(excluded) == resourceIdx {
-			return diag.Errorf("excluded_attributes value %s does not contain an attribute", excluded)
-		}
-
 		resourceTypePattern := excluded[:resourceIdx]
-		// identify all the resource types which match the regex
-		exporter := exporters[resourceTypePattern]
-		if exporter == nil {
-			for resourceType, exporter1 := range exporters {
-				match, _ := regexp.MatchString(resourceTypePattern, resourceType)
-
-				if match {
-					excludedAttr := excluded[resourceIdx+1:]
-					exporter1.AddExcludedAttribute(excludedAttr)
-					tflog.Info(g.ctx, fmt.Sprintf("Excluding attribute %s on %s resources.", excludedAttr, resourceTypePattern))
-					matchFound = true
-					continue
-				}
-			}
-
-			if !matchFound {
-				if g.addDependsOn {
-					excludedAttr := excluded[resourceIdx+1:]
-					tflog.Warn(g.ctx, fmt.Sprintf("Ignoring exclude attribute %s on %s resources. Since exporter is not retrieved", excludedAttr, resourceTypePattern))
-					continue
-				} else {
-					return diag.Errorf("Resource %s in excluded_attributes is not being exported.", resourceTypePattern)
-				}
-			}
+		attrPath := excluded[resourceIdx+1:]
+		// If the pattern is a literal resource type name (no regex metacharacters), use exact match
+		if regexp.QuoteMeta(resourceTypePattern) == resourceTypePattern {
+			exclusionsByType[resourceTypePattern] = append(exclusionsByType[resourceTypePattern], attrPath)
 		} else {
-			excludedAttr := excluded[resourceIdx+1:]
-			exporter.AddExcludedAttribute(excludedAttr)
-			tflog.Info(g.ctx, fmt.Sprintf("Excluding attribute %s on %s resources.", excludedAttr, resourceTypePattern))
+			exclusionPatterns[resourceTypePattern] = append(exclusionPatterns[resourceTypePattern], attrPath)
 		}
 	}
-	return nil
+
+	// Apply to resourceTypesMaps
+	g.resourceTypesMapsMutex.Lock()
+	for resourceType, blockMaps := range g.resourceTypesMaps {
+		attrsToExclude := g.getExcludedAttrsForType(resourceType, exclusionsByType, exclusionPatterns)
+		if len(attrsToExclude) == 0 {
+			continue
+		}
+		for _, configMap := range blockMaps {
+			removeExcludedAttrsFromMap(configMap, attrsToExclude, "")
+		}
+	}
+	g.resourceTypesMapsMutex.Unlock()
+}
+
+// getExcludedAttrsForType returns the list of attribute paths to exclude for a given resource type.
+func (g *GenesysCloudResourceExporter) getExcludedAttrsForType(resourceType string, exactMap map[string][]string, patternMap map[string][]string) []string {
+	attrs := exactMap[resourceType]
+	for pattern, patternAttrs := range patternMap {
+		if match, _ := regexp.MatchString(pattern, resourceType); match {
+			attrs = append(attrs, patternAttrs...)
+		}
+	}
+	return attrs
+}
+
+// removeExcludedAttrsFromMap nils out excluded attributes from a config map, supporting nested paths.
+func removeExcludedAttrsFromMap(configMap util.JsonMap, excludedAttrs []string, prefix string) {
+	for key, val := range configMap {
+		fullPath := key
+		if prefix != "" {
+			fullPath = prefix + "." + key
+		}
+
+		for _, excluded := range excludedAttrs {
+			if excluded == fullPath || strings.HasPrefix(fullPath, excluded+".") {
+				configMap[key] = nil
+				break
+			}
+		}
+
+		// Recurse into nested maps
+		if nestedMap, ok := val.(map[string]interface{}); ok {
+			removeExcludedAttrsFromMap(nestedMap, excludedAttrs, fullPath)
+		}
+		// Recurse into arrays of maps
+		if arr, ok := val.([]interface{}); ok {
+			for _, item := range arr {
+				if nestedMap, ok := item.(map[string]interface{}); ok {
+					removeExcludedAttrsFromMap(nestedMap, excludedAttrs, fullPath)
+				}
+			}
+		}
+	}
 }
 
 func (g *GenesysCloudResourceExporter) resolveReference(refSettings *resourceExporter.RefAttrSettings, refID string, exporters map[string]*resourceExporter.ResourceExporter, exportingState bool) string {

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
@@ -429,34 +429,31 @@ func TestUnitTfExportFilterResourceById(t *testing.T) {
 }
 
 func TestUnitTfExportTestExcludeAttributes(t *testing.T) {
-
-	gre := &GenesysCloudResourceExporter{
-		ctx:                  context.Background(),
-		exportFormat:         "json",
-		splitFilesByResource: true,
+	// Test that removeExcludedAttrsFromMap correctly nils out excluded attributes
+	configMap := util.JsonMap{
+		"name":        "test-resource",
+		"description": "a description",
+		"nested": map[string]interface{}{
+			"inner_attr": "value",
+			"keep_attr":  "keep",
+		},
 	}
 
-	m1 := map[string]*resourceExporter.ResourceExporter{
-		"exporter1": {AllowZeroValues: []string{"key1", "key2"}},
-		"exporter2": {AllowZeroValues: []string{"key3", "key4"}},
-		"exporter3": {AllowZeroValues: []string{"key3", "key4"}},
+	excludedAttrs := []string{"name", "nested.inner_attr"}
+	removeExcludedAttrsFromMap(configMap, excludedAttrs, "")
+
+	if configMap["name"] != nil {
+		t.Errorf("Expected 'name' to be nil, got %v", configMap["name"])
 	}
-
-	filter := []string{"e*.name"}
-
-	// Call the function
-	gre.populateConfigExcluded(m1, filter)
-	nameAttr := "name"
-	// Check if the exporters in the result have the expected keys
-	for _, exporter := range m1 {
-
-		attributes := exporter.ExcludedAttributes
-
-		for _, atribute := range attributes {
-			if atribute != nameAttr {
-				t.Errorf("Attribute %s not excluded in exporter", nameAttr)
-			}
-		}
+	if configMap["description"] != "a description" {
+		t.Errorf("Expected 'description' to be unchanged, got %v", configMap["description"])
+	}
+	nested := configMap["nested"].(map[string]interface{})
+	if nested["inner_attr"] != nil {
+		t.Errorf("Expected 'nested.inner_attr' to be nil, got %v", nested["inner_attr"])
+	}
+	if nested["keep_attr"] != "keep" {
+		t.Errorf("Expected 'nested.keep_attr' to be unchanged, got %v", nested["keep_attr"])
 	}
 }
 


### PR DESCRIPTION
## Fix: User-defined `exclude_attributes` silently ignored during dependency resolution exports

### Problem

When using `enable_dependency_resolution = true` (which sets `addDependsOn`), the `exclude_attributes` configuration was silently ignored for resource types discovered through dependency resolution.

For example, with this config:

```hcl
resource "genesyscloud_tf_export" "export" {
  include_filter_resources_by_id = var.include_filter_resources_by_id
  exclude_attributes = [
    "genesyscloud_flow.file_content_hash",
    "genesyscloud_routing_queue.outbound_messaging_sms_address_id",
    "genesyscloud_routing_queue.outbound_email_address",
    "genesyscloud_routing_queue.outbound_messaging_open_messaging_recipient_id",
    "genesyscloud_routing_queue.outbound_messaging_whatsapp_recipient_id"
  ]
  enable_dependency_resolution = true
}
```

All five exclusions were logged as warnings and never applied:

```
Ignoring exclude attribute file_content_hash on genesyscloud_flow resources. Since exporter is not retrieved
Ignoring exclude attribute outbound_messaging_sms_address_id on genesyscloud_routing_queue resources. Since exporter is not retrieved
...
```

This caused the excluded attributes to appear in the exported config, breaking downstream consumers.

### Root Cause

The old `populateConfigExcluded` method was called inside `retrieveExporters`, which runs multiple times during the export lifecycle. On the first call, the exporters map only contained resource types matching the user's `include_filter_resources_by_id` filter. Resource types like `genesyscloud_flow` and `genesyscloud_routing_queue` that were later discovered through dependency resolution were not yet in the map, so their exclusions were silently skipped.

When `retrieveExporters` was called again during `rebuildExports` (as part of dependency resolution), it fetched fresh exporter instances from the global registry. Even though the resource types were now present, the complex cycle of deep-copying, rebuilding, and merging exporters meant the `ExcludedAttributes` set during one pass could be lost or never applied to the exporter instances that were ultimately used during `sanitizeConfigMap`.

### Fix

Replaced the fragile approach of trying to attach exclusions to exporter instances at the right time with a single final pass that applies user-defined `exclude_attributes` directly to the finalized config maps, right before output file generation.

**Removed:**
- `populateConfigExcluded` method and its call in `retrieveExporters`
- `ExcludedAttributes` merging logic in `mergeExporters`

**Added:**
- `removeUserDefinedExcludedAttributesFromConfigMaps` — called once in `Export()` after all resource data is finalized (between step 6 and step 7). Parses `exclude_attributes` from the Terraform config and nils out matching attributes directly on the final `resourceTypesMaps`. Supports exact type match, regex patterns, and nested attribute paths.

Hardcoded `ExcludedAttributes` defined in resource schemas (e.g. `webdeployments_deployment` excluding `configuration.version`) are unaffected — they continue to be handled by `IsAttributeExcluded` during `sanitizeConfigMap` as before.

No impact to MRMO or BCP exporters — neither uses `populateConfigExcluded` or `exclude_attributes`.

### Testing

- Updated `TestUnitTfExportTestExcludeAttributes` to test the new `removeExcludedAttrsFromMap` function
- All existing unit tests pass

### Release

- Suggested release with next main release (1.78.0)
- @HemanthDogiparthi12 
