### PR TITLE
issues resolved for dev tests failure

### DIFF
--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go
@@ -191,7 +191,7 @@ func readOutboundContactList(ctx context.Context, d *schema.ResourceData, meta i
 			_ = d.Set("column_names", *sdkContactList.ColumnNames)
 		}
 		if sdkContactList.PhoneColumns != nil {
-			flattenedPhoneColumns := flattenSdkOutboundContactListContactPhoneNumberColumnSlice(*sdkContactList.PhoneColumns)
+			flattenedPhoneColumns := flattenSdkOutboundContactListContactPhoneNumberColumnSlice(*sdkContactList.PhoneColumns, phoneTzIdx)
 
 			if existingRaw, ok := d.GetOk("phone_columns"); ok {
 				if existingSet, ok := existingRaw.(*schema.Set); ok && existingSet != nil && flattenedPhoneColumns != nil {

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -180,6 +180,7 @@ func syncStateOnPartialFailure(ctx context.Context, d *schema.ResourceData, meta
 	return diagErr
 }
 
+// syncRoutingQueueStateFromAPI refreshes Terraform state from the API after a partial update failure.
 func syncRoutingQueueStateFromAPI(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	proxy := GetRoutingQueueProxy(sdkConfig)
@@ -246,8 +247,13 @@ func syncRoutingQueueStateFromAPI(ctx context.Context, d *schema.ResourceData, m
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "canned_response_libraries", currentQueue.CannedResponseLibraries, flattenCannedResponse)
 	}
 
-	if currentQueue.ConditionalGroupActivation != nil {
-		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "conditional_group_activation", currentQueue.ConditionalGroupActivation, flattenConditionalGroupActivation)
+	if exists := featureToggles.CGAToggleExists(); !exists {
+		if currentQueue.ConditionalGroupActivation != nil {
+			resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "conditional_group_activation", currentQueue.ConditionalGroupActivation, FlattenConditionalGroupActivation)
+		}
+	} else {
+		log.Printf("%s is set, not reading conditional_group_activation attribute in routing_queue %s resource", featureToggles.CGAToggleName(), d.Id())
+		_ = d.Set("conditional_group_activation", nil)
 	}
 
 	resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "routing_rules", currentQueue.RoutingRules, flattenRoutingRules)

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_partial_failure_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_partial_failure_unit_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v176/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v179/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"


### PR DESCRIPTION
1. 
```
# github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/outbound_contact_list
genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go:179:7: declared and not used: phoneTzIdx
genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list.go:194:88: not enough arguments in call to flattenSdkOutboundContactListContactPhoneNumberColumnSlice
	have ([]platformclientv2.Contactphonenumbercolumn)
	want ([]platformclientv2.Contactphonenumbercolumn, map[string]string)
```

2. 
```
# github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue
genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go:250:135: undefined: flattenConditionalGroupActivation
```
