### PR TITLE
Fix DEVTOOLING-1669 - type comparison bug

### DIFF
--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -56,9 +56,8 @@ func createPhone(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 
 		d.SetId(*phone.Id)
 
-		webRtcUserId := d.Get("web_rtc_user_id")
-		if webRtcUserId != "" {
-			diagErr := assignUserToWebRtcPhone(ctx, pp, webRtcUserId.(string), *phone.Id)
+		if webRtcUserId := d.Get("web_rtc_user_id").(string); webRtcUserId != "" {
+			diagErr := assignUserToWebRtcPhone(ctx, pp, webRtcUserId, *phone.Id)
 			if diagErr != nil {
 				return resp, diagErr
 			}
@@ -157,9 +156,8 @@ func updatePhone(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 
 	log.Printf("Updated phone %s", *phone.Id)
 
-	webRtcUserId := d.Get("web_rtc_user_id")
-	if webRtcUserId != "" {
-		diagErr := assignUserToWebRtcPhone(ctx, pp, webRtcUserId.(string), *phone.Id)
+	if webRtcUserId := d.Get("web_rtc_user_id").(string); webRtcUserId != "" {
+		diagErr := assignUserToWebRtcPhone(ctx, pp, webRtcUserId, *phone.Id)
 		if diagErr != nil {
 			return diagErr
 		}

--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go
@@ -80,8 +80,7 @@ func getPhoneFromResourceData(ctx context.Context, pp *phoneProxy, d *schema.Res
 		(*phoneConfig.Properties)["phone_standalone"] = phoneStandalone
 	}
 
-	webRtcUserId := d.Get("web_rtc_user_id")
-	if webRtcUserId != "" {
+	if webRtcUserId := d.Get("web_rtc_user_id").(string); webRtcUserId != "" {
 		phoneConfig.WebRtcUser = util.BuildSdkDomainEntityRef(d, "web_rtc_user_id")
 	}
 


### PR DESCRIPTION
## Bug Fix: Phone resource fails with "A webRtcUser is required" for non-WebRTC phones

### Summary

Fixes a type comparison bug in the phone resource that caused all non-WebRTC phone creates and updates to fail with `API Error: 400 - A webRtcUser is required`.

### Root Cause

`d.Get("web_rtc_user_id")` returns `interface{}`, not `string`. The existing code compared this `interface{}` value directly against a string literal `""`:

~~~go
webRtcUserId := d.Get("web_rtc_user_id")
if webRtcUserId != "" {
~~~

In Go, comparing `interface{}` to `string` with `!=` compares types first. Since the types differ, this always evaluates to `true` — even when the underlying value is an empty string. This caused `WebRtcUser` to always be set on the API request body with an empty ID, which the API rejected.

### Changes

**genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone_utils.go**
- Fixed `getPhoneFromResourceData`: type-assert `web_rtc_user_id` to `string` before comparing, so `WebRtcUser` is only set on the phone config when a user ID is actually provided.

**genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go**
- Fixed `createPhone`: same type-assertion fix for the post-create station assignment check.
- Fixed `updatePhone`: same type-assertion fix for the post-update station assignment check.

### AI Disclosure

This fix was identified and implemented with the assistance of Amazon Q Developer. The analysis was prompted by reporting the error message `Failed to create phone ... API Error: 400 - A webRtcUser is required` and asking Q to investigate the phone resource's handling of `web_rtc_user_id`. The same conclusions can be reproduced by examining how `d.Get()` return values are compared across the three affected locations.
