### PR TITLE
Fixes DEVTOOLING-1685 where inin-outbound-id field gets stripped from Contact List Exports

### DIFF
--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
@@ -565,9 +565,20 @@ func stripSystemColumnsFromCSV(filePath string, columnsToKeep []string) error {
 
 	// Find the indexes of columns to keep, preserving CSV column order
 	var keepIndexes []int
+	var rebuiltHeaders []string
 	for i, header := range headers {
+		// Some columns have extra whitespace or unicode that needs to be stripped
+		// For example: "<feff>""inin-outbound-id"""
+		header = util.StripInvisibleUnicodeFromString(header)
+
+		// Some columns have extra quotes that need to be stripped (see above example).
+		// The CSV writer will automagically put them back in and we have no control over
+		// this behavior, but we don't want triple double-quote headers (i.e. """inin-outbound-id""")
+		header = strings.Trim(header, "\"")
+
 		if keepSet[header] {
 			keepIndexes = append(keepIndexes, i)
+			rebuiltHeaders = append(rebuiltHeaders, header)
 		}
 	}
 
@@ -578,16 +589,21 @@ func stripSystemColumnsFromCSV(filePath string, columnsToKeep []string) error {
 
 	log.Printf("Stripping %d system-generated columns from CSV (keeping %d of %d)", len(headers)-len(keepIndexes), len(keepIndexes), len(headers))
 
-	// Build filtered records
-	filteredRecords := make([][]string, len(allRecords))
-	for i, record := range allRecords {
-		filteredRow := make([]string, len(keepIndexes))
+	// Build stripped records
+	strippedColumnsRecords := make([][]string, len(allRecords))
+
+	// Set the header row with rebuilt headers
+	strippedColumnsRecords[0] = rebuiltHeaders
+
+	// Process data rows
+	for i, record := range allRecords[1:len(allRecords)] {
+		strippedRow := make([]string, len(keepIndexes))
 		for j, idx := range keepIndexes {
 			if idx < len(record) {
-				filteredRow[j] = record[idx]
+				strippedRow[j] = record[idx]
 			}
 		}
-		filteredRecords[i] = filteredRow
+		strippedColumnsRecords[i+1] = strippedRow // Index is 1-indexed since we already wrote the header
 	}
 
 	// Write back to the same file
@@ -598,7 +614,7 @@ func stripSystemColumnsFromCSV(filePath string, columnsToKeep []string) error {
 	defer out.Close()
 
 	writer := csv.NewWriter(out)
-	if err := writer.WriteAll(filteredRecords); err != nil {
+	if err := writer.WriteAll(strippedColumnsRecords); err != nil {
 		return fmt.Errorf("failed to write CSV file: %w", err)
 	}
 

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils_test.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils_test.go
@@ -1115,12 +1115,12 @@ func TestStripSystemColumnsFromCSV(t *testing.T) {
 		}
 	})
 
-	t.Run("strips many system columns like real export scenario", func(t *testing.T) {
+	t.Run("strips handles exported CSV column output, with many system columns like real export scenario", func(t *testing.T) {
 		tempDir := t.TempDir()
 		csvPath := filepath.Join(tempDir, "test.csv")
 
 		// Simulate a real export: 3 user columns + 5 system columns
-		header := "inin-outbound-id,acct_numb,phone1,ContactCallable,AutomaticTimeZone-phone1,Callable-phone1,CallRecordLastAttempt-phone1,CallRecordLastResult-phone1"
+		header := "\uFEFF\"\"inin-outbound-id\"\",acct_numb,phone1,ContactCallable,AutomaticTimeZone-phone1,Callable-phone1,CallRecordLastAttempt-phone1,CallRecordLastResult-phone1"
 		row := "id1,123,555-0100,true,US/Eastern,true,2024-01-01,BUSY"
 		csvContent := header + "\n" + row + "\n"
 		os.WriteFile(csvPath, []byte(csvContent), 0644)

--- a/genesyscloud/util/util_strings.go
+++ b/genesyscloud/util/util_strings.go
@@ -53,3 +53,20 @@ func StringOrNil(s *string) string {
 	}
 	return *s
 }
+
+func StripInvisibleUnicodeFromString(s string) string {
+	return strings.Map(func(r rune) rune {
+		switch r {
+		case '\u00A0': // Non-breaking space → replace with regular space
+			return ' '
+		case '\u200B', // Zero-width space
+			'\u200C', // Zero-width non-joiner
+			'\u200D', // Zero-width joiner
+			'\u2060', // Word joiner
+			'\uFEFF': // Byte order mark
+			return -1
+		default:
+			return r
+		}
+	}, s)
+}

--- a/genesyscloud/util/util_strings_test.go
+++ b/genesyscloud/util/util_strings_test.go
@@ -1,0 +1,128 @@
+package util
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStripInvisibleUnicodeFromString(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no invisible characters",
+			input:    "hello world",
+			expected: "hello world",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "non-breaking space replaced with regular space",
+			input:    "hello\u00A0world",
+			expected: "hello world",
+		},
+		{
+			name:     "zero-width space removed",
+			input:    "hello\u200Bworld",
+			expected: "helloworld",
+		},
+		{
+			name:     "zero-width non-joiner removed",
+			input:    "hello\u200Cworld",
+			expected: "helloworld",
+		},
+		{
+			name:     "zero-width joiner removed",
+			input:    "hello\u200Dworld",
+			expected: "helloworld",
+		},
+		{
+			name:     "word joiner removed",
+			input:    "hello\u2060world",
+			expected: "helloworld",
+		},
+		{
+			name:     "byte order mark removed",
+			input:    "\uFEFFhello world",
+			expected: "hello world",
+		},
+		{
+			name:     "multiple invisible characters",
+			input:    "\uFEFFhello\u200B\u200C\u00A0world\u2060",
+			expected: "hello world",
+		},
+		{
+			name:     "only invisible characters",
+			input:    "\u200B\u200C\u200D\u2060\uFEFF",
+			expected: "",
+		},
+		{
+			name:     "multiple non-breaking spaces",
+			input:    "a\u00A0b\u00A0c",
+			expected: "a b c",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := StripInvisibleUnicodeFromString(tt.input)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+func TestToSnakeCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"CamelCase", "camel_case"},
+		{"camelCase", "camel_case"},
+		{"HTMLParser", "html_parser"},
+		{"simpletest", "simpletest"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ToSnakeCase(tt.input))
+		})
+	}
+}
+
+func TestToCamelCase(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"snake_case", "snakeCase"},
+		{"one_two_three", "oneTwoThree"},
+		{"nounderscores", "nounderscores"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.expected, ToCamelCase(tt.input))
+		})
+	}
+}
+
+func TestStringExists(t *testing.T) {
+	slice := []string{"a", "b", "c"}
+	assert.True(t, StringExists("b", slice))
+	assert.False(t, StringExists("d", slice))
+	assert.False(t, StringExists("a", nil))
+}
+
+func TestStringOrNil(t *testing.T) {
+	s := "hello"
+	assert.Equal(t, "hello", StringOrNil(&s))
+	assert.Equal(t, "nil", StringOrNil(nil))
+}


