### PR TITLE
[RULES-1491]: Add whitespace diff suppression for decision table literal values

### DIFF
--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
@@ -382,7 +382,7 @@ func literalValueSchemaFunc() *schema.Resource {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "",
-				DiffSuppressFunc: suppressNumberFormattingDiff,
+				DiffSuppressFunc: suppressLiteralValueDiff,
 			},
 		},
 	}
@@ -486,34 +486,39 @@ func DataSourceBusinessRulesDecisionTable() *schema.Resource {
 	}
 }
 
-// suppressNumberFormattingDiff suppresses diffs when the only difference is number formatting
-// (e.g., "1.0" vs "1", "1.00" vs "1", etc.) for number type literals.
-// This allows users to write "1.0" in their Terraform config while the API returns "1",
-// without causing unnecessary plan diffs.
-func suppressNumberFormattingDiff(k, old, new string, d *schema.ResourceData) bool {
-	// Get the type field from the same resource path
-	typeKey := strings.Replace(k, ".value", ".type", 1)
-	literalType := d.Get(typeKey).(string)
-
-	// Only suppress diffs for number type literals
-	if literalType != "number" {
-		return false
-	}
-
+// suppressLiteralValueDiff suppresses diffs for the following literal value types:
+//   - string: trims leading/trailing whitespace and invisible Unicode characters
+//   - stringList: normalizes comma spacing and trims whitespace from each element
+//   - number: suppresses formatting differences (e.g. "1.0" vs "1")
+func suppressLiteralValueDiff(k, old, new string, d *schema.ResourceData) bool {
 	// If either value is empty, don't suppress (let normal diff handling work)
 	if old == "" || new == "" {
 		return false
 	}
 
-	// Parse both values as floats
-	oldFloat, oldErr := strconv.ParseFloat(old, 64)
-	newFloat, newErr := strconv.ParseFloat(new, 64)
-
-	// If either parsing fails, don't suppress (let normal diff handling work)
-	if oldErr != nil || newErr != nil {
-		return false
+	// Get the type field from the same resource path
+	typeKey := strings.Replace(k, ".value", ".type", 1)
+	literalType := ""
+	if d != nil {
+		if v, ok := d.GetOk(typeKey); ok {
+			literalType = v.(string)
+		}
 	}
 
-	// Suppress diff if the numeric values are equal
-	return oldFloat == newFloat
+	switch literalType {
+	case "number":
+		// Parse both values as floats
+		oldFloat, oldErr := strconv.ParseFloat(old, 64)
+		newFloat, newErr := strconv.ParseFloat(new, 64)
+		// If either parsing fails, don't suppress (let normal diff handling work)
+		if oldErr != nil || newErr != nil {
+			return false
+		}
+		// Suppress diff if the numeric values are equal
+		return oldFloat == newFloat
+	case "string", "stringList":
+		return normalizeLiteralValue(old, literalType) == normalizeLiteralValue(new, literalType)
+	default:
+		return false
+	}
 }

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test.go
@@ -665,3 +665,128 @@ func generateColumnsWithInvalidPropertyKey(queueResourceLabel string) string {
 func generateHomeDivisionReference() string {
 	return "\ndata \"genesyscloud_auth_division_home\" \"home\" {}\n"
 }
+
+// TestAccResourceBusinessRulesDecisionTableWhitespaceEdgeCases replicates the customer issue
+// from RULES-1491: whitespace differences between .tf config and API response cause false
+// state mismatches and unnecessary updates on every terraform plan/apply.
+//
+// The customer scenario: table exists with clean values, user updates .tf from a spreadsheet
+// which introduces trailing spaces and spaces after commas. Terraform sees a diff and forces
+// an unnecessary update even though the data is semantically identical.
+//
+// This test:
+//   - Step 1: Create with clean values (no whitespace)
+//   - Step 2: Re-apply with whitespace-padded values — should produce NO plan changes (the bug)
+//   - Step 3: Real content change — verify actual updates still trigger
+//   - Step 4: Re-apply Step 3 config with whitespace added — should produce NO plan changes
+//
+// BEFORE FIX: Steps 2 and 4 FAIL — Terraform detects non-empty plan from whitespace diffs
+// AFTER FIX: All steps PASS — DiffSuppressFunc normalizes whitespace
+func TestAccResourceBusinessRulesDecisionTableWhitespaceEdgeCases(t *testing.T) {
+	t.Parallel()
+
+	enabled, businessRulesDecisionTableResp, queueResp := businessRulesDecisionTableFtIsEnabled()
+	if !enabled {
+		t.Skipf("Skipping test as required permissions are not configured, decision table: %s, queues: %s", businessRulesDecisionTableResp.Status, queueResp.Status)
+		return
+	}
+
+	var (
+		tableResourceLabel  = "test-whitespace-dt"
+		schemaResourceLabel = "test-whitespace-schema"
+		queueResourceLabel  = "test-whitespace-queue"
+
+		tableName         = "TF Whitespace Test-" + uuid.NewString()[:8]
+		tableDesc         = "Terraform whitespace edge case test"
+		schemaName        = "TF Whitespace Schema-" + uuid.NewString()[:8]
+		schemaDescription = "Test schema for whitespace edge cases"
+		queueName         = "TF Whitespace Queue-" + uuid.NewString()[:8]
+	)
+
+	baseConfig := generateBusinessRulesSchemaResource(schemaResourceLabel, schemaName, schemaDescription) +
+		generateHomeDivisionReference() +
+		generateRoutingQueueResource(queueResourceLabel, queueName)
+
+	// Step 1: Clean values — guaranteed to work with the API
+	cleanConfig := baseConfig +
+		generateBusinessRulesDecisionTableResource(
+			tableResourceLabel, tableName, tableDesc,
+			"data.genesyscloud_auth_division_home.home.id",
+			"genesyscloud_business_rules_schema."+schemaResourceLabel+".id",
+			generateColumns(queueResourceLabel),
+			generateRows(queueResourceLabel),
+		)
+
+	// Step 2: Same data but with whitespace padding — simulates spreadsheet import
+	whitespaceConfig := baseConfig +
+		generateBusinessRulesDecisionTableResource(
+			tableResourceLabel, tableName, tableDesc,
+			"data.genesyscloud_auth_division_home.home.id",
+			"genesyscloud_business_rules_schema."+schemaResourceLabel+".id",
+			generateColumns(queueResourceLabel),
+			generateRowsWithWhitespaceEdgeCases(queueResourceLabel),
+		)
+
+	// Step 3: Real content change — clean values
+	realChangeConfig := baseConfig +
+		generateBusinessRulesDecisionTableResource(
+			tableResourceLabel, tableName, tableDesc,
+			"data.genesyscloud_auth_division_home.home.id",
+			"genesyscloud_business_rules_schema."+schemaResourceLabel+".id",
+			generateColumns(queueResourceLabel),
+			generateRowsWithRealContentChange(queueResourceLabel),
+		)
+
+	// Step 4: Same as Step 3 but with whitespace padding — tests diff suppression after update
+	realChangeWithWhitespaceConfig := baseConfig +
+		generateBusinessRulesDecisionTableResource(
+			tableResourceLabel, tableName, tableDesc,
+			"data.genesyscloud_auth_division_home.home.id",
+			"genesyscloud_business_rules_schema."+schemaResourceLabel+".id",
+			generateColumns(queueResourceLabel),
+			generateRowsWithRealContentChangeAndWhitespace(queueResourceLabel),
+		)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create with clean values
+				Config: cleanConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_business_rules_decision_table."+tableResourceLabel, "name", tableName),
+					resource.TestCheckResourceAttr("genesyscloud_business_rules_decision_table."+tableResourceLabel, "rows.#", "1"),
+					resource.TestCheckResourceAttr("genesyscloud_business_rules_decision_table."+tableResourceLabel, "rows.0.inputs.1.literal.0.value", "John Doe"),
+					resource.TestCheckResourceAttr("genesyscloud_business_rules_decision_table."+tableResourceLabel, "rows.0.outputs.1.literal.0.value", "Premium Support"),
+				),
+			},
+			{
+				// Step 2: Re-apply with whitespace-padded values — should be NO plan changes
+				// BEFORE FIX: FAILS — Terraform sees "John Doe" vs "John Doe " as different
+				// AFTER FIX: PASSES — DiffSuppressFunc trims whitespace before comparison
+				Config:             whitespaceConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+			{
+				// Step 3: Real content change — verify actual updates still work
+				Config: realChangeConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_business_rules_decision_table."+tableResourceLabel, "rows.0.inputs.1.literal.0.value", "Jane Smith"),
+					resource.TestCheckResourceAttr("genesyscloud_business_rules_decision_table."+tableResourceLabel, "rows.0.outputs.1.literal.0.value", "Standard Support"),
+				),
+			},
+			{
+				// Step 4: Re-apply Step 3 values with whitespace — should be NO plan changes
+				// Tests that diff suppression works after an update too, not just after create
+				// BEFORE FIX: FAILS
+				// AFTER FIX: PASSES
+				Config:             realChangeWithWhitespaceConfig,
+				PlanOnly:           true,
+				ExpectNonEmptyPlan: false,
+			},
+		},
+		CheckDestroy: testVerifyBusinessRulesDecisionTablesDestroyed,
+	})
+}

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test_utils.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_test_utils.go
@@ -720,3 +720,256 @@ func generateBusinessRulesSchemaResource(resourceLabel, name, description string
 	}
 	`, resourceLabel, name, description)
 }
+
+// generateRowsWithWhitespaceEdgeCases generates rows identical to generateRows() but with
+// whitespace edge cases that reproduce the customer issue from RULES-1491:
+// - "John Doe " (trailing space on customer_name string)
+// - "vip, premium, support" (spaces after commas in stringList)
+// - "Premium Support " (trailing space on output string)
+// - "premium_support, escalation, technical_expert" (spaces after commas in output stringList)
+// All other values are identical to generateRows() so the only differences are whitespace.
+func generateRowsWithWhitespaceEdgeCases(queueResourceLabel string) string {
+	return `rows {
+		inputs {
+			literal {
+				value = "VIP"
+				type  = "string"
+			}
+		}
+		inputs {
+			literal {
+				value = "John Doe "
+				type  = "string"
+			}
+		}
+		inputs {
+			literal {
+				value = "5"
+				type  = "integer"
+			}
+		}
+		inputs {
+			literal {
+				value = "85.5"
+				type  = "number"
+			}
+		}
+		inputs {
+			literal {
+				value = "2023-01-15"
+				type  = "date"
+			}
+		}
+		inputs {
+			literal {
+				value = "2023-01-15T10:30:00.000Z"
+				type  = "datetime"
+			}
+		}
+		inputs {
+			literal {
+				value = "true"
+				type  = "boolean"
+			}
+		}
+		inputs {
+			literal {
+				value = ""
+				type  = ""
+			}
+		}
+		inputs {
+			literal {
+				value = "vip, premium, support"
+				type  = "stringList"
+			}
+		}
+		outputs {
+			literal {
+				value = genesyscloud_routing_queue.` + queueResourceLabel + `.id
+				type  = "string"
+			}
+		}
+		outputs {
+			literal {
+				value = "Premium Support "
+				type  = "string"
+			}
+		}
+		outputs {
+			literal {}
+		}
+		outputs {
+			literal {
+				value = "premium_support, escalation, technical_expert"
+				type  = "stringList"
+			}
+		}
+	}`
+}
+
+// generateRowsWithRealContentChange generates rows with actual content differences from
+// generateRows() to verify that real changes still trigger updates after diff suppression
+// is added. Changes: "John Doe" -> "Jane Smith", "Premium Support" -> "Standard Support"
+func generateRowsWithRealContentChange(queueResourceLabel string) string {
+	return `rows {
+		inputs {
+			literal {
+				value = "VIP"
+				type  = "string"
+			}
+		}
+		inputs {
+			literal {
+				value = "Jane Smith"
+				type  = "string"
+			}
+		}
+		inputs {
+			literal {
+				value = "5"
+				type  = "integer"
+			}
+		}
+		inputs {
+			literal {
+				value = "85.5"
+				type  = "number"
+			}
+		}
+		inputs {
+			literal {
+				value = "2023-01-15"
+				type  = "date"
+			}
+		}
+		inputs {
+			literal {
+				value = "2023-01-15T10:30:00.000Z"
+				type  = "datetime"
+			}
+		}
+		inputs {
+			literal {
+				value = "true"
+				type  = "boolean"
+			}
+		}
+		inputs {
+			literal {
+				value = ""
+				type  = ""
+			}
+		}
+		inputs {
+			literal {
+				value = "vip,premium,support"
+				type  = "stringList"
+			}
+		}
+		outputs {
+			literal {
+				value = genesyscloud_routing_queue.` + queueResourceLabel + `.id
+				type  = "string"
+			}
+		}
+		outputs {
+			literal {
+				value = "Standard Support"
+				type  = "string"
+			}
+		}
+		outputs {
+			literal {}
+		}
+		outputs {
+			literal {
+				value = "premium_support,escalation,technical_expert"
+				type  = "stringList"
+			}
+		}
+	}`
+}
+
+// generateRowsWithRealContentChangeAndWhitespace is the same as generateRowsWithRealContentChange
+// but with whitespace padding added. Used to verify diff suppression works after an update too.
+// "Jane Smith" -> "Jane Smith ", "Standard Support" -> "Standard Support "
+func generateRowsWithRealContentChangeAndWhitespace(queueResourceLabel string) string {
+	return `rows {
+		inputs {
+			literal {
+				value = "VIP"
+				type  = "string"
+			}
+		}
+		inputs {
+			literal {
+				value = "Jane Smith "
+				type  = "string"
+			}
+		}
+		inputs {
+			literal {
+				value = "5"
+				type  = "integer"
+			}
+		}
+		inputs {
+			literal {
+				value = "85.5"
+				type  = "number"
+			}
+		}
+		inputs {
+			literal {
+				value = "2023-01-15"
+				type  = "date"
+			}
+		}
+		inputs {
+			literal {
+				value = "2023-01-15T10:30:00.000Z"
+				type  = "datetime"
+			}
+		}
+		inputs {
+			literal {
+				value = "true"
+				type  = "boolean"
+			}
+		}
+		inputs {
+			literal {
+				value = ""
+				type  = ""
+			}
+		}
+		inputs {
+			literal {
+				value = "vip, premium, support"
+				type  = "stringList"
+			}
+		}
+		outputs {
+			literal {
+				value = genesyscloud_routing_queue.` + queueResourceLabel + `.id
+				type  = "string"
+			}
+		}
+		outputs {
+			literal {
+				value = "Standard Support "
+				type  = "string"
+			}
+		}
+		outputs {
+			literal {}
+		}
+		outputs {
+			literal {
+				value = "premium_support, escalation, technical_expert"
+				type  = "stringList"
+			}
+		}
+	}`
+}

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
@@ -3152,3 +3152,138 @@ func intPtr(i int) *int {
 func float64Ptr(f float64) *float64 {
 	return &f
 }
+
+// TestUnitNormalizeLiteralValue tests the normalizeLiteralValue utility function.
+func TestUnitNormalizeLiteralValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		literalType string
+		expected    string
+	}{
+		{"String trailing whitespace", "John Doe ", "string", "John Doe"},
+		{"String leading whitespace", " VIP", "string", "VIP"},
+		{"String both sides", " hello ", "string", "hello"},
+		{"Invisible Unicode U+00A0", "Hello\u00A0World", "string", "Hello World"},
+		{"Invisible Unicode U+200B", "test\u200Bvalue", "string", "testvalue"},
+		{"Invisible Unicode U+FEFF BOM", "\uFEFFdata", "string", "data"},
+		{"StringList comma spacing", "vip, premium, support", "stringList", "vip,premium,support"},
+		{"StringList trailing space and comma spacing", "a , b , c ", "stringList", "a,b,c"},
+		{"Empty string unchanged", "", "string", ""},
+		{"Non-string type unchanged", "5 ", "integer", "5 "},
+		{"Boolean type unchanged", "true ", "boolean", "true "},
+		{"No whitespace unchanged", "clean", "string", "clean"},
+		{"Special type unchanged", "Wildcard", "special", "Wildcard"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeLiteralValue(tt.value, tt.literalType)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestUnitSuppressLiteralValueDiff tests the suppressLiteralValueDiff DiffSuppressFunc.
+func TestUnitSuppressLiteralValueDiff(t *testing.T) {
+	paramSchema := rowParameterSchemaFunc().Schema
+
+	tests := []struct {
+		name         string
+		literalType  string
+		oldValue     string
+		newValue     string
+		expectResult bool
+		description  string
+	}{
+		// Whitespace suppression for string
+		{"String trailing whitespace suppressed", "string", "John Doe", "John Doe ", true, "trailing space should be suppressed"},
+		{"String leading whitespace suppressed", "string", "VIP", " VIP", true, "leading space should be suppressed"},
+		{"Invisible Unicode suppressed", "string", "Hello World", "Hello\u00A0World", true, "non-breaking space should be suppressed"},
+
+		// Whitespace suppression for stringList
+		{"StringList comma spacing suppressed", "stringList", "vip,premium,support", "vip, premium, support", true, "spaces after commas should be suppressed"},
+
+		// Number formatting preserved
+		{"Number formatting still suppressed", "number", "1", "1.0", true, "existing number formatting suppression preserved"},
+
+		// Real content differences NOT suppressed
+		{"String content difference not suppressed", "string", "VIP", "Standard", false, "actual content change must be detected"},
+		{"StringList content difference not suppressed", "stringList", "A,B", "A,C", false, "actual list change must be detected"},
+		{"Integer content difference not suppressed", "integer", "5", "8", false, "integer change must be detected"},
+
+		// Non-string types NOT suppressed for whitespace
+		{"Integer whitespace not suppressed", "integer", "5", "5 ", false, "integer type should not get whitespace suppression"},
+		{"Boolean whitespace not suppressed", "boolean", "true", "true ", false, "boolean type should not get whitespace suppression"},
+
+		// Empty string defaults NOT suppressed
+		{"Empty string default not suppressed", "string", "", "", false, "empty defaults must be preserved"},
+		{"Empty vs non-empty not suppressed", "string", "", "value", false, "empty to non-empty must be detected"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resourceDataMap := map[string]interface{}{
+				"literal": []interface{}{
+					map[string]interface{}{
+						"type":  tt.literalType,
+						"value": tt.oldValue,
+					},
+				},
+			}
+			d := schema.TestResourceDataRaw(t, paramSchema, resourceDataMap)
+			result := suppressLiteralValueDiff("literal.0.value", tt.oldValue, tt.newValue, d)
+			assert.Equal(t, tt.expectResult, result, "%s", tt.description)
+		})
+	}
+}
+
+// TestUnitConvertSDKLiteralToProviderTrimsWhitespace verifies that the read/export path
+// trims whitespace from string and stringList values returned by the API.
+func TestUnitConvertSDKLiteralToProviderTrimsWhitespace(t *testing.T) {
+	tests := []struct {
+		name          string
+		literal       *platformclientv2.Literal
+		expectedValue string
+		expectedType  string
+	}{
+		{
+			name:          "String trailing space trimmed",
+			literal:       &platformclientv2.Literal{VarString: stringPtr("John Doe ")},
+			expectedValue: "John Doe",
+			expectedType:  "string",
+		},
+		{
+			name:          "String leading space trimmed",
+			literal:       &platformclientv2.Literal{VarString: stringPtr(" VIP")},
+			expectedValue: "VIP",
+			expectedType:  "string",
+		},
+		{
+			name:          "String no whitespace unchanged",
+			literal:       &platformclientv2.Literal{VarString: stringPtr("clean")},
+			expectedValue: "clean",
+			expectedType:  "string",
+		},
+		{
+			name:          "StringList elements trimmed",
+			literal:       &platformclientv2.Literal{Strings: &[]string{" vip ", "premium", " support "}},
+			expectedValue: "vip,premium,support",
+			expectedType:  "stringList",
+		},
+		{
+			name:          "StringList no whitespace unchanged",
+			literal:       &platformclientv2.Literal{Strings: &[]string{"vip", "premium"}},
+			expectedValue: "vip,premium",
+			expectedType:  "stringList",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertSDKLiteralToProvider(tt.literal)
+			assert.Equal(t, tt.expectedValue, result["value"])
+			assert.Equal(t, tt.expectedType, result["type"])
+		})
+	}
+}

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_utils.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_utils.go
@@ -629,12 +629,14 @@ func convertLiteralToSDK(literal map[string]interface{}) (*platformclientv2.Lite
 	return sdkLiteral, nil
 }
 
-// converts an SDK literal to provider format
+// convertSDKLiteralToProvider converts an SDK literal to provider format.
+// String and stringList values are trimmed to ensure clean exports between orgs.
 func convertSDKLiteralToProvider(sdkLiteral *platformclientv2.Literal) map[string]interface{} {
 	literal := make(map[string]interface{})
 
 	if sdkLiteral.VarString != nil {
-		literal["value"] = *sdkLiteral.VarString
+		// Trim whitespace to ensure consistency between orgs
+		literal["value"] = strings.TrimSpace(*sdkLiteral.VarString)
 		literal["type"] = "string"
 	} else if sdkLiteral.Integer != nil {
 		literal["value"] = strconv.Itoa(*sdkLiteral.Integer)
@@ -657,8 +659,12 @@ func convertSDKLiteralToProvider(sdkLiteral *platformclientv2.Literal) map[strin
 		literal["value"] = *sdkLiteral.Special
 		literal["type"] = "special"
 	} else if sdkLiteral.Strings != nil {
-		// Convert string slice back to comma-separated string
-		literal["value"] = strings.Join(*sdkLiteral.Strings, ",")
+		// Trim whitespace to ensure consistency between orgs
+		trimmed := make([]string, len(*sdkLiteral.Strings))
+		for i, s := range *sdkLiteral.Strings {
+			trimmed[i] = strings.TrimSpace(s)
+		}
+		literal["value"] = strings.Join(trimmed, ",")
 		literal["type"] = "stringList"
 	} else {
 		// If no fields are set, return empty values to indicate use of column default
@@ -1050,4 +1056,43 @@ func applyRowChanges(ctx context.Context, proxy *BusinessRulesDecisionTableProxy
 
 	log.Printf("Successfully applied all row changes: %d deletes, %d updates, %d adds", len(changes.deletes), len(changes.updates), len(addedRows))
 	return nil
+}
+
+// normalizeLiteralValue normalizes whitespace in string and stringList literal values.
+func normalizeLiteralValue(value, literalType string) string {
+	if value == "" {
+		return value
+	}
+
+	switch literalType {
+	case "string":
+		return strings.TrimSpace(stripInvisibleUnicode(value))
+	case "stringList":
+		stripped := stripInvisibleUnicode(value)
+		parts := strings.Split(stripped, ",")
+		for i, part := range parts {
+			parts[i] = strings.TrimSpace(part)
+		}
+		return strings.Join(parts, ",")
+	default:
+		return value
+	}
+}
+
+// stripInvisibleUnicode removes invisible Unicode characters from spreadsheet copy-paste.
+func stripInvisibleUnicode(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\u00A0': // Non-breaking space → replace with regular space
+			return ' '
+		case '\u200B', // Zero-width space
+			'\u200C', // Zero-width non-joiner
+			'\u200D', // Zero-width joiner
+			'\u2060', // Word joiner
+			'\uFEFF': // Byte order mark
+			return -1 // Remove the character
+		default:
+			return r
+		}
+	}, s)
 }

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_utils.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_utils.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mypurecloud/platform-client-sdk-go/v179/platformclientv2"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 )
 
@@ -1066,9 +1067,9 @@ func normalizeLiteralValue(value, literalType string) string {
 
 	switch literalType {
 	case "string":
-		return strings.TrimSpace(stripInvisibleUnicode(value))
+		return strings.TrimSpace(util.StripInvisibleUnicodeFromString(value))
 	case "stringList":
-		stripped := stripInvisibleUnicode(value)
+		stripped := util.StripInvisibleUnicodeFromString(value)
 		parts := strings.Split(stripped, ",")
 		for i, part := range parts {
 			parts[i] = strings.TrimSpace(part)
@@ -1077,22 +1078,4 @@ func normalizeLiteralValue(value, literalType string) string {
 	default:
 		return value
 	}
-}
-
-// stripInvisibleUnicode removes invisible Unicode characters from spreadsheet copy-paste.
-func stripInvisibleUnicode(s string) string {
-	return strings.Map(func(r rune) rune {
-		switch r {
-		case '\u00A0': // Non-breaking space → replace with regular space
-			return ' '
-		case '\u200B', // Zero-width space
-			'\u200C', // Zero-width non-joiner
-			'\u200D', // Zero-width joiner
-			'\u2060', // Word joiner
-			'\uFEFF': // Byte order mark
-			return -1 // Remove the character
-		default:
-			return r
-		}
-	}, s)
 }

--- a/genesyscloud/util/util_strings.go
+++ b/genesyscloud/util/util_strings.go
@@ -53,3 +53,20 @@ func StringOrNil(s *string) string {
 	}
 	return *s
 }
+
+func StripInvisibleUnicodeFromString(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\u00A0': // Non-breaking space → replace with regular space
+			return ' '
+		case '\u200B', // Zero-width space
+			'\u200C', // Zero-width non-joiner
+			'\u200D', // Zero-width joiner
+			'\u2060', // Word joiner
+			'\uFEFF': // Byte order mark
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}


### PR DESCRIPTION
Customer reported perpetual drift when decision table `.tf` configs contained trailing spaces on strings or spaces after commas in stringList values.

**Root cause:** 

No diff suppression existed for whitespace in literal values. For stringList specifically, the write path trims spaces around commas but the read path joins without spaces, creating a permanent mismatch. For strings, trailing/leading whitespace was preserved in the config but not normalized during comparison.

**Changes:**

- Added `suppressLiteralValueDiff` DiffSuppressFunc handling string (whitespace trim + invisible Unicode), stringList (comma spacing normalization), and number (formatting) types
- Added `normalizeLiteralValue` and `stripInvisibleUnicode` utility functions
- Trimmed string/stringList values in `convertSDKLiteralToProvider` on the read/export path for clean cross-org exports
- Removed `suppressNumberFormattingDiff` — its logic is now inlined in `suppressLiteralValueDiff`

**Tests:**

- Acceptance test: 4-step test covering create → whitespace re-plan → real update → whitespace re-plan after update
- Unit tests: `normalizeLiteralValue` (13 cases), `suppressLiteralValueDiff` (12 cases), `convertSDKLiteralToProvider` trimming (5 cases)
- All existing business rules acceptance tests pass