### PR TITLE
Updates the 'integration_credential' proxy to look up integrations by credential ID

### DIFF
--- a/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter.go
+++ b/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_register"
+	tfExporterState "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/errors"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
@@ -56,6 +57,7 @@ func createBcpTfExporter(ctx context.Context, d *schema.ResourceData, meta inter
 	}
 
 	exporters := resourceExporter.GetResourceExporters()
+	tfExporterState.ActivateExporterState()
 	filteredExporters := filterExporters(ctx, exporters, d)
 	exportData := make(BcpExportData)
 

--- a/genesyscloud/integration/data_source_genesyscloud_integration.go
+++ b/genesyscloud/integration/data_source_genesyscloud_integration.go
@@ -3,9 +3,10 @@ package integration
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
-	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
@@ -23,7 +24,7 @@ import (
 // dataSourceIntegrationRead retrieves by name the integration id in question
 func dataSourceIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sdkConfig := m.(*provider.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 	integrationName := d.Get("name").(string)
 
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {

--- a/genesyscloud/integration/data_source_genesyscloud_integration.go
+++ b/genesyscloud/integration/data_source_genesyscloud_integration.go
@@ -24,7 +24,7 @@ import (
 // dataSourceIntegrationRead retrieves by name the integration id in question
 func dataSourceIntegrationRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sdkConfig := m.(*provider.ProviderMeta).ClientConfig
-	ip := GetIntegrationsProxy(sdkConfig)
+	ip := getIntegrationsProxy(sdkConfig)
 	integrationName := d.Get("name").(string)
 
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {

--- a/genesyscloud/integration/data_source_genesyscloud_integration_webhook.go
+++ b/genesyscloud/integration/data_source_genesyscloud_integration_webhook.go
@@ -24,7 +24,7 @@ import (
 // dataSourceIntegrationWebhookRead retrieves webhook integration by name
 func dataSourceIntegrationWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sdkConfig := m.(*provider.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 	integrationName := d.Get("name").(string)
 
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {

--- a/genesyscloud/integration/data_source_genesyscloud_integration_webhook.go
+++ b/genesyscloud/integration/data_source_genesyscloud_integration_webhook.go
@@ -24,7 +24,7 @@ import (
 // dataSourceIntegrationWebhookRead retrieves webhook integration by name
 func dataSourceIntegrationWebhookRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	sdkConfig := m.(*provider.ProviderMeta).ClientConfig
-	ip := GetIntegrationsProxy(sdkConfig)
+	ip := getIntegrationsProxy(sdkConfig)
 	integrationName := d.Get("name").(string)
 
 	return util.WithRetries(ctx, 15*time.Second, func() *retry.RetryError {

--- a/genesyscloud/integration/genesyscloud_integration_proxy.go
+++ b/genesyscloud/integration/genesyscloud_integration_proxy.go
@@ -31,20 +31,20 @@ Each proxy implementation:
 */
 
 // internalProxy holds a proxy instance that can be used throughout the package
-var internalProxy *integrationsProxy
+var internalProxy *IntegrationsProxy
 
 // Type definitions for each func on our proxy so we can easily mock them out later
-type getAllIntegrationsFunc func(ctx context.Context, p *integrationsProxy) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error)
-type createIntegrationFunc func(ctx context.Context, p *integrationsProxy, integration *platformclientv2.Createintegrationrequest) (*platformclientv2.Integration, *platformclientv2.APIResponse, error)
-type getIntegrationByIdFunc func(ctx context.Context, p *integrationsProxy, integrationId string) (integration *platformclientv2.Integration, response *platformclientv2.APIResponse, err error)
-type getIntegrationByNameFunc func(ctx context.Context, p *integrationsProxy, integrationName string) (integration *platformclientv2.Integration, retryable bool, response *platformclientv2.APIResponse, err error)
-type updateIntegrationFunc func(ctx context.Context, p *integrationsProxy, integrationId string, integration *platformclientv2.Integration) (*platformclientv2.Integration, *platformclientv2.APIResponse, error)
-type deleteIntegrationFunc func(ctx context.Context, p *integrationsProxy, integrationId string) (response *platformclientv2.APIResponse, err error)
-type getIntegrationConfigFunc func(ctx context.Context, p *integrationsProxy, integrationId string) (config *platformclientv2.Integrationconfiguration, response *platformclientv2.APIResponse, err error)
-type updateIntegrationConfigFunc func(ctx context.Context, p *integrationsProxy, integrationId string, integrationConfig *platformclientv2.Integrationconfiguration) (integration *platformclientv2.Integrationconfiguration, response *platformclientv2.APIResponse, err error)
+type getAllIntegrationsFunc func(ctx context.Context, p *IntegrationsProxy) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error)
+type createIntegrationFunc func(ctx context.Context, p *IntegrationsProxy, integration *platformclientv2.Createintegrationrequest) (*platformclientv2.Integration, *platformclientv2.APIResponse, error)
+type getIntegrationByIdFunc func(ctx context.Context, p *IntegrationsProxy, integrationId string) (integration *platformclientv2.Integration, response *platformclientv2.APIResponse, err error)
+type getIntegrationByNameFunc func(ctx context.Context, p *IntegrationsProxy, integrationName string) (integration *platformclientv2.Integration, retryable bool, response *platformclientv2.APIResponse, err error)
+type updateIntegrationFunc func(ctx context.Context, p *IntegrationsProxy, integrationId string, integration *platformclientv2.Integration) (*platformclientv2.Integration, *platformclientv2.APIResponse, error)
+type deleteIntegrationFunc func(ctx context.Context, p *IntegrationsProxy, integrationId string) (response *platformclientv2.APIResponse, err error)
+type getIntegrationConfigFunc func(ctx context.Context, p *IntegrationsProxy, integrationId string) (config *platformclientv2.Integrationconfiguration, response *platformclientv2.APIResponse, err error)
+type updateIntegrationConfigFunc func(ctx context.Context, p *IntegrationsProxy, integrationId string, integrationConfig *platformclientv2.Integrationconfiguration) (integration *platformclientv2.Integrationconfiguration, response *platformclientv2.APIResponse, err error)
 
 // integrationProxy contains all of the methods that call genesys cloud APIs.
-type integrationsProxy struct {
+type IntegrationsProxy struct {
 	clientConfig                *platformclientv2.Configuration
 	integrationsApi             *platformclientv2.IntegrationsApi
 	getAllIntegrationsAttr      getAllIntegrationsFunc
@@ -58,9 +58,9 @@ type integrationsProxy struct {
 }
 
 // newIntegrationsProxy initializes the Integrations proxy with all of the data needed to communicate with Genesys Cloud
-func newIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integrationsProxy {
+func newIntegrationsProxy(clientConfig *platformclientv2.Configuration) *IntegrationsProxy {
 	api := platformclientv2.NewIntegrationsApiWithConfig(clientConfig)
-	return &integrationsProxy{
+	return &IntegrationsProxy{
 		clientConfig:                clientConfig,
 		integrationsApi:             api,
 		getAllIntegrationsAttr:      getAllIntegrationsFn,
@@ -74,57 +74,62 @@ func newIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integra
 	}
 }
 
-// GetIntegrationsProxy acts as a singleton to for the internalProxy.  It also ensures
+// getIntegrationsProxy acts as a singleton to for the internalProxy.  It also ensures
 // that we can still proxy our tests by directly setting internalProxy package variable
-func GetIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integrationsProxy {
+func getIntegrationsProxy(clientConfig *platformclientv2.Configuration) *IntegrationsProxy {
 	if internalProxy == nil {
 		internalProxy = newIntegrationsProxy(clientConfig)
 	}
 	return internalProxy
 }
 
+// GetIntegrationsProxy returns the proxy instance for use by other packages (e.g. tests)
+func GetIntegrationsProxy(clientConfig *platformclientv2.Configuration) *IntegrationsProxy {
+	return getIntegrationsProxy(clientConfig)
+}
+
 // GetAllIntegrations retrieves all Genesys Cloud Integrations
-func (p *integrationsProxy) GetAllIntegrations(ctx context.Context) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func (p *IntegrationsProxy) GetAllIntegrations(ctx context.Context) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	return p.getAllIntegrationsAttr(ctx, p)
 }
 
 // createIntegration creates a Genesys Cloud Integration
-func (p *integrationsProxy) createIntegration(ctx context.Context, integrationReq *platformclientv2.Createintegrationrequest) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func (p *IntegrationsProxy) createIntegration(ctx context.Context, integrationReq *platformclientv2.Createintegrationrequest) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	return p.createIntegrationAttr(ctx, p, integrationReq)
 }
 
 // getIntegrationById gets Genesys Cloud Integration by id
-func (p *integrationsProxy) getIntegrationById(ctx context.Context, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func (p *IntegrationsProxy) getIntegrationById(ctx context.Context, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	return p.getIntegrationByIdAttr(ctx, p, integrationId)
 }
 
 // getIntegrationByName gets a Genesys Cloud Integration by name
-func (p *integrationsProxy) getIntegrationByName(ctx context.Context, integrationName string) (*platformclientv2.Integration, bool, *platformclientv2.APIResponse, error) {
+func (p *IntegrationsProxy) getIntegrationByName(ctx context.Context, integrationName string) (*platformclientv2.Integration, bool, *platformclientv2.APIResponse, error) {
 	return p.getIntegrationByNameAttr(ctx, p, integrationName)
 }
 
 // updateIntegration updates a Genesys Cloud Integration
-func (p *integrationsProxy) updateIntegration(ctx context.Context, integrationId string, integration *platformclientv2.Integration) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func (p *IntegrationsProxy) updateIntegration(ctx context.Context, integrationId string, integration *platformclientv2.Integration) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	return p.updateIntegrationAttr(ctx, p, integrationId, integration)
 }
 
 // deleteIntegration deletes a Genesys Cloud Integration
-func (p *integrationsProxy) deleteIntegration(ctx context.Context, integrationId string) (response *platformclientv2.APIResponse, err error) {
+func (p *IntegrationsProxy) deleteIntegration(ctx context.Context, integrationId string) (response *platformclientv2.APIResponse, err error) {
 	return p.deleteIntegrationAttr(ctx, p, integrationId)
 }
 
 // GetIntegrationConfig get the current config of a Genesys Cloud Integration
-func (p *integrationsProxy) GetIntegrationConfig(ctx context.Context, integrationId string) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
+func (p *IntegrationsProxy) GetIntegrationConfig(ctx context.Context, integrationId string) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
 	return p.getIntegrationConfigAttr(ctx, p, integrationId)
 }
 
 // updateIntegrationConfig updates the config of a Genesys Cloud Integration
-func (p *integrationsProxy) updateIntegrationConfig(ctx context.Context, integrationId string, integrationConfig *platformclientv2.Integrationconfiguration) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
+func (p *IntegrationsProxy) updateIntegrationConfig(ctx context.Context, integrationId string, integrationConfig *platformclientv2.Integrationconfiguration) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
 	return p.updateIntegrationConfigAttr(ctx, p, integrationId, integrationConfig)
 }
 
 // getAllIntegrationsFn is the implementation for retrieving all integrations in Genesys Cloud
-func getAllIntegrationsFn(ctx context.Context, p *integrationsProxy) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func getAllIntegrationsFn(ctx context.Context, p *IntegrationsProxy) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -146,7 +151,7 @@ func getAllIntegrationsFn(ctx context.Context, p *integrationsProxy) (*[]platfor
 }
 
 // createIntegrationFn is the implementation for creating an integration in Genesys Cloud
-func createIntegrationFn(ctx context.Context, p *integrationsProxy, integrationReq *platformclientv2.Createintegrationrequest) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func createIntegrationFn(ctx context.Context, p *IntegrationsProxy, integrationReq *platformclientv2.Createintegrationrequest) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -158,7 +163,7 @@ func createIntegrationFn(ctx context.Context, p *integrationsProxy, integrationR
 }
 
 // getIntegrationByIdFn is the implementation for getting a Genesys Cloud Integration by id
-func getIntegrationByIdFn(ctx context.Context, p *integrationsProxy, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func getIntegrationByIdFn(ctx context.Context, p *IntegrationsProxy, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -172,7 +177,7 @@ func getIntegrationByIdFn(ctx context.Context, p *integrationsProxy, integration
 }
 
 // getIntegrationByNameFn is the implementation for getting a Genesys Cloud Integration by name
-func getIntegrationByNameFn(ctx context.Context, p *integrationsProxy, integrationName string) (*platformclientv2.Integration, bool, *platformclientv2.APIResponse, error) {
+func getIntegrationByNameFn(ctx context.Context, p *IntegrationsProxy, integrationName string) (*platformclientv2.Integration, bool, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -203,7 +208,7 @@ func getIntegrationByNameFn(ctx context.Context, p *integrationsProxy, integrati
 }
 
 // updateIntegrationFn is the implementation for updating a Genesys Cloud Integration
-func updateIntegrationFn(ctx context.Context, p *integrationsProxy, integrationId string, integration *platformclientv2.Integration) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func updateIntegrationFn(ctx context.Context, p *IntegrationsProxy, integrationId string, integration *platformclientv2.Integration) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -217,7 +222,7 @@ func updateIntegrationFn(ctx context.Context, p *integrationsProxy, integrationI
 }
 
 // deleteIntegrationFn is the implementation for deleting a Genesys Cloud Integration
-func deleteIntegrationFn(ctx context.Context, p *integrationsProxy, integrationId string) (response *platformclientv2.APIResponse, err error) {
+func deleteIntegrationFn(ctx context.Context, p *IntegrationsProxy, integrationId string) (response *platformclientv2.APIResponse, err error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -229,7 +234,7 @@ func deleteIntegrationFn(ctx context.Context, p *integrationsProxy, integrationI
 }
 
 // getIntegrationConfigFn is the implementation for getting the current config of a Genesys Cloud Integration
-func getIntegrationConfigFn(ctx context.Context, p *integrationsProxy, integrationId string) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
+func getIntegrationConfigFn(ctx context.Context, p *IntegrationsProxy, integrationId string) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -241,7 +246,7 @@ func getIntegrationConfigFn(ctx context.Context, p *integrationsProxy, integrati
 }
 
 // updateIntegrationConfigFn is the implementation for updating a Genesys Cloud Integration Config
-func updateIntegrationConfigFn(ctx context.Context, p *integrationsProxy, integrationId string, integrationConfig *platformclientv2.Integrationconfiguration) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
+func updateIntegrationConfigFn(ctx context.Context, p *IntegrationsProxy, integrationId string, integrationConfig *platformclientv2.Integrationconfiguration) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 

--- a/genesyscloud/integration/genesyscloud_integration_proxy.go
+++ b/genesyscloud/integration/genesyscloud_integration_proxy.go
@@ -74,17 +74,17 @@ func newIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integra
 	}
 }
 
-// getIntegrationsProxy acts as a singleton to for the internalProxy.  It also ensures
+// GetIntegrationsProxy acts as a singleton to for the internalProxy.  It also ensures
 // that we can still proxy our tests by directly setting internalProxy package variable
-func getIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integrationsProxy {
+func GetIntegrationsProxy(clientConfig *platformclientv2.Configuration) *integrationsProxy {
 	if internalProxy == nil {
 		internalProxy = newIntegrationsProxy(clientConfig)
 	}
 	return internalProxy
 }
 
-// getAllIntegrations retrieves all Genesys Cloud Integrations
-func (p *integrationsProxy) getAllIntegrations(ctx context.Context) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+// GetAllIntegrations retrieves all Genesys Cloud Integrations
+func (p *integrationsProxy) GetAllIntegrations(ctx context.Context) (*[]platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	return p.getAllIntegrationsAttr(ctx, p)
 }
 
@@ -113,8 +113,8 @@ func (p *integrationsProxy) deleteIntegration(ctx context.Context, integrationId
 	return p.deleteIntegrationAttr(ctx, p, integrationId)
 }
 
-// getIntegrationConfig get the current config of a Genesys Cloud Integration
-func (p *integrationsProxy) getIntegrationConfig(ctx context.Context, integrationId string) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
+// GetIntegrationConfig get the current config of a Genesys Cloud Integration
+func (p *integrationsProxy) GetIntegrationConfig(ctx context.Context, integrationId string) (*platformclientv2.Integrationconfiguration, *platformclientv2.APIResponse, error) {
 	return p.getIntegrationConfigAttr(ctx, p, integrationId)
 }
 

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -42,10 +42,10 @@ utils function in the package.  This will keep the code manageable and easy to w
 
 // getAllIntegrations retrieves all of the integrations via Terraform in the Genesys Cloud and is used for the exporter
 func getAllIntegrations(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
-	ip := getIntegrationsProxy(clientConfig)
+	ip := GetIntegrationsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 
-	integrations, resp, err := ip.getAllIntegrations(ctx)
+	integrations, resp, err := ip.GetAllIntegrations(ctx)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get all integrations %s", err), resp)
 	}
@@ -67,7 +67,7 @@ func createIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 	integrationType := d.Get("integration_type").(string)
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	createIntegrationReq := &platformclientv2.Createintegrationrequest{
 		IntegrationType: &platformclientv2.Integrationtype{
@@ -104,7 +104,7 @@ func createIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 // readIntegration is used by the integration resource to read an integration from genesys cloud.
 func readIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	log.Printf("Reading integration %s", d.Id())
 
@@ -124,7 +124,7 @@ func readIntegration(ctx context.Context, d *schema.ResourceData, meta interface
 		resourcedata.SetNillableValue(d, "intended_state", currentIntegration.IntendedState)
 
 		// Use returned ID to get current config, which contains complete configuration
-		integrationConfig, resp, err := ip.getIntegrationConfig(ctx, *currentIntegration.Id)
+		integrationConfig, resp, err := ip.GetIntegrationConfig(ctx, *currentIntegration.Id)
 
 		if err != nil {
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("failed to read config of integration %s | error: %s", d.Id(), getErr), resp))
@@ -140,7 +140,7 @@ func readIntegration(ctx context.Context, d *schema.ResourceData, meta interface
 func updateIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	intendedState := d.Get("intended_state").(string)
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	diagErr, name := updateIntegrationConfigFromResourceData(ctx, d, ip)
 	if diagErr != nil {
@@ -163,7 +163,7 @@ func updateIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 // deleteIntegration is used by the integration resource to delete an integration from Genesys cloud.
 func deleteIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := getIntegrationsProxy(sdkConfig)
+	ip := GetIntegrationsProxy(sdkConfig)
 
 	resp, err := ip.deleteIntegration(ctx, d.Id())
 	if err != nil {

--- a/genesyscloud/integration/resource_genesyscloud_integration.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration.go
@@ -42,7 +42,7 @@ utils function in the package.  This will keep the code manageable and easy to w
 
 // getAllIntegrations retrieves all of the integrations via Terraform in the Genesys Cloud and is used for the exporter
 func getAllIntegrations(ctx context.Context, clientConfig *platformclientv2.Configuration) (resourceExporter.ResourceIDMetaMap, diag.Diagnostics) {
-	ip := GetIntegrationsProxy(clientConfig)
+	ip := getIntegrationsProxy(clientConfig)
 	resources := make(resourceExporter.ResourceIDMetaMap)
 
 	integrations, resp, err := ip.GetAllIntegrations(ctx)
@@ -67,7 +67,7 @@ func createIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 	integrationType := d.Get("integration_type").(string)
 
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := GetIntegrationsProxy(sdkConfig)
+	ip := getIntegrationsProxy(sdkConfig)
 
 	createIntegrationReq := &platformclientv2.Createintegrationrequest{
 		IntegrationType: &platformclientv2.Integrationtype{
@@ -104,7 +104,7 @@ func createIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 // readIntegration is used by the integration resource to read an integration from genesys cloud.
 func readIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := GetIntegrationsProxy(sdkConfig)
+	ip := getIntegrationsProxy(sdkConfig)
 
 	log.Printf("Reading integration %s", d.Id())
 
@@ -140,7 +140,7 @@ func readIntegration(ctx context.Context, d *schema.ResourceData, meta interface
 func updateIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	intendedState := d.Get("intended_state").(string)
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := GetIntegrationsProxy(sdkConfig)
+	ip := getIntegrationsProxy(sdkConfig)
 
 	diagErr, name := updateIntegrationConfigFromResourceData(ctx, d, ip)
 	if diagErr != nil {
@@ -163,7 +163,7 @@ func updateIntegration(ctx context.Context, d *schema.ResourceData, meta interfa
 // deleteIntegration is used by the integration resource to delete an integration from Genesys cloud.
 func deleteIntegration(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ip := GetIntegrationsProxy(sdkConfig)
+	ip := getIntegrationsProxy(sdkConfig)
 
 	resp, err := ip.deleteIntegration(ctx, d.Id())
 	if err != nil {

--- a/genesyscloud/integration/resource_genesyscloud_integration_test.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_test.go
@@ -454,10 +454,10 @@ func testVerifyIntegrationCredentialLookup(integrationResourcePath, credentialRe
 
 		integration, _, err := proxy.GetIntegrationByCredentialId(nil, credentialId)
 		if err != nil {
-			return fmt.Errorf("getIntegrationByCredentialId failed: %s", err)
+			return fmt.Errorf("GetIntegrationByCredentialId failed: %s", err)
 		}
 		if integration == nil || integration.Id == nil {
-			return fmt.Errorf("getIntegrationByCredentialId returned nil integration for credential %s", credentialId)
+			return fmt.Errorf("GetIntegrationByCredentialId returned nil integration for credential %s", credentialId)
 		}
 		if *integration.Id != expectedIntegrationId {
 			return fmt.Errorf("expected integration id %s, got %s", expectedIntegrationId, *integration.Id)

--- a/genesyscloud/integration/resource_genesyscloud_integration_test.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_test.go
@@ -382,6 +382,90 @@ func validateIntegrationProperties(integrationResourcePath string, groupResource
 	}
 }
 
+func TestAccResourceIntegrationCredentialLookup(t *testing.T) {
+	var (
+		inteResourceLabel = "test_integration_cred_lookup"
+		inteName          = "Terraform Integration Cred Lookup-" + uuid.NewString()
+		enabledState      = "ENABLED"
+		typeID            = "custom-smtp-server"
+
+		credResourceLabel = "test_credential_lookup"
+		credName          = "Terraform Credential Lookup-" + uuid.NewString()
+		credTypeName      = "basicAuth"
+		key               = "userName"
+		val               = "someUserName"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				Config: integrationCred.GenerateCredentialResource(
+					credResourceLabel,
+					strconv.Quote(credName),
+					strconv.Quote(credTypeName),
+					integrationCred.GenerateCredentialFields(
+						map[string]string{
+							key: strconv.Quote(val),
+						},
+					),
+				) + GenerateIntegrationResource(
+					inteResourceLabel,
+					strconv.Quote(enabledState),
+					strconv.Quote(typeID),
+					GenerateIntegrationConfig(
+						strconv.Quote(inteName),
+						util.NullValue,
+						util.GenerateMapProperty(credTypeName, "genesyscloud_integration_credential."+credResourceLabel+".id"),
+						util.GenerateJsonEncodedProperties(
+							util.GenerateJsonProperty("smtpHost", strconv.Quote("fakeHost")),
+						),
+						util.NullValue,
+					),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					testVerifyIntegrationCredentialLookup("genesyscloud_integration."+inteResourceLabel, "genesyscloud_integration_credential."+credResourceLabel),
+				),
+			},
+		},
+		CheckDestroy: testVerifyIntegrationAndUsersDestroyed,
+	})
+}
+
+func testVerifyIntegrationCredentialLookup(integrationResourcePath, credentialResourcePath string) resource.TestCheckFunc {
+	return func(state *terraform.State) error {
+		integrationResource, ok := state.RootModule().Resources[integrationResourcePath]
+		if !ok {
+			return fmt.Errorf("failed to find integration %s in state", integrationResourcePath)
+		}
+
+		credentialResource, ok := state.RootModule().Resources[credentialResourcePath]
+		if !ok {
+			return fmt.Errorf("failed to find credential %s in state", credentialResourcePath)
+		}
+
+		credentialId := credentialResource.Primary.ID
+		expectedIntegrationId := integrationResource.Primary.ID
+
+		// Use the integration credential proxy to look up the integration by credential ID
+		sdkConfig := platformclientv2.GetDefaultConfiguration()
+		proxy := integrationCred.GetIntegrationCredsProxy(sdkConfig)
+
+		integration, _, err := proxy.GetIntegrationByCredentialId(nil, credentialId)
+		if err != nil {
+			return fmt.Errorf("getIntegrationByCredentialId failed: %s", err)
+		}
+		if integration == nil || integration.Id == nil {
+			return fmt.Errorf("getIntegrationByCredentialId returned nil integration for credential %s", credentialId)
+		}
+		if *integration.Id != expectedIntegrationId {
+			return fmt.Errorf("expected integration id %s, got %s", expectedIntegrationId, *integration.Id)
+		}
+		return nil
+	}
+}
+
 func testVerifyIntegrationAndUsersDestroyed(state *terraform.State) error {
 	integrationAPI := platformclientv2.NewIntegrationsApi()
 	usersAPI := platformclientv2.NewUsersApi()

--- a/genesyscloud/integration/resource_genesyscloud_integration_utils.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_utils.go
@@ -88,7 +88,7 @@ func flattenConfigCredentials(credentials map[string]platformclientv2.Credential
 
 // updateIntegrationConfigFromResourceData takes the integrationsProxy to update updates the config of an integration
 // Returns a diag error and the name of the integration
-func updateIntegrationConfigFromResourceData(ctx context.Context, d *schema.ResourceData, p *integrationsProxy) (diag.Diagnostics, string) {
+func updateIntegrationConfigFromResourceData(ctx context.Context, d *schema.ResourceData, p *IntegrationsProxy) (diag.Diagnostics, string) {
 	if d.HasChange("config") {
 		if configInput := d.Get("config").([]interface{}); configInput != nil {
 

--- a/genesyscloud/integration/resource_genesyscloud_integration_utils.go
+++ b/genesyscloud/integration/resource_genesyscloud_integration_utils.go
@@ -92,7 +92,7 @@ func updateIntegrationConfigFromResourceData(ctx context.Context, d *schema.Reso
 	if d.HasChange("config") {
 		if configInput := d.Get("config").([]interface{}); configInput != nil {
 
-			integrationConfig, resp, err := p.getIntegrationConfig(ctx, d.Id())
+			integrationConfig, resp, err := p.GetIntegrationConfig(ctx, d.Id())
 			if err != nil {
 				return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get the integration config for integration %s before updating its config error: %s", d.Id(), err), resp), ""
 			}
@@ -133,7 +133,7 @@ func updateIntegrationConfigFromResourceData(ctx context.Context, d *schema.Reso
 			diagErr := util.RetryWhen(util.IsVersionMismatch, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
 
 				// Get latest config version
-				integrationConfig, resp, err := p.getIntegrationConfig(ctx, d.Id())
+				integrationConfig, resp, err := p.GetIntegrationConfig(ctx, d.Id())
 				if err != nil {
 					return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get the integration config for integration %s before updating its config. error: %s", d.Id(), err), resp)
 				}

--- a/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
+++ b/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
+	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v188/platformclientv2"
 )
@@ -39,34 +40,36 @@ type getIntegrationCredByIdFunc func(ctx context.Context, p *integrationCredsPro
 type getIntegrationCredByNameFunc func(ctx context.Context, p *integrationCredsProxy, credentialName string) (credential *platformclientv2.Credentialinfo, retryable bool, response *platformclientv2.APIResponse, err error)
 type updateIntegrationCredFunc func(ctx context.Context, p *integrationCredsProxy, credentialId string, credential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error)
 type deleteIntegrationCredFunc func(ctx context.Context, p *integrationCredsProxy, credentialId string) (response *platformclientv2.APIResponse, err error)
-type getIntegrationByIdFunc func(ctx context.Context, p *integrationCredsProxy, integrationId string) (integration *platformclientv2.Integration, response *platformclientv2.APIResponse, err error)
+type getIntegrationByCredentialIdFunc func(ctx context.Context, p *integrationCredsProxy, integrationId string) (integration *platformclientv2.Integration, response *platformclientv2.APIResponse, err error)
 
 // integrationCredsProxy contains all of the methods that call genesys cloud APIs.
 type integrationCredsProxy struct {
-	clientConfig                 *platformclientv2.Configuration
-	integrationsApi              *platformclientv2.IntegrationsApi
-	getAllIntegrationCredsAttr   getAllIntegrationCredsFunc
-	createIntegrationCredAttr    createIntegrationCredFunc
-	getIntegrationCredByIdAttr   getIntegrationCredByIdFunc
-	getIntegrationCredByNameAttr getIntegrationCredByNameFunc
-	updateIntegrationCredAttr    updateIntegrationCredFunc
-	deleteIntegrationCredAttr    deleteIntegrationCredFunc
-	getIntegrationByIdAttr       getIntegrationByIdFunc
+	clientConfig                     *platformclientv2.Configuration
+	integrationsApi                  *platformclientv2.IntegrationsApi
+	getAllIntegrationCredsAttr       getAllIntegrationCredsFunc
+	createIntegrationCredAttr        createIntegrationCredFunc
+	getIntegrationCredByIdAttr       getIntegrationCredByIdFunc
+	getIntegrationCredByNameAttr     getIntegrationCredByNameFunc
+	updateIntegrationCredAttr        updateIntegrationCredFunc
+	deleteIntegrationCredAttr        deleteIntegrationCredFunc
+	getIntegrationByCredentialIdAttr getIntegrationByCredentialIdFunc
+	integrationCache                 rc.CacheInterface[platformclientv2.Integration]
 }
 
 // newIntegrationCredsProxy initializes the Integration Credentials proxy with all of the data needed to communicate with Genesys Cloud
 func newIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *integrationCredsProxy {
 	api := platformclientv2.NewIntegrationsApiWithConfig(clientConfig)
 	return &integrationCredsProxy{
-		clientConfig:                 clientConfig,
-		integrationsApi:              api,
-		getAllIntegrationCredsAttr:   getAllIntegrationCredsFn,
-		createIntegrationCredAttr:    createIntegrationCredFn,
-		getIntegrationCredByIdAttr:   getIntegrationCredByIdFn,
-		getIntegrationCredByNameAttr: getIntegrationCredByNameFn,
-		updateIntegrationCredAttr:    updateIntegrationCredFn,
-		deleteIntegrationCredAttr:    deleteIntegrationCredFn,
-		getIntegrationByIdAttr:       getIntegrationByIdFn,
+		clientConfig:                     clientConfig,
+		integrationsApi:                  api,
+		getAllIntegrationCredsAttr:       getAllIntegrationCredsFn,
+		createIntegrationCredAttr:        createIntegrationCredFn,
+		getIntegrationCredByIdAttr:       getIntegrationCredByIdFn,
+		getIntegrationCredByNameAttr:     getIntegrationCredByNameFn,
+		updateIntegrationCredAttr:        updateIntegrationCredFn,
+		deleteIntegrationCredAttr:        deleteIntegrationCredFn,
+		getIntegrationByCredentialIdAttr: getIntegrationByCredentialIdFn,
+		integrationCache:                 rc.NewResourceCache[platformclientv2.Integration](),
 	}
 }
 
@@ -77,6 +80,11 @@ func getIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *int
 		internalProxy = newIntegrationCredsProxy(clientConfig)
 	}
 	return internalProxy
+}
+
+// GetIntegrationCredsProxy returns the proxy instance for use by other packages (e.g. tests)
+func GetIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *integrationCredsProxy {
+	return getIntegrationCredsProxy(clientConfig)
 }
 
 // getAllIntegrationCreds retrieves all Genesys Cloud Integration Credentials using cursor-based paging
@@ -109,9 +117,14 @@ func (p *integrationCredsProxy) deleteIntegrationCred(ctx context.Context, crede
 	return p.deleteIntegrationCredAttr(ctx, p, credentialId)
 }
 
-// getIntegrationById gets Genesys Cloud Integration by id
-func (p *integrationCredsProxy) getIntegrationById(ctx context.Context, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
-	return p.getIntegrationByIdAttr(ctx, p, integrationId)
+// getIntegrationByCredentialId gets Genesys Cloud Integration by id
+func (p *integrationCredsProxy) getIntegrationByCredentialId(ctx context.Context, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+	return p.getIntegrationByCredentialIdAttr(ctx, p, credentialId)
+}
+
+// GetIntegrationByCredentialId is the public wrapper for getIntegrationByCredentialId for use by other packages (e.g. tests)
+func (p *integrationCredsProxy) GetIntegrationByCredentialId(ctx context.Context, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+	return p.getIntegrationByCredentialId(ctx, credentialId)
 }
 
 // getAllIntegrationCredsFn is the implementation for getting all integration credentials in Genesys Cloud using cursor-based paging
@@ -245,16 +258,54 @@ func deleteIntegrationCredFn(ctx context.Context, p *integrationCredsProxy, cred
 	return resp, nil
 }
 
-// getIntegrationByIdFn is the implementation for getting a Genesys Cloud Integration by id
-func getIntegrationByIdFn(ctx context.Context, p *integrationCredsProxy, integrationId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+// getIntegrationByCredentialIdFn is the implementation for getting a Genesys Cloud Integration by credential id.
+// It builds a credential-to-integration cache on first call to avoid repeated API calls during export.
+func getIntegrationByCredentialIdFn(ctx context.Context, p *integrationCredsProxy, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
-	const pageSize = 100
-	const pageNum = 1
-	integration, resp, err := p.integrationsApi.GetIntegration(integrationId, pageSize, pageNum, "", nil, "", "")
-	if err != nil {
-		return nil, resp, err
+	// Check cache first
+	if cached := rc.GetCacheItem(p.integrationCache, credentialId); cached != nil {
+		return cached, nil, nil
 	}
-	return integration, resp, nil
+
+	// Cache miss — fetch all integrations and their configs, then populate cache
+	var allIntegrations []platformclientv2.Integration
+	var resp *platformclientv2.APIResponse
+	const pageSize = 100
+	for pageNum := 1; ; pageNum++ {
+		integrations, response, err := p.integrationsApi.GetIntegrations(pageSize, pageNum, "", nil, "", "", nil, "", "")
+		if err != nil {
+			return nil, response, err
+		}
+		resp = response
+		if integrations.Entities == nil || len(*integrations.Entities) == 0 {
+			break
+		}
+		allIntegrations = append(allIntegrations, *integrations.Entities...)
+	}
+
+	for _, integ := range allIntegrations {
+		if integ.Id == nil || *integ.Id == "" {
+			continue
+		}
+		integrationConfig, _, err := p.integrationsApi.GetIntegrationConfigCurrent(*integ.Id)
+		if err != nil {
+			continue
+		}
+		if integrationConfig.Credentials == nil {
+			continue
+		}
+		for _, cred := range *integrationConfig.Credentials {
+			if cred.Id != nil {
+				rc.SetCache(p.integrationCache, *cred.Id, integ)
+			}
+		}
+	}
+
+	// Check cache again after populating
+	if cached := rc.GetCacheItem(p.integrationCache, credentialId); cached != nil {
+		return cached, resp, nil
+	}
+	return nil, nil, fmt.Errorf("failed to find integration using credential id: %s", credentialId)
 }

--- a/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
+++ b/genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 
@@ -31,19 +32,19 @@ Each proxy implementation:
 */
 
 // internalProxy holds a proxy instance that can be used throughout the package
-var internalProxy *integrationCredsProxy
+var internalProxy *IntegrationCredsProxy
 
 // Type definitions for each func on our proxy so we can easily mock them out later
-type getAllIntegrationCredsFunc func(ctx context.Context, p *integrationCredsProxy) (*[]platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error)
-type createIntegrationCredFunc func(ctx context.Context, p *integrationCredsProxy, createCredential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error)
-type getIntegrationCredByIdFunc func(ctx context.Context, p *integrationCredsProxy, credentialId string) (credential *platformclientv2.Credential, response *platformclientv2.APIResponse, err error)
-type getIntegrationCredByNameFunc func(ctx context.Context, p *integrationCredsProxy, credentialName string) (credential *platformclientv2.Credentialinfo, retryable bool, response *platformclientv2.APIResponse, err error)
-type updateIntegrationCredFunc func(ctx context.Context, p *integrationCredsProxy, credentialId string, credential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error)
-type deleteIntegrationCredFunc func(ctx context.Context, p *integrationCredsProxy, credentialId string) (response *platformclientv2.APIResponse, err error)
-type getIntegrationByCredentialIdFunc func(ctx context.Context, p *integrationCredsProxy, integrationId string) (integration *platformclientv2.Integration, response *platformclientv2.APIResponse, err error)
+type getAllIntegrationCredsFunc func(ctx context.Context, p *IntegrationCredsProxy) (*[]platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error)
+type createIntegrationCredFunc func(ctx context.Context, p *IntegrationCredsProxy, createCredential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error)
+type getIntegrationCredByIdFunc func(ctx context.Context, p *IntegrationCredsProxy, credentialId string) (credential *platformclientv2.Credential, response *platformclientv2.APIResponse, err error)
+type getIntegrationCredByNameFunc func(ctx context.Context, p *IntegrationCredsProxy, credentialName string) (credential *platformclientv2.Credentialinfo, retryable bool, response *platformclientv2.APIResponse, err error)
+type updateIntegrationCredFunc func(ctx context.Context, p *IntegrationCredsProxy, credentialId string, credential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error)
+type deleteIntegrationCredFunc func(ctx context.Context, p *IntegrationCredsProxy, credentialId string) (response *platformclientv2.APIResponse, err error)
+type getIntegrationByCredentialIdFunc func(ctx context.Context, p *IntegrationCredsProxy, integrationId string) (integration *platformclientv2.Integration, response *platformclientv2.APIResponse, err error)
 
-// integrationCredsProxy contains all of the methods that call genesys cloud APIs.
-type integrationCredsProxy struct {
+// IntegrationCredsProxy contains all of the methods that call genesys cloud APIs.
+type IntegrationCredsProxy struct {
 	clientConfig                     *platformclientv2.Configuration
 	integrationsApi                  *platformclientv2.IntegrationsApi
 	getAllIntegrationCredsAttr       getAllIntegrationCredsFunc
@@ -57,9 +58,9 @@ type integrationCredsProxy struct {
 }
 
 // newIntegrationCredsProxy initializes the Integration Credentials proxy with all of the data needed to communicate with Genesys Cloud
-func newIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *integrationCredsProxy {
+func newIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *IntegrationCredsProxy {
 	api := platformclientv2.NewIntegrationsApiWithConfig(clientConfig)
-	return &integrationCredsProxy{
+	return &IntegrationCredsProxy{
 		clientConfig:                     clientConfig,
 		integrationsApi:                  api,
 		getAllIntegrationCredsAttr:       getAllIntegrationCredsFn,
@@ -75,7 +76,7 @@ func newIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *int
 
 // getIntegrationCredsProxy acts as a singleton to for the internalProxy.  It also ensures
 // that we can still proxy our tests by directly setting internalProxy package variable
-func getIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *integrationCredsProxy {
+func getIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *IntegrationCredsProxy {
 	if internalProxy == nil {
 		internalProxy = newIntegrationCredsProxy(clientConfig)
 	}
@@ -83,52 +84,47 @@ func getIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *int
 }
 
 // GetIntegrationCredsProxy returns the proxy instance for use by other packages (e.g. tests)
-func GetIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *integrationCredsProxy {
+func GetIntegrationCredsProxy(clientConfig *platformclientv2.Configuration) *IntegrationCredsProxy {
 	return getIntegrationCredsProxy(clientConfig)
 }
 
 // getAllIntegrationCreds retrieves all Genesys Cloud Integration Credentials using cursor-based paging
-func (p *integrationCredsProxy) getAllIntegrationCreds(ctx context.Context) (*[]platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
+func (p *IntegrationCredsProxy) getAllIntegrationCreds(ctx context.Context) (*[]platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
 	return p.getAllIntegrationCredsAttr(ctx, p)
 }
 
 // createIntegrationCred creates a Genesys Cloud Crdential
-func (p *integrationCredsProxy) createIntegrationCred(ctx context.Context, createCredential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
+func (p *IntegrationCredsProxy) createIntegrationCred(ctx context.Context, createCredential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
 	return p.createIntegrationCredAttr(ctx, p, createCredential)
 }
 
 // getIntegrationCredById gets a Genesys Cloud Integration Credential by id
-func (p *integrationCredsProxy) getIntegrationCredById(ctx context.Context, credentialId string) (credential *platformclientv2.Credential, response *platformclientv2.APIResponse, err error) {
+func (p *IntegrationCredsProxy) getIntegrationCredById(ctx context.Context, credentialId string) (credential *platformclientv2.Credential, response *platformclientv2.APIResponse, err error) {
 	return p.getIntegrationCredByIdAttr(ctx, p, credentialId)
 }
 
 // getIntegrationCredByName gets a Genesys Cloud Integration Credential by name
-func (p *integrationCredsProxy) getIntegrationCredByName(ctx context.Context, credentialName string) (*platformclientv2.Credentialinfo, bool, *platformclientv2.APIResponse, error) {
+func (p *IntegrationCredsProxy) getIntegrationCredByName(ctx context.Context, credentialName string) (*platformclientv2.Credentialinfo, bool, *platformclientv2.APIResponse, error) {
 	return p.getIntegrationCredByNameAttr(ctx, p, credentialName)
 }
 
 // updateIntegrationCred updates a Genesys Cloud Integration Credential
-func (p *integrationCredsProxy) updateIntegrationCred(ctx context.Context, credentialId string, credential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
+func (p *IntegrationCredsProxy) updateIntegrationCred(ctx context.Context, credentialId string, credential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
 	return p.updateIntegrationCredAttr(ctx, p, credentialId, credential)
 }
 
 // deleteIntegrationCred deletes a Genesys Cloud Integration Credential
-func (p *integrationCredsProxy) deleteIntegrationCred(ctx context.Context, credentialId string) (response *platformclientv2.APIResponse, err error) {
+func (p *IntegrationCredsProxy) deleteIntegrationCred(ctx context.Context, credentialId string) (response *platformclientv2.APIResponse, err error) {
 	return p.deleteIntegrationCredAttr(ctx, p, credentialId)
 }
 
-// getIntegrationByCredentialId gets Genesys Cloud Integration by id
-func (p *integrationCredsProxy) getIntegrationByCredentialId(ctx context.Context, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+// GetIntegrationByCredentialId is the public wrapper for getting the Genesys Cloud Integration by id
+func (p *IntegrationCredsProxy) GetIntegrationByCredentialId(ctx context.Context, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	return p.getIntegrationByCredentialIdAttr(ctx, p, credentialId)
 }
 
-// GetIntegrationByCredentialId is the public wrapper for getIntegrationByCredentialId for use by other packages (e.g. tests)
-func (p *integrationCredsProxy) GetIntegrationByCredentialId(ctx context.Context, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
-	return p.getIntegrationByCredentialId(ctx, credentialId)
-}
-
 // getAllIntegrationCredsFn is the implementation for getting all integration credentials in Genesys Cloud using cursor-based paging
-func getAllIntegrationCredsFn(ctx context.Context, p *integrationCredsProxy) (*[]platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
+func getAllIntegrationCredsFn(ctx context.Context, p *IntegrationCredsProxy) (*[]platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -165,7 +161,7 @@ func getAllIntegrationCredsFn(ctx context.Context, p *integrationCredsProxy) (*[
 }
 
 // createIntegrationCredFn is the implementation for creating an integration credential in Genesys Cloud
-func createIntegrationCredFn(ctx context.Context, p *integrationCredsProxy, createCredential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
+func createIntegrationCredFn(ctx context.Context, p *IntegrationCredsProxy, createCredential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -177,7 +173,7 @@ func createIntegrationCredFn(ctx context.Context, p *integrationCredsProxy, crea
 }
 
 // getIntegrationCredByIdFn is the implementation for getting an integration credential by id in Genesys Cloud
-func getIntegrationCredByIdFn(ctx context.Context, p *integrationCredsProxy, credentialId string) (*platformclientv2.Credential, *platformclientv2.APIResponse, error) {
+func getIntegrationCredByIdFn(ctx context.Context, p *IntegrationCredsProxy, credentialId string) (*platformclientv2.Credential, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -189,7 +185,7 @@ func getIntegrationCredByIdFn(ctx context.Context, p *integrationCredsProxy, cre
 }
 
 // getIntegrationCredByNameFn is the implementation for getting an integration credential by name in Genesys Cloud
-func getIntegrationCredByNameFn(ctx context.Context, p *integrationCredsProxy, credentialName string) (*platformclientv2.Credentialinfo, bool, *platformclientv2.APIResponse, error) {
+func getIntegrationCredByNameFn(ctx context.Context, p *IntegrationCredsProxy, credentialName string) (*platformclientv2.Credentialinfo, bool, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -235,7 +231,7 @@ func getIntegrationCredByNameFn(ctx context.Context, p *integrationCredsProxy, c
 }
 
 // updateIntegrationCredFn is the implementation for updating an integration credential in Genesys Cloud
-func updateIntegrationCredFn(ctx context.Context, p *integrationCredsProxy, credentialId string, credential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
+func updateIntegrationCredFn(ctx context.Context, p *IntegrationCredsProxy, credentialId string, credential *platformclientv2.Credential) (*platformclientv2.Credentialinfo, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -247,7 +243,7 @@ func updateIntegrationCredFn(ctx context.Context, p *integrationCredsProxy, cred
 }
 
 // deleteIntegrationCredFn is the implementation for deleting an integration credential in Genesys Cloud
-func deleteIntegrationCredFn(ctx context.Context, p *integrationCredsProxy, credentialId string) (response *platformclientv2.APIResponse, err error) {
+func deleteIntegrationCredFn(ctx context.Context, p *IntegrationCredsProxy, credentialId string) (response *platformclientv2.APIResponse, err error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -260,7 +256,7 @@ func deleteIntegrationCredFn(ctx context.Context, p *integrationCredsProxy, cred
 
 // getIntegrationByCredentialIdFn is the implementation for getting a Genesys Cloud Integration by credential id.
 // It builds a credential-to-integration cache on first call to avoid repeated API calls during export.
-func getIntegrationByCredentialIdFn(ctx context.Context, p *integrationCredsProxy, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
+func getIntegrationByCredentialIdFn(ctx context.Context, p *IntegrationCredsProxy, credentialId string) (*platformclientv2.Integration, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
@@ -271,26 +267,27 @@ func getIntegrationByCredentialIdFn(ctx context.Context, p *integrationCredsProx
 
 	// Cache miss — fetch all integrations and their configs, then populate cache
 	var allIntegrations []platformclientv2.Integration
-	var resp *platformclientv2.APIResponse
 	const pageSize = 100
 	for pageNum := 1; ; pageNum++ {
 		integrations, response, err := p.integrationsApi.GetIntegrations(pageSize, pageNum, "", nil, "", "", nil, "", "")
 		if err != nil {
 			return nil, response, err
 		}
-		resp = response
 		if integrations.Entities == nil || len(*integrations.Entities) == 0 {
 			break
 		}
 		allIntegrations = append(allIntegrations, *integrations.Entities...)
 	}
 
+	var foundIntegration platformclientv2.Integration
+	var foundResp *platformclientv2.APIResponse
 	for _, integ := range allIntegrations {
 		if integ.Id == nil || *integ.Id == "" {
 			continue
 		}
-		integrationConfig, _, err := p.integrationsApi.GetIntegrationConfigCurrent(*integ.Id)
+		integrationConfig, response, err := p.integrationsApi.GetIntegrationConfigCurrent(*integ.Id)
 		if err != nil {
+			tflog.Warn(ctx, "Failed to retrieve integration config for integration "+*integ.Id, map[string]interface{}{"error": err, "response": response})
 			continue
 		}
 		if integrationConfig.Credentials == nil {
@@ -299,13 +296,16 @@ func getIntegrationByCredentialIdFn(ctx context.Context, p *integrationCredsProx
 		for _, cred := range *integrationConfig.Credentials {
 			if cred.Id != nil {
 				rc.SetCache(p.integrationCache, *cred.Id, integ)
+				if *cred.Id == credentialId {
+					foundResp = response
+					foundIntegration = integ
+				}
 			}
 		}
 	}
-
-	// Check cache again after populating
-	if cached := rc.GetCacheItem(p.integrationCache, credentialId); cached != nil {
-		return cached, resp, nil
+	if foundIntegration.Id != nil {
+		return &foundIntegration, foundResp, nil
 	}
+
 	return nil, nil, fmt.Errorf("failed to find integration using credential id: %s", credentialId)
 }

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
 
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
@@ -52,23 +53,23 @@ func getAllCredentials(ctx context.Context, clientConfig *platformclientv2.Confi
 	}
 
 	for _, cred := range *credentials {
-		log.Printf("Dealing with credential id: %s, credential name: %s", *cred.Id, util.StringOrNil(cred.Name))
+		tflog.Info(ctx, fmt.Sprintf("Dealing with credential id: %s, credential name: %s", *cred.Id, util.StringOrNil(cred.Name)))
 		if cred.Name != nil { // Credential is possible to have no name
 
 			// Verify that the integration entity itself exist before exporting the integration credentials associated to it: DEVTOOLING-282
-			integration, resp, err := ip.getIntegrationByCredentialId(ctx, *cred.Id)
+			integration, resp, err := ip.GetIntegrationByCredentialId(ctx, *cred.Id)
 			if err != nil {
 				if util.IsStatus404(resp) {
-					log.Printf("The Integration associated with the Integration Credential %s no longer exist, we are therefore not exporting the Integration Credential", cred.Id)
+					tflog.Warn(ctx, fmt.Sprintf("The Integration associated with the Integration Credential %s no longer exist, we are therefore not exporting the Integration Credential", *cred.Id))
 					continue
 				} else {
-					log.Printf("The Integration associated with the Integration Credential %s exists but we got an unexpected error retrieving it: %v", cred.Id, err)
+					tflog.Warn(ctx, fmt.Sprintf("The Integration associated with the Integration Credential %s exists but we got an unexpected error retrieving it: %v", *cred.Id, err))
 				}
 
 			}
 
 			if integration == nil {
-				log.Printf("Could not find integration associated with integration credential %s, we are therefore not exporting the associated integration credential", cred.Id)
+				log.Printf("Could not find integration associated with integration credential %s, we are therefore not exporting the associated integration credential", *cred.Id)
 				continue
 			}
 			// Block Label: DEVTOOLING-1135

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
@@ -52,18 +52,24 @@ func getAllCredentials(ctx context.Context, clientConfig *platformclientv2.Confi
 	}
 
 	for _, cred := range *credentials {
-		log.Printf("Dealing with credential id : %s, credential name : %s", *cred.Id, util.StringOrNil(cred.Name))
+		log.Printf("Dealing with credential id: %s, credential name: %s", *cred.Id, util.StringOrNil(cred.Name))
 		if cred.Name != nil { // Credential is possible to have no name
 
 			// Verify that the integration entity itself exist before exporting the integration credentials associated to it: DEVTOOLING-282
 			integration, resp, err := ip.getIntegrationByCredentialId(ctx, *cred.Id)
 			if err != nil {
 				if util.IsStatus404(resp) {
-					log.Printf("Integration id %s no longer exist, we are therefore not exporting the associated integration credential id %s", cred.Id, *cred.Id)
+					log.Printf("The Integration associated with the Integration Credential %s no longer exist, we are therefore not exporting the Integration Credential", cred.Id)
 					continue
 				} else {
-					log.Printf("Integration Credential id %s exists but we got an unexpected error retrieving it: %v", cred.Id, err)
+					log.Printf("The Integration associated with the Integration Credential %s exists but we got an unexpected error retrieving it: %v", cred.Id, err)
 				}
+
+			}
+
+			if integration == nil {
+				log.Printf("Could not find integration associated with integration credential %s, we are therefore not exporting the associated integration credential", cred.Id)
+				continue
 			}
 			// Block Label: DEVTOOLING-1135
 			resources[*cred.Id] = &resourceExporter.ResourceMeta{BlockLabel: "Integration-" + *integration.Name}

--- a/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
+++ b/genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"log"
-	"regexp"
-	"strings"
 	"time"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
@@ -57,21 +55,14 @@ func getAllCredentials(ctx context.Context, clientConfig *platformclientv2.Confi
 		log.Printf("Dealing with credential id : %s, credential name : %s", *cred.Id, util.StringOrNil(cred.Name))
 		if cred.Name != nil { // Credential is possible to have no name
 
-			// Export integration credential only if it matches the expected format: DEVTOOLING-310
-			regexPattern := regexp.MustCompile("Integration-.+")
-			if !regexPattern.MatchString(*cred.Name) {
-				log.Printf("integration credential name [%s] does not match the expected format [%s], not exporting integration credential id %s", *cred.Name, regexPattern.String(), *cred.Id)
-				continue
-			}
 			// Verify that the integration entity itself exist before exporting the integration credentials associated to it: DEVTOOLING-282
-			integrationId := strings.Split(*cred.Name, "Integration-")[1]
-			integration, resp, err := ip.getIntegrationById(ctx, integrationId)
+			integration, resp, err := ip.getIntegrationByCredentialId(ctx, *cred.Id)
 			if err != nil {
 				if util.IsStatus404(resp) {
-					log.Printf("Integration id %s no longer exist, we are therefore not exporting the associated integration credential id %s", integrationId, *cred.Id)
+					log.Printf("Integration id %s no longer exist, we are therefore not exporting the associated integration credential id %s", cred.Id, *cred.Id)
 					continue
 				} else {
-					log.Printf("Integration id %s exists but we got an unexpected error retrieving it: %v", integrationId, err)
+					log.Printf("Integration Credential id %s exists but we got an unexpected error retrieving it: %v", cred.Id, err)
 				}
 			}
 			// Block Label: DEVTOOLING-1135


### PR DESCRIPTION
## Note
Something got screwed up with the github PR/branch in https://github.com/MyPureCloud/terraform-provider-genesyscloud/pull/2338 and I had to reopen as a new PR.

## Summary

Replaces the previous integration credential export logic — which relied on parsing the credential name to extract an integration ID — with a proper credential-to-integration lookup using a cached bulk-fetch strategy. This fixes cases where the credential name does not follow the `Integration-{id}` naming convention (DEVTOOLING-282, DEVTOOLING-310).

## Changes

### `genesyscloud/integration_credential/genesyscloud_integration_credential_proxy.go`
- Renamed `getIntegrationByIdFunc` → `getIntegrationByCredentialIdFunc` and corresponding struct field/method to reflect the actual lookup semantics
- Replaced `getIntegrationByIdFn` (single `GetIntegration` call by integration ID) with `getIntegrationByCredentialIdFn` which:
  - Checks a new `integrationCache` (keyed by credential ID → integration) before making API calls
  - On cache miss, fetches all integrations and their configs via pagination, populates the cache with credential-to-integration mappings
  - Returns the matched integration from cache or an error if not found
- Added `integrationCache` field (`rc.CacheInterface[platformclientv2.Integration]`) to the proxy struct
- Added public `GetIntegrationCredsProxy` function to expose the proxy singleton to other packages
- Added public `GetIntegrationByCredentialId` method as a public wrapper for cross-package usage

### `genesyscloud/integration_credential/resource_genesyscloud_integration_credential.go`
- Removed the regex-based name format check (`Integration-.+`) that was gating credential export (DEVTOOLING-310)
- Removed `strings.Split(*cred.Name, "Integration-")[1]` logic for extracting integration IDs from credential names
- Now calls `getIntegrationByCredentialId(ctx, *cred.Id)` to verify the integration exists before exporting
- Removed unused imports (`regexp`, `strings`)

### `genesyscloud/integration/genesyscloud_integration_proxy.go`
- Exported `getIntegrationsProxy` → `GetIntegrationsProxy`
- Exported `getAllIntegrations` → `GetAllIntegrations`
- Exported `getIntegrationConfig` → `GetIntegrationConfig`

### `genesyscloud/integration/resource_genesyscloud_integration.go`
- Updated all call sites to use the newly exported proxy method names

### `genesyscloud/integration/resource_genesyscloud_integration_utils.go`
- Updated call sites to use `GetIntegrationConfig`

### `genesyscloud/integration/data_source_genesyscloud_integration.go` & `data_source_genesyscloud_integration_webhook.go`
- Updated call sites to use `GetIntegrationsProxy`
- Minor import reordering (stdlib first per Go convention)

### `genesyscloud/integration/resource_genesyscloud_integration_test.go`
- Added `TestAccResourceIntegrationCredentialLookup` acceptance test that:
  - Creates a credential and an integration with that credential attached
  - Verifies `GetIntegrationByCredentialId` correctly resolves the integration from the credential ID

## Motivation

The previous implementation assumed integration credentials always follow the naming pattern `Integration-{integrationId}`. This is not always accurate — credentials can be renamed or created with non-standard names. The new approach:

1. Looks up integrations by iterating all integrations and their credential configs, matching on the actual credential ID
2. Uses a bulk-fetch + cache strategy to avoid N+1 API calls during export
3. Removes the brittle regex/string-split logic entirely
4. Exposes proxy methods publicly for cross-package testing and reuse

## Testing

- New acceptance test `TestAccResourceIntegrationCredentialLookup` validates the credential-to-integration lookup end-to-end
- Existing integration tests continue to pass with the renamed exported methods

## AI Disclosure
- The caching implementation was generated with the assistance of Amazon Q Developer.
- This PR description was generated with the assistance of Amazon Q Developer. 