### PR DESCRIPTION
Fixes an issue introduced by GH-2221 where the exported CSV's contact custom id field can be output with extra quotes and whitespaces and so it doesn't get properly retained when the extra columns are stripped.

Causes these errors to show up in BCP Syncing for 1.79.0+
> Failed to upload contacts to contact list (fce1c4e3-850f-4820-833c-c7ca9a0f50a8) due to MISSING_CUSTOM_ID {"resourceType":"genesyscloud_outbound_contact_list","method":"GET","path":"/api/v2/outbound/contactlists/fce1c4e3-850f-4820-833c-c7ca9a0f50a8/importstatus","statusCode":200,"correlationId":"ce60f9bc-9d11-4d5d-9be4-e37c23f89531"}

Looking at the CSV file we can see the inin-outbound-id field is missing:
```
cat contacts/ASD_CCB.csv | head -n1
phone,name,delay,callbackId
```

Debugging the provider, I was able to identify that the exported CSV was getting read with a field like `"\uFEFF\"\"inin-outbound-id\"\""`. 

The keepColumns list wasn't enough to properly retain this column, and adding `"\uFEFF\"\"inin-outbound-id\"\""` to the list wouldn't allow a clean re-import.

So, we have to strip whitespace and double quotes of the field names. The CSV writer will handle writing the output with quotes as required (we don't have control over this, but the writer will triple double quote these extra double quotes if we don't strip them out).