### PR TITLE
Add the BlockLabel to the output of the bcp exporter

### DIFF
--- a/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter.go
+++ b/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter.go
@@ -29,6 +29,7 @@ import (
 type BcpResource struct {
 	ID           string                `json:"id"`
 	Name         string                `json:"name"`
+	BlockLabel   string                `json:"blockLabel"`
 	Dependencies BcpResourceDependency `json:"dependencies"`
 }
 
@@ -137,6 +138,7 @@ func createBcpTfExporter(ctx context.Context, d *schema.ResourceData, meta inter
 			resources = append(resources, BcpResource{
 				ID:           id,
 				Name:         name,
+				BlockLabel:   resMeta.BlockLabel,
 				Dependencies: deps,
 			})
 		}

--- a/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter_test.go
+++ b/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter_test.go
@@ -221,6 +221,7 @@ func TestUnitBcpTfExporter_JSONStructure(t *testing.T) {
 	user := userResources[0]
 	assert.Equal(t, "user1", user.ID)
 	assert.Equal(t, "Test User", user.Name)
+	assert.Equal(t, "test_user", user.BlockLabel)
 	assert.Equal(t, user.Dependencies, BcpResourceDependency{
 		AsProviderResourceList: []string{},
 		AsObjectMap:            map[string][]string{},
@@ -232,6 +233,7 @@ func TestUnitBcpTfExporter_JSONStructure(t *testing.T) {
 	group := groupResources[0]
 	assert.Equal(t, "group1", group.ID)
 	assert.Equal(t, "Test Group", group.Name)
+	assert.Equal(t, "test_group", group.BlockLabel)
 	// Should have empty dependencies since resource reading fails in test
 	assert.Equal(t, group.Dependencies, BcpResourceDependency{
 		AsProviderResourceList: []string{},


### PR DESCRIPTION
This is required for BCP Wizard's new functionality