### PR TITLE
Aligns Routing Queue resource's attributes with SDK's attributes and descriptions

### DIFF
--- a/.amazonq/rules/sdk-reference.md
+++ b/.amazonq/rules/sdk-reference.md
@@ -1,0 +1,27 @@
+# SDK Reference
+
+When working on schema definitions, build/flatten functions, proxy layers, or any code that interacts with the Genesys Cloud SDK, always read the corresponding SDK model types from:
+
+.sdk-reference/
+
+This should be a symlink to `$(go env GOPATH)/pkg/mod/github.com/mypurecloud/platform-client-sdk-go/` (typically `~/go/pkg/mod/github.com/mypurecloud/platform-client-sdk-go/`).
+
+Check `go.mod` for the current `platform-client-sdk-go` SDK version to determine which version directory to read from. Just read the file itself using `fs_read`. **IMPORTANT: Do not attempt to use `grep` or `cat` or an external tool do this simple check in `go.mod`. You can assume that the ./sdk-reference/ directory has the appropriate directory with the version (e.g., if the version is v179.1.0 then the directory is `v179@v179.1.0`).**
+
+You have standing permission to read any file under this directory without asking. Do not ask for permission — just read the files you need.
+
+Never make up or guess field descriptions, field names, types, or struct definitions. Always read them from the SDK model struct comments and field definitions.
+
+## Setup
+
+**IMPORTANT: If `.sdk-reference` does not exist, STOP what you are doing and offer to create it before proceeding.** Do not attempt to find SDK files through alternative means. Do not skip this step.
+
+Offer to create it by running:
+
+```bash
+ln -s "$(go env GOPATH)/pkg/mod/github.com/mypurecloud/platform-client-sdk-go" .sdk-reference
+```
+
+The symlink is already in `.gitignore`.
+
+If the user declines to create the symlink, ignore this entire rule for the remainder of the session.

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ public/data/dependency_tree*
 public/data/resource_permissions*
 
 tools/resource_metadata_exporter/build/*
+
+# Symlink to the GC Platform SDK Go module cache for Amazon Q SDK reference (avoids out-of-workspace prompts)
+.sdk-reference

--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -374,19 +374,19 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 ### Optional
 
-- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW. Only set when ACW is MANDATORY_TIMEOUT, MANDATORY_FORCED_TIMEOUT or AGENT_REQUESTED.
+- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW (Min: 1 sec, Max: 60 min). Can only be used when ACW is AGENT_REQUESTED, MANDATORY_TIMEOUT or MANDATORY_FORCED_TIMEOUT.
 - `acw_wrapup_prompt` (String) This field controls how the UI prompts the agent for a wrapup (MANDATORY | OPTIONAL | MANDATORY_TIMEOUT | MANDATORY_FORCED_TIMEOUT | AGENT_REQUESTED). Defaults to `MANDATORY_TIMEOUT`.
-- `agent_owned_routing` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--agent_owned_routing))
+- `agent_owned_routing` (Block List, Max: 1) The Agent Owned Routing settings for the queue. (see [below for nested schema](#nestedblock--agent_owned_routing))
 - `auto_answer_only` (Boolean) Specifies whether the configured whisper should play for all ACD calls, or only for those which are auto-answered. Defaults to `true`.
 - `bullseye_rings` (Block List, Max: 6) The bullseye ring settings for the queue. (see [below for nested schema](#nestedblock--bullseye_rings))
 - `calling_party_name` (String) The name to use for caller identification for outbound calls from this queue.
 - `calling_party_number` (String) The phone number to use for caller identification for outbound calls from this queue.
-- `canned_response_libraries` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--canned_response_libraries))
+- `canned_response_libraries` (Block List, Max: 1) Canned response library IDs and mode with which they are associated with the queue. (see [below for nested schema](#nestedblock--canned_response_libraries))
 - `conditional_group_activation` (Block List, Max: 1) The Conditional Group Activation settings for the queue. (see [below for nested schema](#nestedblock--conditional_group_activation))
 - `conditional_group_routing_rules` (Block List, Max: 5) The Conditional Group Routing settings for the queue. **Note**: conditional_group_routing_rules is deprecated in genesyscloud_routing_queue. CGR is now a standalone resource, please set ENABLE_STANDALONE_CGR in your environment variables to enable and use genesyscloud_routing_queue_conditional_group_routing (see [below for nested schema](#nestedblock--conditional_group_routing_rules))
 - `default_script_ids` (Map of String) The default script IDs for each communication type. Communication types: (CALL | CALLBACK | CHAT | COBROWSE | EMAIL | MESSAGE | SOCIAL_EXPRESSION | VIDEO | SCREENSHARE)
 - `description` (String) Queue description.
-- `direct_routing` (Block List, Max: 1) Used by the System to set Direct Routing settings for a system Direct Routing queue. (see [below for nested schema](#nestedblock--direct_routing))
+- `direct_routing` (Block List, Max: 1) The Direct Routing settings for the queue. (see [below for nested schema](#nestedblock--direct_routing))
 - `division_id` (String) The division to which this queue will belong. If not set, the home division will be used.
 - `email_in_queue_flow_id` (String) The in-queue flow ID to use for email conversations waiting in queue.
 - `enable_audio_monitoring` (Boolean) Indicates whether audio monitoring is enabled for this queue.
@@ -428,9 +428,9 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 Optional:
 
-- `enable_agent_owned_callbacks` (Boolean) Enable Agent Owned Callbacks
-- `max_owned_callback_delay_hours` (Number) Max Owned Call Back Delay Hours >= 7
-- `max_owned_callback_hours` (Number) Auto End Delay Seconds Must be >= 7
+- `enable_agent_owned_callbacks` (Boolean) Indicates if Agent Owned Callbacks are enabled for the queue.
+- `max_owned_callback_delay_hours` (Number) The max amount of time a callback can be scheduled out into the future (in hours). Allowable range 1 - 720 hour(s) (inclusive).
+- `max_owned_callback_hours` (Number) The max amount of time a callback can be owned (in hours). Allowable range 1 - 168 hour(s) (inclusive).
 
 
 <a id="nestedblock--bullseye_rings"></a>
@@ -578,12 +578,12 @@ Required:
 
 Optional:
 
-- `agent_wait_seconds` (Number) The queue default time a Direct Routing interaction will wait for an agent before it goes to configured backup. Defaults to `60`.
-- `backup_queue_id` (String) Direct Routing default backup queue id (if none supplied this queue will be used as backup).
+- `agent_wait_seconds` (Number) Time (in seconds) that a Direct Routing interaction will wait for Direct Routing agent before going to selected backup. Valid range [60, 864000]. Defaults to `60`.
+- `backup_queue_id` (String) ID of another queue to be used as the default backup if an agent does not have their Backup Settings configured. If not set, the current queue will be used as backup, but with Direct Routing criteria removed from the conversation.
 - `call_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for calls. Defaults to `true`.
 - `email_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for emails. Defaults to `true`.
 - `message_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for messages. Defaults to `true`.
-- `wait_for_agent` (Boolean) Boolean indicating if Direct Routing interactions should wait for the targeted agent by default. Defaults to `false`.
+- `wait_for_agent` (Boolean) Flag indicating if Direct Routing interactions should wait for Direct Routing agent or go immediately to selected backup. Defaults to `false`.
 
 
 <a id="nestedblock--media_settings_call"></a>
@@ -592,19 +592,11 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_call--sub_type_settings))
-
-<a id="nestedblock--media_settings_call--sub_type_settings"></a>
-### Nested Schema for `media_settings_call.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_callback"></a>
@@ -616,10 +608,10 @@ Optional:
 - `answering_machine_flow_id` (String) The inbound flow to transfer to if an answering machine is detected during the outbound call of a customer first callback when answeringMachineReactionType is set to TransferToFlow.
 - `answering_machine_reaction_type` (String) The action to take if an answering machine is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `auto_dial_delay_seconds` (Number) Auto Dial Delay Seconds.
-- `auto_end_delay_seconds` (Number) Auto End Delay Seconds.
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
-- `enable_auto_dial_and_end` (Boolean) Auto Dial and End Defaults to `false`.
+- `auto_dial_delay_seconds` (Number) Time in seconds after agent connects to callback before outgoing call is auto-dialed. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
+- `auto_end_delay_seconds` (Number) Time in seconds after agent disconnects from the outgoing call before the encasing callback is auto-ended. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `enable_auto_dial_and_end` (Boolean) Flag to enable Auto-Dial and Auto-End automation for callbacks on this queue. Defaults to `false`.
 - `live_voice_flow_id` (String) The inbound flow to transfer to if a live voice is detected during the outbound call of a customer first callback.
 - `live_voice_reaction_type` (String) The action to take if a live voice is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
@@ -629,16 +621,6 @@ Optional:
 - `retry_delay_seconds` (Number) Delay in seconds between each retry of a customer first callback.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_callback--sub_type_settings))
-
-<a id="nestedblock--media_settings_callback--sub_type_settings"></a>
-### Nested Schema for `media_settings_callback.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_chat"></a>
@@ -647,19 +629,11 @@ Required:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_chat--sub_type_settings))
-
-<a id="nestedblock--media_settings_chat--sub_type_settings"></a>
-### Nested Schema for `media_settings_chat.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_email"></a>
@@ -668,19 +642,11 @@ Required:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_email--sub_type_settings))
-
-<a id="nestedblock--media_settings_email--sub_type_settings"></a>
-### Nested Schema for `media_settings_email.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_message"></a>
@@ -689,12 +655,12 @@ Required:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
-- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. Defaults to `false`.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. The API does not enforce this, so its essentially a no-op. You should drive this configuration via the "sub_type_settings" configuration for each media type Defaults to `false`.
 - `inactivity_timeout_settings` (Block List, Max: 1) Inactivity timeout settings for messages. (see [below for nested schema](#nestedblock--media_settings_message--inactivity_timeout_settings))
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
+- `sub_type_settings` (Block List) Map of media subtype to media subtype specific settings. (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
 
 <a id="nestedblock--media_settings_message--inactivity_timeout_settings"></a>
 ### Nested Schema for `media_settings_message.inactivity_timeout_settings`
@@ -715,7 +681,11 @@ Optional:
 Required:
 
 - `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
+- `media_type` (String) The media subtype key (e.g. webmessaging, instagram, whatsapp).
+
+Optional:
+
+- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for the given subtype.
 
 
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -70,17 +70,17 @@ var (
 	agentOwnedRoutingResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"enable_agent_owned_callbacks": {
-				Description: "Enable Agent Owned Callbacks",
+				Description: "Indicates if Agent Owned Callbacks are enabled for the queue.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 			},
 			"max_owned_callback_hours": {
-				Description: "Auto End Delay Seconds Must be >= 7",
+				Description: "The max amount of time a callback can be owned (in hours). Allowable range 1 - 168 hour(s) (inclusive).",
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},
 			"max_owned_callback_delay_hours": {
-				Description: "Max Owned Call Back Delay Hours >= 7",
+				Description: "The max amount of time a callback can be scheduled out into the future (in hours). Allowable range 1 - 720 hour(s) (inclusive).",
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},
@@ -89,13 +89,18 @@ var (
 	subTypeSettingsResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"media_type": {
-				Description: "The name of the social media company",
+				Description: "The media subtype key (e.g. webmessaging, instagram, whatsapp).",
 				Type:        schema.TypeString,
 				Required:    true,
 			},
 			"enable_auto_answer": {
 				Description: "Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.",
 				Required:    true,
+				Type:        schema.TypeBool,
+			},
+			"enable_inactivity_timeout": {
+				Description: "Indicates if inactivity timeout is enabled for the given subtype.",
+				Optional:    true,
 				Type:        schema.TypeBool,
 			},
 		},
@@ -108,14 +113,8 @@ var (
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(7),
 			},
-			"sub_type_settings": {
-				Description: "Auto-Answer for digital channels(Email, Message)",
-				Type:        schema.TypeList,
-				Optional:    true,
-				Elem:        subTypeSettingsResource,
-			},
 			"enable_auto_answer": {
-				Description: "Auto-Answer for digital channels(Email, Message)",
+				Description: "Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -132,6 +131,16 @@ var (
 				Optional:     true,
 				ValidateFunc: validation.IntAtLeast(1000),
 			},
+			"auto_answer_alert_tone_seconds": {
+				Description: "How long to play the alerting tone for an auto-answer interaction.",
+				Type:        schema.TypeFloat,
+				Optional:    true,
+			},
+			"manual_answer_alert_tone_seconds": {
+				Description: "How long to play the alerting tone for a manual-answer interaction.",
+				Type:        schema.TypeFloat,
+				Optional:    true,
+			},
 		},
 	}
 	queueMediaSettingsMessageResource = &schema.Resource{
@@ -143,13 +152,13 @@ var (
 				ValidateFunc: validation.IntAtLeast(7),
 			},
 			"sub_type_settings": {
-				Description: "Auto-Answer for digital channels(Email, Message)",
+				Description: "Map of media subtype to media subtype specific settings.",
 				Type:        schema.TypeList,
 				Optional:    true,
 				Elem:        subTypeSettingsResource,
 			},
 			"enable_auto_answer": {
-				Description: "Auto-Answer for digital channels(Email, Message)",
+				Description: "Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -185,7 +194,6 @@ var (
 	queueCallbackMediaSettingsResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"alerting_timeout_sec":      queueMediaSettingsResource.Schema["alerting_timeout_sec"],
-			"sub_type_settings":         queueMediaSettingsResource.Schema["sub_type_settings"],
 			"enable_auto_answer":        queueMediaSettingsResource.Schema["enable_auto_answer"],
 			"service_level_percentage":  queueMediaSettingsResource.Schema["service_level_percentage"],
 			"service_level_duration_ms": queueMediaSettingsResource.Schema["service_level_duration_ms"],
@@ -197,18 +205,18 @@ var (
 				ValidateFunc: validation.StringInSlice([]string{"AgentFirst", "CustomerFirst"}, false),
 			},
 			"enable_auto_dial_and_end": {
-				Description: "Auto Dial and End",
+				Description: "Flag to enable Auto-Dial and Auto-End automation for callbacks on this queue.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
 			},
 			"auto_dial_delay_seconds": {
-				Description: "Auto Dial Delay Seconds.",
+				Description: "Time in seconds after agent connects to callback before outgoing call is auto-dialed. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.",
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},
 			"auto_end_delay_seconds": {
-				Description: "Auto End Delay Seconds.",
+				Description: "Time in seconds after agent disconnects from the outgoing call before the encasing callback is auto-ended. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.",
 				Type:        schema.TypeInt,
 				Optional:    true,
 			},
@@ -283,19 +291,19 @@ var (
 	directRoutingResource = &schema.Resource{
 		Schema: map[string]*schema.Schema{
 			"backup_queue_id": {
-				Description: "Direct Routing default backup queue id (if none supplied this queue will be used as backup).",
+				Description: "ID of another queue to be used as the default backup if an agent does not have their Backup Settings configured. If not set, the current queue will be used as backup, but with Direct Routing criteria removed from the conversation.",
 				Type:        schema.TypeString,
 				Optional:    true,
 				Computed:    true,
 			},
 			"agent_wait_seconds": {
-				Description: "The queue default time a Direct Routing interaction will wait for an agent before it goes to configured backup.",
+				Description: "Time (in seconds) that a Direct Routing interaction will wait for Direct Routing agent before going to selected backup. Valid range [60, 864000].",
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Default:     60,
 			},
 			"wait_for_agent": {
-				Description: "Boolean indicating if Direct Routing interactions should wait for the targeted agent by default.",
+				Description: "Flag indicating if Direct Routing interactions should wait for Direct Routing agent or go immediately to selected backup.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,
@@ -489,7 +497,7 @@ func ResourceRoutingQueue() *schema.Resource {
 				Elem:        queueMediaSettingsResource,
 			},
 			"agent_owned_routing": {
-				Description: "Agent Owned Routing.",
+				Description: "The Agent Owned Routing settings for the queue.",
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
@@ -497,7 +505,7 @@ func ResourceRoutingQueue() *schema.Resource {
 				Elem:        agentOwnedRoutingResource,
 			},
 			"canned_response_libraries": {
-				Description: "Agent Owned Routing.",
+				Description: "Canned response library IDs and mode with which they are associated with the queue.",
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,
@@ -655,7 +663,7 @@ func ResourceRoutingQueue() *schema.Resource {
 				ValidateFunc: validation.StringInSlice([]string{"MANDATORY", "OPTIONAL", "MANDATORY_TIMEOUT", "MANDATORY_FORCED_TIMEOUT", "AGENT_REQUESTED"}, false),
 			},
 			"acw_timeout_ms": {
-				Description:  "The amount of time the agent can stay in ACW. Only set when ACW is MANDATORY_TIMEOUT, MANDATORY_FORCED_TIMEOUT or AGENT_REQUESTED.",
+				Description:  "The amount of time the agent can stay in ACW (Min: 1 sec, Max: 60 min). Can only be used when ACW is AGENT_REQUESTED, MANDATORY_TIMEOUT or MANDATORY_FORCED_TIMEOUT.",
 				Type:         schema.TypeInt,
 				Optional:     true,
 				Computed:     true, // Default may be set by server
@@ -814,7 +822,7 @@ func ResourceRoutingQueue() *schema.Resource {
 				Elem:        &schema.Schema{Type: schema.TypeString},
 			},
 			"direct_routing": {
-				Description: "Used by the System to set Direct Routing settings for a system Direct Routing queue.",
+				Description: "The Direct Routing settings for the queue.",
 				Type:        schema.TypeList,
 				MaxItems:    1,
 				Optional:    true,

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -176,7 +176,7 @@ var (
 				ValidateFunc: validation.IntAtLeast(1000),
 			},
 			"enable_inactivity_timeout": {
-				Description: "Indicates if inactivity timeout is enabled for all subtypes.",
+				Description: "Indicates if inactivity timeout is enabled for all subtypes. The API does not enforce this, so its essentially a no-op. You should drive this configuration via the \"sub_type_settings\" configuration for each media type",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -140,7 +140,7 @@ func buildSdkMediaEmailSetting(settings []interface{}) *platformclientv2.Emailme
 		return nil
 	}
 
-	return &platformclientv2.Emailmediasettings{
+	emailSetting := &platformclientv2.Emailmediasettings{
 		AlertingTimeoutSeconds: platformclientv2.Int(settingsMap["alerting_timeout_sec"].(int)),
 		EnableAutoAnswer:       platformclientv2.Bool(settingsMap["enable_auto_answer"].(bool)),
 		ServiceLevel: &platformclientv2.Servicelevel{
@@ -148,6 +148,11 @@ func buildSdkMediaEmailSetting(settings []interface{}) *platformclientv2.Emailme
 			DurationMs: platformclientv2.Int(settingsMap["service_level_duration_ms"].(int)),
 		},
 	}
+
+	emailSetting.AutoAnswerAlertToneSeconds = resourcedata.GetNillableValueFromMap[float64](settingsMap, "auto_answer_alert_tone_seconds", false)
+	emailSetting.ManualAnswerAlertToneSeconds = resourcedata.GetNillableValueFromMap[float64](settingsMap, "manual_answer_alert_tone_seconds", false)
+
+	return emailSetting
 }
 
 func buildSdkMediaSetting(settings []interface{}) *platformclientv2.Mediasettings {
@@ -159,7 +164,7 @@ func buildSdkMediaSetting(settings []interface{}) *platformclientv2.Mediasetting
 		return nil
 	}
 
-	return &platformclientv2.Mediasettings{
+	mediaSetting := &platformclientv2.Mediasettings{
 		AlertingTimeoutSeconds: platformclientv2.Int(settingsMap["alerting_timeout_sec"].(int)),
 		EnableAutoAnswer:       platformclientv2.Bool(settingsMap["enable_auto_answer"].(bool)),
 		ServiceLevel: &platformclientv2.Servicelevel{
@@ -167,6 +172,11 @@ func buildSdkMediaSetting(settings []interface{}) *platformclientv2.Mediasetting
 			DurationMs: platformclientv2.Int(settingsMap["service_level_duration_ms"].(int)),
 		},
 	}
+
+	mediaSetting.AutoAnswerAlertToneSeconds = resourcedata.GetNillableValueFromMap[float64](settingsMap, "auto_answer_alert_tone_seconds", false)
+	mediaSetting.ManualAnswerAlertToneSeconds = resourcedata.GetNillableValueFromMap[float64](settingsMap, "manual_answer_alert_tone_seconds", false)
+
+	return mediaSetting
 }
 
 func buildSdkMediaSettingsMessage(settings []any) *platformclientv2.Messagemediasettings {
@@ -298,10 +308,13 @@ func buildSubTypeSettings(subTypeList []interface{}) *map[string]platformclientv
 		subTypeMap := subTypeItem.(map[string]interface{})
 		mediaType := subTypeMap["media_type"].(string)
 		enableAutoAnswer := subTypeMap["enable_auto_answer"].(bool)
-		baseMediaSettings := platformclientv2.Messagesubtypesettings{
+		subTypeSetting := platformclientv2.Messagesubtypesettings{
 			EnableAutoAnswer: &enableAutoAnswer,
 		}
-		returnObj[mediaType] = baseMediaSettings
+		if enableInactivityTimeout, ok := subTypeMap["enable_inactivity_timeout"].(bool); ok && enableInactivityTimeout {
+			subTypeSetting.EnableInactivityTimeout = &enableInactivityTimeout
+		}
+		returnObj[mediaType] = subTypeSetting
 	}
 
 	if len(returnObj) > 0 {
@@ -673,6 +686,8 @@ func flattenMediaEmailSetting(settings *platformclientv2.Emailmediasettings) []i
 	resourcedata.SetMapValueIfNotNil(settingsMap, "enable_auto_answer", settings.EnableAutoAnswer)
 	settingsMap["service_level_percentage"] = *settings.ServiceLevel.Percentage
 	settingsMap["service_level_duration_ms"] = *settings.ServiceLevel.DurationMs
+	resourcedata.SetMapValueIfNotNil(settingsMap, "auto_answer_alert_tone_seconds", settings.AutoAnswerAlertToneSeconds)
+	resourcedata.SetMapValueIfNotNil(settingsMap, "manual_answer_alert_tone_seconds", settings.ManualAnswerAlertToneSeconds)
 	return []interface{}{settingsMap}
 }
 
@@ -683,6 +698,8 @@ func flattenMediaSetting(settings *platformclientv2.Mediasettings) []interface{}
 	resourcedata.SetMapValueIfNotNil(settingsMap, "enable_auto_answer", settings.EnableAutoAnswer)
 	settingsMap["service_level_percentage"] = *settings.ServiceLevel.Percentage
 	settingsMap["service_level_duration_ms"] = *settings.ServiceLevel.DurationMs
+	resourcedata.SetMapValueIfNotNil(settingsMap, "auto_answer_alert_tone_seconds", settings.AutoAnswerAlertToneSeconds)
+	resourcedata.SetMapValueIfNotNil(settingsMap, "manual_answer_alert_tone_seconds", settings.ManualAnswerAlertToneSeconds)
 	return []interface{}{settingsMap}
 }
 
@@ -740,6 +757,7 @@ func flattenSubTypeSettings(subType map[string]platformclientv2.Messagesubtypese
 		subTypeMap := make(map[string]interface{})
 		resourcedata.SetMapValueIfNotNil(subTypeMap, "media_type", &key)
 		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_auto_answer", value.EnableAutoAnswer)
+		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_inactivity_timeout", value.EnableInactivityTimeout)
 		subTypeList = append(subTypeList, subTypeMap)
 	}
 	return subTypeList

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -311,7 +311,7 @@ func buildSubTypeSettings(subTypeList []interface{}) *map[string]platformclientv
 		subTypeSetting := platformclientv2.Messagesubtypesettings{
 			EnableAutoAnswer: &enableAutoAnswer,
 		}
-		if enableInactivityTimeout, ok := subTypeMap["enable_inactivity_timeout"].(bool); ok && enableInactivityTimeout {
+		if enableInactivityTimeout, ok := subTypeMap["enable_inactivity_timeout"].(bool); ok {
 			subTypeSetting.EnableInactivityTimeout = &enableInactivityTimeout
 		}
 		returnObj[mediaType] = subTypeSetting


### PR DESCRIPTION
## Impetus

While looking into https://github.com/MyPureCloud/terraform-provider-genesyscloud/issues/2274 I realized that there were some inconsistencies, particularly with the extra `sub_type_settings` in other media settings (and not just the messaging settings). While doing manual comparisons between the API Explorer clued me into this issue, I decided to ask Amazon Q about any inconsistencies it found between the existing attributes and to fix them.

## Summary

Aligns the `genesyscloud_routing_queue` Terraform schema with the Genesys Cloud SDK v179.1.0 `Createqueuerequest` model. Fixes incorrect field placement, adds missing fields, and corrects descriptions to match the SDK.

## Changes

### Schema corrections (`resource_genesyscloud_routing_queue_schema.go`)

**Removed `sub_type_settings` from incorrect media settings:**
- Removed from `queueMediaSettingsResource` (used by call, chat, email). The SDK's `Mediasettings` and `Emailmediasettings` types do not have `SubTypeSettings`.
- Removed inherited reference from `queueCallbackMediaSettingsResource`. The SDK's `Callbackmediasettings` does not have `SubTypeSettings`.
- `sub_type_settings` remains correctly on `queueMediaSettingsMessageResource` only, matching the SDK's `Messagemediasettings`.

**Added missing fields to `queueMediaSettingsResource`:**
- `auto_answer_alert_tone_seconds` — present on SDK's `Mediasettings` and `Emailmediasettings` but was missing from the Terraform schema for call, chat, and email.
- `manual_answer_alert_tone_seconds` — same as above.

**Added missing field to `subTypeSettingsResource`:**
- `enable_inactivity_timeout` — present on SDK's `Messagesubtypesettings` but was missing from the Terraform schema.

**Fixed 11 descriptions to match SDK model comments:**
- `agent_owned_routing` — was "Agent Owned Routing."
- `enable_agent_owned_callbacks` — was "Enable Agent Owned Callbacks"
- `enable_auto_dial_and_end` — was "Auto Dial and End"
- `auto_dial_delay_seconds` — was "Auto Dial Delay Seconds."
- `auto_end_delay_seconds` — was "Auto End Delay Seconds."
- `direct_routing` — was "Used by the System to set Direct Routing settings for a system Direct Routing queue."
- `backup_queue_id` — was vague, now matches SDK
- `agent_wait_seconds` — was missing valid range
- `wait_for_agent` — was slightly inaccurate
- `acw_timeout_ms` — was missing min/max info from SDK
- `media_type` (subTypeSettingsResource) — was "The name of the social media company"
- `canned_response_libraries` — was "Agent Owned Routing." (copy-paste error)
- `max_owned_callback_hours` — was "Auto End Delay Seconds Must be >= 7"
- `max_owned_callback_delay_hours` — was "Max Owned Call Back Delay Hours >= 7"

### Build/flatten function updates (`resource_genesyscloud_routing_queue_utils.go`)

- `buildSdkMediaSetting` — now sets `AutoAnswerAlertToneSeconds` and `ManualAnswerAlertToneSeconds`
- `buildSdkMediaEmailSetting` — now sets `AutoAnswerAlertToneSeconds` and `ManualAnswerAlertToneSeconds`
- `buildSubTypeSettings` — now sets `EnableInactivityTimeout` on `Messagesubtypesettings`
- `flattenMediaSetting` — now reads `AutoAnswerAlertToneSeconds` and `ManualAnswerAlertToneSeconds`
- `flattenMediaEmailSetting` — now reads `AutoAnswerAlertToneSeconds` and `ManualAnswerAlertToneSeconds`
- `flattenSubTypeSettings` — now reads `EnableInactivityTimeout`

### Dev tooling

- Added `.sdk-reference` symlink to Go module cache for Amazon Q SDK reference access
- Added `.sdk-reference` to `.gitignore`
- Added `.amazonq/rules/sdk-reference.md` rule to ensure SDK models are always consulted for field definitions

## Migration

No state migration is required. All changes are transparent:
- New Optional fields without Defaults don't break existing state
- Removed `sub_type_settings` on call/chat/email/callback was never read from the API or written to state by the flatten functions
- Description changes don't affect state

## Testing

All existing unit tests pass. No new tests required — the existing `TestUnitResourceRoutingQueueUpdate` and `TestUnitBuildSdkMediaSettingCallback` tests validate the build/flatten changes.

## AI Disclosure

This PR was developed with Amazon Q Developer assistance. The following prompts were used and can be reused to arrive at the same conclusions:

1. **Schema comparison**: "Compare the schema defined on this swagger link: https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues with the schema in this file. What is different?" — followed by redirecting to the SDK source at `$GOHOME/go/pkg/mod/github.com/mypurecloud/platform-client-sdk-go/v179@v179.1.0/platformclientv2/` for accurate comparison against `Createqueuerequest`, `Mediasettings`, `Emailmediasettings`, `Callbackmediasettings`, `Messagemediasettings`, `Messagesubtypesettings`, and `Cannedresponselibraries` Go structs.
2. **sub_type_settings analysis**: "Let's talk about sub_type_settings and dig into exactly what needs to be changed for this across all the various media_settings_* attributes" — comparing which SDK media settings types have `SubTypeSettings` (only `Messagemediasettings`) vs which Terraform schemas incorrectly included it.
3. **Migration assessment**: "What would the migration look like? Is a migration required?" — concluded no migration needed because removed fields were never written to state by flatten functions, and new fields are Optional without Defaults.
4. **Description audit**: "Can you check all of the descriptions in all of the fields in this schema?" — systematic comparison of every Terraform field description against the corresponding SDK struct comment, reading directly from the Go module cache.