### PR TITLE
MRMO-466: Add get-by-ID fast path for MrMo exports

### DIFF
--- a/genesyscloud/mrmo/exporter/main.go
+++ b/genesyscloud/mrmo/exporter/main.go
@@ -47,8 +47,16 @@ func Export(ctx context.Context, input ExportInput, clientConfig *platformclient
 	log.Println("Getting the resource exporter by resource type")
 	exporter := providerRegistrar.GetResourceExporterByResourceType(input.ResourceType)
 
-	log.Printf("Exporting %s resource to '%s'. ID: '%s'", input.ResourceType, input.Directory, input.EntityId)
-	exportResponse, exportDiags := gcResourceExporter.ExportForMrMo(input.ResourceType, input.EntityId, input.GenerateOutputFiles, exporter)
+	log.Printf("Exporting %s resource to '%s'. ID: '%s' (useGetByID=%t)", input.ResourceType, input.Directory, input.EntityId, input.UseGetByID)
+	var (
+		exportResponse *tfexporter.MrMoExportResponse
+		exportDiags    diag.Diagnostics
+	)
+	if input.UseGetByID {
+		exportResponse, exportDiags = gcResourceExporter.ExportForMrMoByID(input.ResourceType, input.EntityId, input.GenerateOutputFiles, exporter)
+	} else {
+		exportResponse, exportDiags = gcResourceExporter.ExportForMrMo(input.ResourceType, input.EntityId, input.GenerateOutputFiles, exporter)
+	}
 	if exportDiags != nil {
 		diags = append(diags, exportDiags...)
 	}

--- a/genesyscloud/mrmo/exporter/types.go
+++ b/genesyscloud/mrmo/exporter/types.go
@@ -30,6 +30,14 @@ type ExportInput struct {
 
 	// Directory - The output directory that export data will be written to. Required if GenerateOutputFiles is true.
 	Directory string
+
+	// UseGetByID, when true, causes Export to fetch the single entity directly
+	// via the resource's get-by-ID path (its Read context) instead of calling
+	// the resource type's GetResourcesFunc, which lists every instance of the
+	// type in the org. This is O(1) API calls per export rather than O(N).
+	// All current Genesys Cloud resources support get-by-ID; singleton
+	// resources transparently fall back to the legacy listing path.
+	UseGetByID bool
 }
 
 type ExportOutput struct {

--- a/genesyscloud/tfexporter/mr_mo_utils.go
+++ b/genesyscloud/tfexporter/mr_mo_utils.go
@@ -20,6 +20,120 @@ type MrMoExportResponse struct {
 	ResourceData *schema.ResourceData
 }
 
+// ExportForMrMoByID runs the MrMo export pipeline for a single entity without
+// calling the resource type's GetResourcesFunc (i.e. without listing every
+// instance in the org). It relies on the resource's own Read context to fetch
+// the entity by ID, which every Genesys Cloud resource already does via the
+// standard RefreshWithoutUpgrade flow inside retrieveGenesysCloudObjectInstancesForMrMo.
+//
+// For singleton resources (exporter.IsSingleton), this function falls back to
+// the legacy ExportForMrMo path because their map key is derived from
+// exporter.ExportId rather than a free-form resource ID, and the list-cost is
+// trivial (one entry).
+//
+// If the target entity cannot be fetched (e.g. 404), an error diagnostic is
+// returned rather than silently producing an empty export, which is the
+// desired behavior for MrMo where we expect the entity to exist.
+func (g *GenesysCloudResourceExporter) ExportForMrMoByID(resType, resourceId string, generateOutputFiles bool, exporter *resourceExporter.ResourceExporter) (_ *MrMoExportResponse, diags diag.Diagnostics) {
+	if exporter != nil && exporter.IsSingleton {
+		log.Printf("ExportForMrMoByID: resource type %s is a singleton; falling back to ExportForMrMo", resType)
+		return g.ExportForMrMo(resType, resourceId, generateOutputFiles, exporter)
+	}
+
+	exporters := map[string]*resourceExporter.ResourceExporter{resType: exporter}
+	g.exporters = &exporters
+
+	if resType == architectFlow.ResourceType {
+		var flowExporterToUse *resourceExporter.ResourceExporter
+		if generateOutputFiles {
+			log.Printf("Replaced flow exporter with new exporter")
+			flowExporterToUse = resourceExporter.GetNewFlowResourceExporter()
+		} else {
+			log.Printf("Using legacy flow exporter")
+			flowExporterToUse = architectFlow.ArchitectFlowExporter()
+		}
+		flowExporterToUse.SetSanitizedResourceMap(exporter.GetSanitizedResourceMap())
+		(*g.exporters)[resType] = flowExporterToUse
+	}
+
+	// Seed a single-entry SanitizedResourceMap so retrieveGenesysCloudObjectInstancesForMrMo
+	// has an ID to iterate. BlockLabel is temporarily the ID; we backfill it
+	// from the refreshed state below so the exported HCL/JSON block label and
+	// state address match what ExportForMrMo would produce.
+	activeExporter := (*g.exporters)[resType]
+	activeExporter.SanitizedResourceMap = resourceExporter.ResourceIDMetaMap{
+		resourceId: &resourceExporter.ResourceMeta{BlockLabel: resourceId},
+	}
+
+	// Fetch the one object via the resource's Read context. This calls
+	// resource.RefreshWithoutUpgrade -> readContext -> proxy.get<Resource>ById.
+	// It is the only Genesys Cloud API call we actually need.
+	diags = append(diags, g.retrieveGenesysCloudObjectInstancesForMrMo()...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	// If the resource was not found (404/410), getResourceState returns
+	// (nil, nil) and the resource is silently skipped. For MrMo we treat this
+	// as a hard error: the caller explicitly named an entity that must exist.
+	//
+	// The error message deliberately matches the legacy ExportForMrMo format
+	// ("Resource <id> not found") because downstream consumers (e.g. the
+	// MrMo replicator) inspect the error string to detect the delete-event
+	// no-op case. Keeping the two paths' errors identical preserves behavior.
+	if len(g.resources) == 0 {
+		diags = append(diags, diag.Errorf("Resource %s not found", resourceId)...)
+		return nil, diags
+	}
+
+	// Backfill a human-readable BlockLabel from the refreshed state so the
+	// exported block label and state address are identical to what
+	// ExportForMrMo would produce.
+	for _, r := range g.resources {
+		if r.State == nil {
+			continue
+		}
+		if name, ok := r.State.Attributes["name"]; ok && name != "" {
+			meta := activeExporter.SanitizedResourceMap[resourceId]
+			if meta != nil {
+				meta.BlockLabel = name
+				meta.OriginalLabel = name
+			}
+			r.BlockLabel = name
+			r.OriginalLabel = name
+		}
+	}
+
+	diags = append(diags, g.buildAndExportDependsOnResourcesForFlows()...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	diags = append(diags, g.buildResourceConfigMap()...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	diags = append(diags, g.buildAndExportDependentResources()...)
+	if diags.HasError() {
+		return nil, diags
+	}
+
+	if generateOutputFiles {
+		diags = append(diags, g.generateOutputFiles()...)
+		if diags.HasError() {
+			return nil, diags
+		}
+	}
+
+	return &MrMoExportResponse{
+		Config: util.JsonMap{
+			"resource": g.resourceTypesMaps,
+		},
+		ResourceData: g.resourceExportedForMrMo,
+	}, diags
+}
+
 func (g *GenesysCloudResourceExporter) ExportForMrMo(resType, resourceId string, generateOutputFiles bool, exporter *resourceExporter.ResourceExporter) (_ *MrMoExportResponse, diags diag.Diagnostics) {
 	exporters := make(map[string]*resourceExporter.ResourceExporter)
 	exporters[resType] = exporter


### PR DESCRIPTION
Single-entity MrMo exports previously ran the resource type's **GetResourcesFunc** (a full list of every instance in the org) before filtering down to the one entity being replicated. For high-cardinality types (routing queues, users, flows) that meant _**O(N) Genesys Cloud API calls per replication event**_ — often hundreds of wasted list calls.

Add **ExportForMrMoByID** in tfexporter/mr_mo_utils.go that seeds a single- entry SanitizedResourceMap and goes straight through the resource's Read context (every Genesys Cloud resource already supports get-by-ID via RefreshWithoutUpgrade). Expose the fast path to callers via a UseGetByID flag on ExportInput; dispatch happens in mrmo/exporter/main.go.

Behavior preserved:
- Singleton resources (IsSingleton) transparently fall back to ExportForMrMo — their map key is derived from exporter.ExportId rather than a free-form ID and the list cost is trivial.
- 404 / "entity not found" responses emit the same "Resource <id> not found" diagnostic as the legacy path so downstream consumers that inspect the error string (e.g. MrMo replicator's delete-event no-op detection) continue to work unchanged.
- BlockLabel is backfilled from the refreshed state so the exported HCL/JSON block label and state address match what ExportForMrMo would have produced.