### PR TITLE
Fixes DEVTOOLING-1655 to unblock bottlenecks

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -571,6 +571,12 @@ func (g *GenesysCloudResourceExporter) retrieveGenesysCloudObjectInstances() dia
 	var failedTypes []string
 	var statsMutex sync.Mutex
 
+	maxConcurrentOps := g.maxConcurrentOps
+	if maxConcurrentOps <= 0 {
+		maxConcurrentOps = 10
+	}
+	sem := make(chan struct{}, maxConcurrentOps)
+
 	// We use concurrency here to spin off each exporter type and getting the data
 	for resType, exporter := range exportersCopy {
 		tflog.Debug(g.ctx, fmt.Sprintf("Starting processing for resource type: %s", resType))
@@ -579,12 +585,13 @@ func (g *GenesysCloudResourceExporter) retrieveGenesysCloudObjectInstances() dia
 			defer wg.Done()
 			tflog.Trace(g.ctx, fmt.Sprintf("Starting goroutine for resource type: %s", resType))
 
-			// Check if context was cancelled before processing
+			// Acquire semaphore
 			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
 			case <-ctx.Done():
-				tflog.Warn(g.ctx, fmt.Sprintf("Context cancelled before processing resource type: %s", resType))
+				tflog.Warn(g.ctx, fmt.Sprintf("Context cancelled while acquiring semaphore for resource type: %s", resType))
 				return
-			default:
 			}
 
 			tflog.Debug(g.ctx, fmt.Sprintf("Getting exported resources for [%s]", resType))
@@ -2101,11 +2108,9 @@ func (g *GenesysCloudResourceExporter) getResourceState(ctx context.Context, res
 		tflog.Debug(g.ctx, fmt.Sprintf("Resource has no importer or StateContext for ID: %s", resID))
 	}
 
-	g.resourceStateMutex.Lock()
-	tflog.Trace(g.ctx, fmt.Sprintf("Acquiring mutex lock for RefreshWithoutUpgrade for ID: %s", resID))
+	// resourceStateMutex is not needed to wrap this, as it operates on its own copy of state and is safe to call concurrently.
+	// In fact, wrapping it with the resourceStateMutex causes performance bottlenecks (DEVTOOLING-1655)
 	state, err := resource.RefreshWithoutUpgrade(ctx, instanceState, meta)
-	g.resourceStateMutex.Unlock()
-	tflog.Trace(g.ctx, fmt.Sprintf("Released mutex lock after RefreshWithoutUpgrade for ID: %s", resID))
 
 	if err != nil {
 		tflog.Error(g.ctx, fmt.Sprintf("Error during RefreshWithoutUpgrade for resource %s: %v", resID, err))


### PR DESCRIPTION
## TF Exporter Test Timeout: `resourceStateMutex` Serializes All API Calls

### Summary

The TF exporter acceptance tests (e.g. `TestAccResourceTfExportExcludeFilterResourcesByRegEx`) time out because a single global mutex (`resourceStateMutex`) serializes all resource state API calls across all resource types, defeating the exporter's concurrency model and reducing effective throughput to ~1 resource at a time.

### Symptoms

- Test times out after 2 hours (ran for 65+ minutes before panic)
- Goroutine dump shows goroutines stuck in `getResourcesForType` blocked on semaphore acquisition (`select` at line ~1799)
- All semaphore slots are occupied by goroutines blocked on `resourceStateMutex`
- Tests that use exclude filters are most affected because they export nearly all resource types in the org

### Root Cause

In `getResourceState` within `genesyscloud_resource_exporter.go`, the `resourceStateMutex` is held during `resource.RefreshWithoutUpgrade()`, which makes live Genesys Cloud API calls:

```go
g.resourceStateMutex.Lock()
state, err := resource.RefreshWithoutUpgrade(ctx, instanceState, meta)  // API call while holding mutex
g.resourceStateMutex.Unlock()
```

The concurrency model spawns goroutines at two levels:
1. `retrieveGenesysCloudObjectInstances` — one goroutine per resource type (100+), **no concurrency limit**
2. `getResourcesForType` — one goroutine per resource instance, limited by a per-type semaphore (default 10)

This creates 1000+ goroutines all funneled through a single mutex. Since each API call can take seconds, the pipeline stalls and the test times out.

### Recommended Fix

1. **Remove `resourceStateMutex` from around `RefreshWithoutUpgrade`** — This call operates on independent per-resource data and does not require global serialization. Keep the mutex only around `resource.Data(instanceState)` which is fast and may have schema-level thread-safety concerns.
2. **Add a semaphore to `retrieveGenesysCloudObjectInstances`** — Limit concurrent resource-type goroutines (similar to how `buildSanitizedResourceMaps` already does).

