### PR TITLE
Fix DEVTOOLING-1665 by adding support for ordered maps when the datatable properties doesn't have a displayOrder field (applies to old GC orgs)

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,7 +1,5 @@
 name: PR Labeler
 on:
-  pull_request:
-    types: [opened]
   pull_request_target:
     types: [opened]
 

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatable.go
@@ -31,11 +31,11 @@ type Datatableproperty struct {
 
 // Overriding the SDK Datatable document as it does not allow setting additionalProperties to 'false' as required by the API
 type Jsonschemadocument struct {
-	Schema               *string                       `json:"$schema,omitempty"`
-	VarType              *string                       `json:"type,omitempty"`
-	Required             *[]string                     `json:"required,omitempty"`
-	Properties           *map[string]Datatableproperty `json:"properties,omitempty"`
-	AdditionalProperties *interface{}                  `json:"additionalProperties,omitempty"`
+	Schema               *string                             `json:"$schema,omitempty"`
+	VarType              *string                             `json:"type,omitempty"`
+	Required             *[]string                           `json:"required,omitempty"`
+	Properties           *util.OrderedMap[Datatableproperty] `json:"properties,omitempty"`
+	AdditionalProperties *interface{}                        `json:"additionalProperties,omitempty"`
 }
 
 type Datatable struct {
@@ -127,7 +127,7 @@ func readArchitectDatatable(ctx context.Context, d *schema.ResourceData, meta in
 		}
 
 		if datatable.Schema != nil && datatable.Schema.Properties != nil {
-			_ = d.Set("properties", flattenDatatableProperties(*datatable.Schema.Properties))
+			_ = d.Set("properties", flattenDatatableProperties(datatable.Schema.Properties))
 		} else {
 			_ = d.Set("properties", nil)
 		}

--- a/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatables_utils.go
+++ b/genesyscloud/architect_datatable/resource_genesyscloud_architect_datatables_utils.go
@@ -2,9 +2,10 @@ package architect_datatable
 
 import (
 	"fmt"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"sort"
 	"strconv"
+
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -32,10 +33,10 @@ func buildSdkDatatableSchema(d *schema.ResourceData) (*Jsonschemadocument, diag.
 	}, nil
 }
 
-func buildSdkDatatableProperties(d *schema.ResourceData) (*map[string]Datatableproperty, diag.Diagnostics) {
+func buildSdkDatatableProperties(d *schema.ResourceData) (*util.OrderedMap[Datatableproperty], diag.Diagnostics) {
 	const propIdPrefix = "/properties/"
 	if properties := d.Get("properties").([]interface{}); properties != nil {
-		sdkProps := map[string]Datatableproperty{}
+		sdkProps := util.NewOrderedMap[Datatableproperty]()
 		for i, property := range properties {
 			propMap := property.(map[string]interface{})
 
@@ -84,39 +85,48 @@ func buildSdkDatatableProperties(d *schema.ResourceData) (*map[string]Datatablep
 					sdkProp.Default = &defaultVal
 				}
 			}
-			sdkProps[propName] = sdkProp
+			sdkProps.Set(propName, sdkProp)
 		}
-		return &sdkProps, nil
+		return sdkProps, nil
 	}
 	return nil, nil
 }
 
-func flattenDatatableProperties(properties map[string]Datatableproperty) []interface{} {
-	configProps := []interface{}{}
-
+func flattenDatatableProperties(properties *util.OrderedMap[Datatableproperty]) []interface{} {
 	type kv struct {
 		Key   string
 		Value Datatableproperty
 	}
 
+	// Build list preserving the OrderedMap key order (API response order) as the default
 	var propList []kv
-	defaultOrder := 0
-	for k, v := range properties {
-		if v.DisplayOrder == nil {
-			// Set a default so the sort doesn't fail
-			v.DisplayOrder = &defaultOrder
+	hasDisplayOrder := false
+	for _, key := range properties.Keys() {
+		prop, _ := properties.Get(key)
+		if prop.DisplayOrder != nil {
+			hasDisplayOrder = true
 		}
-		propList = append(propList, kv{k, v})
+		propList = append(propList, kv{key, prop})
 	}
 
-	// Sort by display order
-	sort.SliceStable(propList, func(i, j int) bool {
-		return *propList[i].Value.DisplayOrder < *propList[j].Value.DisplayOrder
-	})
+	// If DisplayOrder is provided, sort by it; otherwise rely on the preserved JSON key order
+	if hasDisplayOrder {
+		sort.SliceStable(propList, func(i, j int) bool {
+			di := propList[i].Value.DisplayOrder
+			dj := propList[j].Value.DisplayOrder
+			if di == nil {
+				return false
+			}
+			if dj == nil {
+				return true
+			}
+			return *di < *dj
+		})
+	}
 
+	configProps := []interface{}{}
 	for _, propKV := range propList {
 		propMap := make(map[string]interface{})
-
 		propMap["name"] = propKV.Key
 		if propKV.Value.VarType != nil {
 			propMap["type"] = *propKV.Value.VarType

--- a/genesyscloud/architect_datatable_row/genesyscloud_architect_datatable_row_utils.go
+++ b/genesyscloud/architect_datatable_row/genesyscloud_architect_datatable_row_utils.go
@@ -81,7 +81,8 @@ func customizeDatatableRowDiff(ctx context.Context, diff *schema.ResourceDiff, m
 
 	// For each property in the schema, check if a value is set in the config
 	if datatable.Schema != nil && datatable.Schema.Properties != nil {
-		for name, prop := range *datatable.Schema.Properties {
+		for _, name := range datatable.Schema.Properties.Keys() {
+			prop, _ := datatable.Schema.Properties.Get(name)
 			if name == "key" {
 				// Skip setting the key value
 				continue

--- a/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
+++ b/genesyscloud/architect_datatable_row/resource_genesyscloud_architect_datatable_row.go
@@ -32,11 +32,11 @@ type Datatableproperty struct {
 
 // Overriding the SDK Datatable document as it does not allow setting additionalProperties to 'false' as required by the API
 type Jsonschemadocument struct {
-	Schema               *string                       `json:"$schema,omitempty"`
-	VarType              *string                       `json:"type,omitempty"`
-	Required             *[]string                     `json:"required,omitempty"`
-	Properties           *map[string]Datatableproperty `json:"properties,omitempty"`
-	AdditionalProperties *interface{}                  `json:"additionalProperties,omitempty"`
+	Schema               *string                             `json:"$schema,omitempty"`
+	VarType              *string                             `json:"type,omitempty"`
+	Required             *[]string                           `json:"required,omitempty"`
+	Properties           *util.OrderedMap[Datatableproperty] `json:"properties,omitempty"`
+	AdditionalProperties *interface{}                        `json:"additionalProperties,omitempty"`
 }
 
 type Datatable struct {

--- a/genesyscloud/util/ordered_map.go
+++ b/genesyscloud/util/ordered_map.go
@@ -1,0 +1,103 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+)
+
+// OrderedMap is a generic map that preserves the insertion order of keys.
+// It correctly maintains key order when unmarshalling from JSON, unlike Go's built-in map type.
+type OrderedMap[V any] struct {
+	keys   []string
+	values map[string]V
+}
+
+func NewOrderedMap[V any]() *OrderedMap[V] {
+	return &OrderedMap[V]{values: make(map[string]V)}
+}
+
+func (m *OrderedMap[V]) Set(key string, value V) {
+	if _, exists := m.values[key]; !exists {
+		m.keys = append(m.keys, key)
+	}
+	m.values[key] = value
+}
+
+func (m *OrderedMap[V]) Get(key string) (V, bool) {
+	v, ok := m.values[key]
+	return v, ok
+}
+
+func (m *OrderedMap[V]) Delete(key string) {
+	if _, exists := m.values[key]; !exists {
+		return
+	}
+	delete(m.values, key)
+	for i, k := range m.keys {
+		if k == key {
+			m.keys = append(m.keys[:i], m.keys[i+1:]...)
+			break
+		}
+	}
+}
+
+func (m *OrderedMap[V]) Keys() []string {
+	return m.keys
+}
+
+func (m *OrderedMap[V]) Len() int {
+	return len(m.keys)
+}
+
+func (m *OrderedMap[V]) UnmarshalJSON(data []byte) error {
+	m.keys = nil
+	m.values = make(map[string]V)
+
+	dec := json.NewDecoder(bytes.NewReader(data))
+	t, err := dec.Token()
+	if err != nil {
+		return err
+	}
+	if delim, ok := t.(json.Delim); !ok || delim != '{' {
+		return fmt.Errorf("expected '{', got %v", t)
+	}
+
+	for dec.More() {
+		t, err := dec.Token()
+		if err != nil {
+			return err
+		}
+		key := t.(string)
+
+		var val V
+		if err := dec.Decode(&val); err != nil {
+			return err
+		}
+		m.Set(key, val)
+	}
+	return nil
+}
+
+func (m OrderedMap[V]) MarshalJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteByte('{')
+	for i, key := range m.keys {
+		if i > 0 {
+			buf.WriteByte(',')
+		}
+		keyBytes, err := json.Marshal(key)
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(keyBytes)
+		buf.WriteByte(':')
+		valBytes, err := json.Marshal(m.values[key])
+		if err != nil {
+			return nil, err
+		}
+		buf.Write(valBytes)
+	}
+	buf.WriteByte('}')
+	return buf.Bytes(), nil
+}

--- a/genesyscloud/util/ordered_map_test.go
+++ b/genesyscloud/util/ordered_map_test.go
@@ -1,0 +1,111 @@
+package util
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOrderedMap_UnmarshalJSON_PreservesOrder(t *testing.T) {
+	jsonStr := `{"zebra":"z","apple":"a","mango":"m","banana":"b"}`
+
+	var om OrderedMap[string]
+	err := json.Unmarshal([]byte(jsonStr), &om)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"zebra", "apple", "mango", "banana"}, om.Keys())
+	assert.Equal(t, 4, om.Len())
+
+	val, ok := om.Get("apple")
+	assert.True(t, ok)
+	assert.Equal(t, "a", val)
+}
+
+func TestOrderedMap_MarshalJSON_PreservesOrder(t *testing.T) {
+	om := NewOrderedMap[string]()
+	om.Set("zebra", "z")
+	om.Set("apple", "a")
+	om.Set("mango", "m")
+
+	data, err := json.Marshal(om)
+	assert.NoError(t, err)
+	assert.Equal(t, `{"zebra":"z","apple":"a","mango":"m"}`, string(data))
+}
+
+func TestOrderedMap_RoundTrip(t *testing.T) {
+	jsonStr := `{"third":"3","first":"1","second":"2"}`
+
+	var om OrderedMap[string]
+	err := json.Unmarshal([]byte(jsonStr), &om)
+	assert.NoError(t, err)
+
+	data, err := json.Marshal(&om)
+	assert.NoError(t, err)
+	assert.Equal(t, jsonStr, string(data))
+}
+
+func TestOrderedMap_SetOverwrite(t *testing.T) {
+	om := NewOrderedMap[string]()
+	om.Set("a", "1")
+	om.Set("b", "2")
+	om.Set("a", "3")
+
+	assert.Equal(t, []string{"a", "b"}, om.Keys())
+	val, _ := om.Get("a")
+	assert.Equal(t, "3", val)
+}
+
+func TestOrderedMap_Delete(t *testing.T) {
+	om := NewOrderedMap[string]()
+	om.Set("a", "1")
+	om.Set("b", "2")
+	om.Set("c", "3")
+	om.Delete("b")
+
+	assert.Equal(t, []string{"a", "c"}, om.Keys())
+	assert.Equal(t, 2, om.Len())
+	_, ok := om.Get("b")
+	assert.False(t, ok)
+}
+
+func TestOrderedMap_DeleteNonExistent(t *testing.T) {
+	om := NewOrderedMap[string]()
+	om.Set("a", "1")
+	om.Delete("z")
+	assert.Equal(t, 1, om.Len())
+}
+
+type testStruct struct {
+	Name  *string `json:"name,omitempty"`
+	Value *int    `json:"value,omitempty"`
+}
+
+func TestOrderedMap_UnmarshalJSON_StructValues(t *testing.T) {
+	jsonStr := `{"second":{"name":"b","value":2},"first":{"name":"a","value":1}}`
+
+	var om OrderedMap[testStruct]
+	err := json.Unmarshal([]byte(jsonStr), &om)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"second", "first"}, om.Keys())
+
+	val, ok := om.Get("first")
+	assert.True(t, ok)
+	assert.Equal(t, "a", *val.Name)
+	assert.Equal(t, 1, *val.Value)
+}
+
+func TestOrderedMap_EmbeddedInStruct(t *testing.T) {
+	type wrapper struct {
+		Props *OrderedMap[string] `json:"props,omitempty"`
+	}
+
+	jsonStr := `{"props":{"z":"1","a":"2"}}`
+	var w wrapper
+	err := json.Unmarshal([]byte(jsonStr), &w)
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"z", "a"}, w.Props.Keys())
+
+	data, err := json.Marshal(&w)
+	assert.NoError(t, err)
+	assert.Equal(t, jsonStr, string(data))
+}


### PR DESCRIPTION
## Fix DEVTOOLING-1665 and https://github.com/MyPureCloud/terraform-provider-genesyscloud/issues/1838 Datatable Properties Ordering

### Problem

The `flattenDatatableProperties` function in the `architect_datatable` package had a bug related to property ordering:

**Lost JSON key order**: The `Jsonschemadocument.Properties` field was typed as `*map[string]Datatableproperty`. Go maps have randomized iteration order, so even though the API returns properties in the correct order, that order was lost during `json.Unmarshal`. This made the `defaultOrder` fallback for legacy instances (without `DisplayOrder`) unreliable.

### Solution

- **New `OrderedMap[V]` generic type** in `genesyscloud/util/ordered_map.go`: A reusable ordered map that preserves JSON key insertion order via custom `UnmarshalJSON`/`MarshalJSON` implementations using `json.Decoder` token parsing. This can be used anywhere in the codebase where JSON object key order needs to be preserved.

- **Updated `Jsonschemadocument.Properties`** from `*map[string]Datatableproperty` to `*util.OrderedMap[Datatableproperty]` in both the `architect_datatable` and `architect_datatable_row` packages.

- **Updated `flattenDatatableProperties`**: When any property has `DisplayOrder` set, properties are sorted by it (non-legacy path). When no properties have `DisplayOrder` (legacy path), the preserved JSON key order from the API response is used as-is — eliminating the shared pointer bug entirely.

- **Updated `architect_datatable_row`** `customizeDatatableRowDiff` to iterate properties via `Keys()`/`Get()` instead of map range to match the new type.


