### PR TITLE
fix/Cache custom retry timeout on provider meta

### DIFF
--- a/genesyscloud/provider/provider.go
+++ b/genesyscloud/provider/provider.go
@@ -79,6 +79,7 @@ type ProviderMeta struct {
 	Organization          *platformclientv2.Organization
 	DefaultCountryCode    string
 	MaxClients            int
+	CustomRetryTimeout    time.Duration
 }
 
 type IntegrationMeta struct {
@@ -152,6 +153,8 @@ func configure(version string) schema.ConfigureContextFunc {
 		}
 		prl.InitPanicRecoveryLoggerInstance(data.Get("log_stack_traces").(bool), data.Get("log_stack_traces_file_path").(string))
 
+		customRetryTimeout := parseCustomRetryTimeout(data)
+
 		meta := &ProviderMeta{
 			Version:               version,
 			Platform:              &platform,
@@ -162,6 +165,7 @@ func configure(version string) schema.ConfigureContextFunc {
 			Organization:          currentOrg,
 			DefaultCountryCode:    *currentOrg.DefaultCountryCode,
 			MaxClients:            maxClients,
+			CustomRetryTimeout:    customRetryTimeout,
 		}
 
 		setProviderMeta(meta)

--- a/genesyscloud/provider/provider_utils.go
+++ b/genesyscloud/provider/provider_utils.go
@@ -129,13 +129,10 @@ func GetOrgDefaultCountryCode() string {
 	return meta.DefaultCountryCode
 }
 
-// GetCustomRetryTimeout returns the configured custom retry timeout.
-// It first checks the provider configuration, then falls back to the environment variable,
-// and finally uses the default value (5 minutes).
-// A timeout of 0 means no retries (immediate fail-fast behavior).
-func GetCustomRetryTimeout() time.Duration {
-	// First try to get from provider configuration
-	config := GetProviderConfig()
+func parseCustomRetryTimeout(config *schema.ResourceData) time.Duration {
+	// Provider config takes precedence over env var/default.
+	// This function is only intended to be called during provider configuration,
+	// where ResourceData access is not concurrent.
 	if config != nil {
 		if v, ok := config.GetOk(AttrCustomRetryTimeout); ok {
 			if timeout, err := time.ParseDuration(v.(string)); err == nil {
@@ -154,4 +151,19 @@ func GetCustomRetryTimeout() time.Duration {
 	// Use default value
 	timeout, _ := time.ParseDuration(DefaultCustomRetryTimeout)
 	return timeout
+}
+
+// GetCustomRetryTimeout returns the configured custom retry timeout.
+// It first checks the provider configuration, then falls back to the environment variable,
+// and finally uses the default value (5 minutes).
+// A timeout of 0 means no retries (immediate fail-fast behavior).
+func GetCustomRetryTimeout() time.Duration {
+	// Value is immutable after provider configuration; cache it on the ProviderMeta
+	// to avoid concurrent access to schema.ResourceData during parallel reads/exports.
+	if meta := GetProviderMeta(); meta != nil {
+		return meta.CustomRetryTimeout
+	}
+
+	// If meta isn't available (e.g. unit tests), fall back to env/default.
+	return parseCustomRetryTimeout(nil)
 }

--- a/genesyscloud/provider/provider_utils_test.go
+++ b/genesyscloud/provider/provider_utils_test.go
@@ -16,7 +16,11 @@ func TestUnitGetCustomRetryTimeout_Default(t *testing.T) {
 		}
 	}()
 
-	// Clear provider config
+	// Clear provider meta/config
+	originalMeta := providerMeta
+	providerMeta = nil
+	defer func() { providerMeta = originalMeta }()
+
 	originalConfig := providerConfig
 	providerConfig = nil
 	defer func() { providerConfig = originalConfig }()
@@ -41,7 +45,11 @@ func TestUnitGetCustomRetryTimeout_EnvVar(t *testing.T) {
 		}
 	}()
 
-	// Clear provider config to test env var fallback
+	// Clear provider meta/config to test env var fallback
+	originalMeta := providerMeta
+	providerMeta = nil
+	defer func() { providerMeta = originalMeta }()
+
 	originalConfig := providerConfig
 	providerConfig = nil
 	defer func() { providerConfig = originalConfig }()
@@ -66,7 +74,11 @@ func TestUnitGetCustomRetryTimeout_ZeroEnvVar(t *testing.T) {
 		}
 	}()
 
-	// Clear provider config
+	// Clear provider meta/config
+	originalMeta := providerMeta
+	providerMeta = nil
+	defer func() { providerMeta = originalMeta }()
+
 	originalConfig := providerConfig
 	providerConfig = nil
 	defer func() { providerConfig = originalConfig }()
@@ -90,7 +102,11 @@ func TestUnitGetCustomRetryTimeout_InvalidEnvVar(t *testing.T) {
 		}
 	}()
 
-	// Clear provider config
+	// Clear provider meta/config
+	originalMeta := providerMeta
+	providerMeta = nil
+	defer func() { providerMeta = originalMeta }()
+
 	originalConfig := providerConfig
 	providerConfig = nil
 	defer func() { providerConfig = originalConfig }()
@@ -100,6 +116,26 @@ func TestUnitGetCustomRetryTimeout_InvalidEnvVar(t *testing.T) {
 
 	if timeout != expectedTimeout {
 		t.Errorf("Expected default timeout %v for invalid env var, got %v", expectedTimeout, timeout)
+	}
+}
+
+func TestUnitGetCustomRetryTimeout_UsesProviderMetaValue(t *testing.T) {
+	originalEnv := os.Getenv(customRetryTimeoutEnvVar)
+	os.Setenv(customRetryTimeoutEnvVar, "30s")
+	defer func() {
+		if originalEnv != "" {
+			os.Setenv(customRetryTimeoutEnvVar, originalEnv)
+		} else {
+			os.Unsetenv(customRetryTimeoutEnvVar)
+		}
+	}()
+
+	originalMeta := providerMeta
+	setProviderMeta(&ProviderMeta{CustomRetryTimeout: 1 * time.Second})
+	defer setProviderMeta(originalMeta)
+
+	if got := GetCustomRetryTimeout(); got != 1*time.Second {
+		t.Fatalf("expected provider meta timeout 1s, got %v", got)
 	}
 }
 

--- a/public/data/resource_permissions-latest.json
+++ b/public/data/resource_permissions-latest.json
@@ -498,6 +498,30 @@
       ]
     },
     {
+      "resource_type": "genesyscloud_customer_intent",
+      "resource_name": "customer_intent",
+      "permissions": [
+        "externalContacts:customerIntentTaxonomy:add",
+        "externalContacts:customerIntentTaxonomy:delete",
+        "externalContacts:customerIntentTaxonomy:edit",
+        "externalContacts:customerIntentTaxonomy:view"
+      ],
+      "scopes": [
+        "external-contacts",
+        "external-contacts:readonly"
+      ],
+      "endpoints": [
+        "POST /api/v2/intents/customerintents",
+        "GET /api/v2/intents/customerintents/{customerIntentId}",
+        "PATCH /api/v2/intents/customerintents/{customerIntentId}",
+        "DELETE /api/v2/intents/customerintents/{customerIntentId}",
+        "GET /api/v2/intents/customerintents",
+        "GET /api/v2/intents/customerintents/{customerIntentId}/sourceintents",
+        "POST /api/v2/intents/customerintents/{customerIntentId}/sourceintents/bulk/add",
+        "POST /api/v2/intents/customerintents/{customerIntentId}/sourceintents/bulk/remove"
+      ]
+    },
+    {
       "resource_type": "genesyscloud_employeeperformance_externalmetrics_definitions",
       "resource_name": "employeeperformance_externalmetrics_definitions",
       "permissions": [
@@ -1057,6 +1081,27 @@
         "PATCH /api/v2/conversations/messaging/integrations/facebook/{integrationId}",
         "DELETE /api/v2/conversations/messaging/integrations/facebook/{integrationId}",
         "GET /api/v2/conversations/messaging/integrations/facebook"
+      ]
+    },
+    {
+      "resource_type": "genesyscloud_intent_category",
+      "resource_name": "intent_category",
+      "permissions": [
+        "externalContacts:customerIntentTaxonomy:add",
+        "externalContacts:customerIntentTaxonomy:delete",
+        "externalContacts:customerIntentTaxonomy:edit",
+        "externalContacts:customerIntentTaxonomy:view"
+      ],
+      "scopes": [
+        "external-contacts",
+        "external-contacts:readonly"
+      ],
+      "endpoints": [
+        "POST /api/v2/intents/categories",
+        "GET /api/v2/intents/categories/{categoryId}",
+        "PATCH /api/v2/intents/categories/{categoryId}",
+        "DELETE /api/v2/intents/categories/{categoryId}",
+        "GET /api/v2/intents/categories"
       ]
     },
     {


### PR DESCRIPTION
Parse custom_retry_timeout once during configure() and store it on ProviderMeta. GetCustomRetryTimeout now reads the cached value to avoid concurrent access to schema.ResourceData during parallel reads/exports.
