### PR TITLE
OBR-1280: Add edge_group_id and site_id to routing_queue callback media settings

### DIFF
--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -54,7 +54,7 @@ resource "genesyscloud_routing_email_route" "example_route" {
     enabled            = false
     canned_response_id = genesyscloud_responsemanagement_response.example_signature_response.id
     always_included    = false
-    inclusion_type     = "FirstResponseOnly"
+    inclusion_type     = "Send"
   }
 }
 

--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -6,25 +6,20 @@ description: |-
 ---
 # genesyscloud_routing_queue (Resource)
 
-<!-- This document is automatically generated. Do not edit manually. Make changes to the schema, examples, or apis.md files in examples/resources/ and run 'make docs' to regenerate. -->
-
 Genesys Cloud Routing Queue
 
 ## API Usage
-
 The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Client has been granted the necessary scopes and permissions to perform these operations:
 
-* [GET /api/v2/routing/queues](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues)
-* [POST /api/v2/routing/queues](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues)
-* [DELETE /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#delete-api-v2-routing-queues--queueId-)
-* [GET /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId-)
-* [PUT /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#put-api-v2-routing-queues--queueId-)
-* [GET /api/v2/routing/queues/{queueId}/members](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId--members)
-* [POST /api/v2/routing/queues/{queueId}/members](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues--queueId--members)
-* [PATCH /api/v2/routing/queues/{queueId}/members/{memberId}](https://developer.genesys.cloud/devapps/api-explorer#patch-api-v2-routing-queues--queueId--members--memberId-)
-* [GET /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId--wrapupcodes)
-* [POST /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues--queueId--wrapupcodes)
-* [DELETE /api/v2/routing/queues/{queueId}/wrapupcodes/{codeId}](https://developer.genesys.cloud/devapps/api-explorer#delete-api-v2-routing-queues--queueId--wrapupcodes--codeId-)
+- [POST /api/v2/routing/queues](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues)
+- [GET /api/v2/routing/queues/{queueId}/members](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId--members)
+- [GET /api/v2/routing/queues/{queueId}](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId-)
+- [POST /api/v2/routing/queues/{queueId}/members](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues--queueId--members)
+- [PATCH /api/v2/routing/queues/{queueId}/members/{memberId}](https://developer.mypurecloud.com/api/rest/v2/routing/#patch-api-v2-routing-queues--queueId--members--memberId-)
+- [DELETE /api/v2/routing/queues/{queueId}](https://developer.mypurecloud.com/api/rest/v2/routing/#delete-api-v2-routing-queues--queueId-)
+- [GET /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId--wrapupcodes)
+- [POST /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues--queueId--wrapupcodes)
+- [DELETE /api/v2/routing/queues/{queueId}/wrapupcodes/{codeId}](https://developer.mypurecloud.com/api/rest/v2/routing/#delete-api-v2-routing-queues--queueId--wrapupcodes--codeId-)
 
 ## Permissions and Scopes
 
@@ -41,7 +36,6 @@ The following OAuth scopes are required to use this resource:
 
 * `routing`
 * `routing:readonly`
-
 ## Schema Migration: Routing Queue V1 to V2
 
 ### Migration Details
@@ -156,6 +150,7 @@ resource "genesyscloud_routing_queue" "example" {
 #### Action Required
 
 The state will be automatically upgraded when you run terraform init with version 1.60.0 or later of the provider. After this, you will have to update your config to remove these attributes from the `media_settings_call`, `media_settings_email`, `media_settings_chat`, and `media_settings_message` config blocks as they are no longer supported.
+
 
 ## Example Usage
 
@@ -379,19 +374,19 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 ### Optional
 
-- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW (Min: 1 sec, Max: 60 min). Can only be used when ACW is AGENT_REQUESTED, MANDATORY_TIMEOUT or MANDATORY_FORCED_TIMEOUT.
+- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW. Only set when ACW is MANDATORY_TIMEOUT, MANDATORY_FORCED_TIMEOUT or AGENT_REQUESTED.
 - `acw_wrapup_prompt` (String) This field controls how the UI prompts the agent for a wrapup (MANDATORY | OPTIONAL | MANDATORY_TIMEOUT | MANDATORY_FORCED_TIMEOUT | AGENT_REQUESTED). Defaults to `MANDATORY_TIMEOUT`.
-- `agent_owned_routing` (Block List, Max: 1) The Agent Owned Routing settings for the queue. (see [below for nested schema](#nestedblock--agent_owned_routing))
+- `agent_owned_routing` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--agent_owned_routing))
 - `auto_answer_only` (Boolean) Specifies whether the configured whisper should play for all ACD calls, or only for those which are auto-answered. Defaults to `true`.
 - `bullseye_rings` (Block List, Max: 6) The bullseye ring settings for the queue. (see [below for nested schema](#nestedblock--bullseye_rings))
 - `calling_party_name` (String) The name to use for caller identification for outbound calls from this queue.
 - `calling_party_number` (String) The phone number to use for caller identification for outbound calls from this queue.
-- `canned_response_libraries` (Block List, Max: 1) Canned response library IDs and mode with which they are associated with the queue. (see [below for nested schema](#nestedblock--canned_response_libraries))
+- `canned_response_libraries` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--canned_response_libraries))
 - `conditional_group_activation` (Block List, Max: 1) The Conditional Group Activation settings for the queue. (see [below for nested schema](#nestedblock--conditional_group_activation))
 - `conditional_group_routing_rules` (Block List, Max: 5) The Conditional Group Routing settings for the queue. **Important:** conditional_group_routing_rules is deprecated in genesyscloud_routing_queue. CGR is now a standalone resource, please set ENABLE_STANDALONE_CGR in your environment variables to enable and use genesyscloud_routing_queue_conditional_group_routing. When ENABLE_STANDALONE_CGR is set, this attribute will not be read or exported. The two approaches are mutually exclusive to prevent duplicate data during org exports. (see [below for nested schema](#nestedblock--conditional_group_routing_rules))
 - `default_script_ids` (Map of String) The default script IDs for each communication type. Communication types: (CALL | CALLBACK | CHAT | COBROWSE | EMAIL | MESSAGE | SOCIAL_EXPRESSION | VIDEO | SCREENSHARE)
 - `description` (String) Queue description.
-- `direct_routing` (Block List, Max: 1) The Direct Routing settings for the queue. (see [below for nested schema](#nestedblock--direct_routing))
+- `direct_routing` (Block List, Max: 1) Used by the System to set Direct Routing settings for a system Direct Routing queue. (see [below for nested schema](#nestedblock--direct_routing))
 - `division_id` (String) The division to which this queue will belong. If not set, the home division will be used.
 - `email_in_queue_flow_id` (String) The in-queue flow ID to use for email conversations waiting in queue.
 - `enable_audio_monitoring` (Boolean) Indicates whether audio monitoring is enabled for this queue.
@@ -433,9 +428,9 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 Optional:
 
-- `enable_agent_owned_callbacks` (Boolean) Indicates if Agent Owned Callbacks are enabled for the queue.
-- `max_owned_callback_delay_hours` (Number) The max amount of time a callback can be scheduled out into the future (in hours). Allowable range 1 - 720 hour(s) (inclusive).
-- `max_owned_callback_hours` (Number) The max amount of time a callback can be owned (in hours). Allowable range 1 - 168 hour(s) (inclusive).
+- `enable_agent_owned_callbacks` (Boolean) Enable Agent Owned Callbacks
+- `max_owned_callback_delay_hours` (Number) Max Owned Call Back Delay Hours >= 7
+- `max_owned_callback_hours` (Number) Auto End Delay Seconds Must be >= 7
 
 
 <a id="nestedblock--bullseye_rings"></a>
@@ -583,12 +578,12 @@ Required:
 
 Optional:
 
-- `agent_wait_seconds` (Number) Time (in seconds) that a Direct Routing interaction will wait for Direct Routing agent before going to selected backup. Valid range [60, 864000]. Defaults to `60`.
-- `backup_queue_id` (String) ID of another queue to be used as the default backup if an agent does not have their Backup Settings configured. If not set, the current queue will be used as backup, but with Direct Routing criteria removed from the conversation.
+- `agent_wait_seconds` (Number) The queue default time a Direct Routing interaction will wait for an agent before it goes to configured backup. Defaults to `60`.
+- `backup_queue_id` (String) Direct Routing default backup queue id (if none supplied this queue will be used as backup).
 - `call_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for calls. Defaults to `true`.
 - `email_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for emails. Defaults to `true`.
 - `message_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for messages. Defaults to `true`.
-- `wait_for_agent` (Boolean) Flag indicating if Direct Routing interactions should wait for Direct Routing agent or go immediately to selected backup. Defaults to `false`.
+- `wait_for_agent` (Boolean) Boolean indicating if Direct Routing interactions should wait for the targeted agent by default. Defaults to `false`.
 
 
 <a id="nestedblock--media_settings_call"></a>
@@ -597,11 +592,19 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_call--sub_type_settings))
+
+<a id="nestedblock--media_settings_call--sub_type_settings"></a>
+### Nested Schema for `media_settings_call.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_callback"></a>
@@ -613,10 +616,11 @@ Optional:
 - `answering_machine_flow_id` (String) The inbound flow to transfer to if an answering machine is detected during the outbound call of a customer first callback when answeringMachineReactionType is set to TransferToFlow.
 - `answering_machine_reaction_type` (String) The action to take if an answering machine is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `auto_dial_delay_seconds` (Number) Time in seconds after agent connects to callback before outgoing call is auto-dialed. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
-- `auto_end_delay_seconds` (Number) Time in seconds after agent disconnects from the outgoing call before the encasing callback is auto-ended. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `enable_auto_dial_and_end` (Boolean) Flag to enable Auto-Dial and Auto-End automation for callbacks on this queue. Defaults to `false`.
+- `auto_dial_delay_seconds` (Number) Auto Dial Delay Seconds.
+- `auto_end_delay_seconds` (Number) Auto End Delay Seconds.
+- `edge_group_id` (String) The identifier of the edge group that will place the calls. Can be set to specify a custom edge group instead of the default one.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `enable_auto_dial_and_end` (Boolean) Auto Dial and End Defaults to `false`.
 - `live_voice_flow_id` (String) The inbound flow to transfer to if a live voice is detected during the outbound call of a customer first callback.
 - `live_voice_reaction_type` (String) The action to take if a live voice is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
@@ -626,6 +630,17 @@ Optional:
 - `retry_delay_seconds` (Number) Delay in seconds between each retry of a customer first callback.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `site_id` (String) The identifier of the site to be used for dialing. If omitted, the default telephony site for the organization is used.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_callback--sub_type_settings))
+
+<a id="nestedblock--media_settings_callback--sub_type_settings"></a>
+### Nested Schema for `media_settings_callback.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_chat"></a>
@@ -634,11 +649,19 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_chat--sub_type_settings))
+
+<a id="nestedblock--media_settings_chat--sub_type_settings"></a>
+### Nested Schema for `media_settings_chat.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_email"></a>
@@ -647,11 +670,19 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_email--sub_type_settings))
+
+<a id="nestedblock--media_settings_email--sub_type_settings"></a>
+### Nested Schema for `media_settings_email.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_message"></a>
@@ -660,12 +691,12 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. The API does not enforce this, so its essentially a no-op. You should drive this configuration via the "sub_type_settings" configuration for each media type
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. Defaults to `false`.
 - `inactivity_timeout_settings` (Block List, Max: 1) Inactivity timeout settings for messages. (see [below for nested schema](#nestedblock--media_settings_message--inactivity_timeout_settings))
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Map of media subtype to media subtype specific settings. (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
 
 <a id="nestedblock--media_settings_message--inactivity_timeout_settings"></a>
 ### Nested Schema for `media_settings_message.inactivity_timeout_settings`
@@ -686,11 +717,7 @@ Optional:
 Required:
 
 - `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The media subtype key (e.g. webmessaging, instagram, whatsapp).
-
-Optional:
-
-- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for the given subtype.
+- `media_type` (String) The name of the social media company
 
 
 

--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -6,20 +6,25 @@ description: |-
 ---
 # genesyscloud_routing_queue (Resource)
 
+<!-- This document is automatically generated. Do not edit manually. Make changes to the schema, examples, or apis.md files in examples/resources/ and run 'make docs' to regenerate. -->
+
 Genesys Cloud Routing Queue
 
 ## API Usage
+
 The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Client has been granted the necessary scopes and permissions to perform these operations:
 
-- [POST /api/v2/routing/queues](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues)
-- [GET /api/v2/routing/queues/{queueId}/members](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId--members)
-- [GET /api/v2/routing/queues/{queueId}](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId-)
-- [POST /api/v2/routing/queues/{queueId}/members](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues--queueId--members)
-- [PATCH /api/v2/routing/queues/{queueId}/members/{memberId}](https://developer.mypurecloud.com/api/rest/v2/routing/#patch-api-v2-routing-queues--queueId--members--memberId-)
-- [DELETE /api/v2/routing/queues/{queueId}](https://developer.mypurecloud.com/api/rest/v2/routing/#delete-api-v2-routing-queues--queueId-)
-- [GET /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId--wrapupcodes)
-- [POST /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues--queueId--wrapupcodes)
-- [DELETE /api/v2/routing/queues/{queueId}/wrapupcodes/{codeId}](https://developer.mypurecloud.com/api/rest/v2/routing/#delete-api-v2-routing-queues--queueId--wrapupcodes--codeId-)
+* [GET /api/v2/routing/queues](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues)
+* [POST /api/v2/routing/queues](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues)
+* [DELETE /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#delete-api-v2-routing-queues--queueId-)
+* [GET /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId-)
+* [PUT /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#put-api-v2-routing-queues--queueId-)
+* [GET /api/v2/routing/queues/{queueId}/members](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId--members)
+* [POST /api/v2/routing/queues/{queueId}/members](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues--queueId--members)
+* [PATCH /api/v2/routing/queues/{queueId}/members/{memberId}](https://developer.genesys.cloud/devapps/api-explorer#patch-api-v2-routing-queues--queueId--members--memberId-)
+* [GET /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId--wrapupcodes)
+* [POST /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues--queueId--wrapupcodes)
+* [DELETE /api/v2/routing/queues/{queueId}/wrapupcodes/{codeId}](https://developer.genesys.cloud/devapps/api-explorer#delete-api-v2-routing-queues--queueId--wrapupcodes--codeId-)
 
 ## Permissions and Scopes
 
@@ -36,6 +41,7 @@ The following OAuth scopes are required to use this resource:
 
 * `routing`
 * `routing:readonly`
+
 ## Schema Migration: Routing Queue V1 to V2
 
 ### Migration Details
@@ -150,7 +156,6 @@ resource "genesyscloud_routing_queue" "example" {
 #### Action Required
 
 The state will be automatically upgraded when you run terraform init with version 1.60.0 or later of the provider. After this, you will have to update your config to remove these attributes from the `media_settings_call`, `media_settings_email`, `media_settings_chat`, and `media_settings_message` config blocks as they are no longer supported.
-
 
 ## Example Usage
 
@@ -374,19 +379,19 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 ### Optional
 
-- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW. Only set when ACW is MANDATORY_TIMEOUT, MANDATORY_FORCED_TIMEOUT or AGENT_REQUESTED.
+- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW (Min: 1 sec, Max: 60 min). Can only be used when ACW is AGENT_REQUESTED, MANDATORY_TIMEOUT or MANDATORY_FORCED_TIMEOUT.
 - `acw_wrapup_prompt` (String) This field controls how the UI prompts the agent for a wrapup (MANDATORY | OPTIONAL | MANDATORY_TIMEOUT | MANDATORY_FORCED_TIMEOUT | AGENT_REQUESTED). Defaults to `MANDATORY_TIMEOUT`.
-- `agent_owned_routing` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--agent_owned_routing))
+- `agent_owned_routing` (Block List, Max: 1) The Agent Owned Routing settings for the queue. (see [below for nested schema](#nestedblock--agent_owned_routing))
 - `auto_answer_only` (Boolean) Specifies whether the configured whisper should play for all ACD calls, or only for those which are auto-answered. Defaults to `true`.
 - `bullseye_rings` (Block List, Max: 6) The bullseye ring settings for the queue. (see [below for nested schema](#nestedblock--bullseye_rings))
 - `calling_party_name` (String) The name to use for caller identification for outbound calls from this queue.
 - `calling_party_number` (String) The phone number to use for caller identification for outbound calls from this queue.
-- `canned_response_libraries` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--canned_response_libraries))
+- `canned_response_libraries` (Block List, Max: 1) Canned response library IDs and mode with which they are associated with the queue. (see [below for nested schema](#nestedblock--canned_response_libraries))
 - `conditional_group_activation` (Block List, Max: 1) The Conditional Group Activation settings for the queue. (see [below for nested schema](#nestedblock--conditional_group_activation))
 - `conditional_group_routing_rules` (Block List, Max: 5) The Conditional Group Routing settings for the queue. **Important:** conditional_group_routing_rules is deprecated in genesyscloud_routing_queue. CGR is now a standalone resource, please set ENABLE_STANDALONE_CGR in your environment variables to enable and use genesyscloud_routing_queue_conditional_group_routing. When ENABLE_STANDALONE_CGR is set, this attribute will not be read or exported. The two approaches are mutually exclusive to prevent duplicate data during org exports. (see [below for nested schema](#nestedblock--conditional_group_routing_rules))
 - `default_script_ids` (Map of String) The default script IDs for each communication type. Communication types: (CALL | CALLBACK | CHAT | COBROWSE | EMAIL | MESSAGE | SOCIAL_EXPRESSION | VIDEO | SCREENSHARE)
 - `description` (String) Queue description.
-- `direct_routing` (Block List, Max: 1) Used by the System to set Direct Routing settings for a system Direct Routing queue. (see [below for nested schema](#nestedblock--direct_routing))
+- `direct_routing` (Block List, Max: 1) The Direct Routing settings for the queue. (see [below for nested schema](#nestedblock--direct_routing))
 - `division_id` (String) The division to which this queue will belong. If not set, the home division will be used.
 - `email_in_queue_flow_id` (String) The in-queue flow ID to use for email conversations waiting in queue.
 - `enable_audio_monitoring` (Boolean) Indicates whether audio monitoring is enabled for this queue.
@@ -428,9 +433,9 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 Optional:
 
-- `enable_agent_owned_callbacks` (Boolean) Enable Agent Owned Callbacks
-- `max_owned_callback_delay_hours` (Number) Max Owned Call Back Delay Hours >= 7
-- `max_owned_callback_hours` (Number) Auto End Delay Seconds Must be >= 7
+- `enable_agent_owned_callbacks` (Boolean) Indicates if Agent Owned Callbacks are enabled for the queue.
+- `max_owned_callback_delay_hours` (Number) The max amount of time a callback can be scheduled out into the future (in hours). Allowable range 1 - 720 hour(s) (inclusive).
+- `max_owned_callback_hours` (Number) The max amount of time a callback can be owned (in hours). Allowable range 1 - 168 hour(s) (inclusive).
 
 
 <a id="nestedblock--bullseye_rings"></a>
@@ -578,12 +583,12 @@ Required:
 
 Optional:
 
-- `agent_wait_seconds` (Number) The queue default time a Direct Routing interaction will wait for an agent before it goes to configured backup. Defaults to `60`.
-- `backup_queue_id` (String) Direct Routing default backup queue id (if none supplied this queue will be used as backup).
+- `agent_wait_seconds` (Number) Time (in seconds) that a Direct Routing interaction will wait for Direct Routing agent before going to selected backup. Valid range [60, 864000]. Defaults to `60`.
+- `backup_queue_id` (String) ID of another queue to be used as the default backup if an agent does not have their Backup Settings configured. If not set, the current queue will be used as backup, but with Direct Routing criteria removed from the conversation.
 - `call_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for calls. Defaults to `true`.
 - `email_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for emails. Defaults to `true`.
 - `message_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for messages. Defaults to `true`.
-- `wait_for_agent` (Boolean) Boolean indicating if Direct Routing interactions should wait for the targeted agent by default. Defaults to `false`.
+- `wait_for_agent` (Boolean) Flag indicating if Direct Routing interactions should wait for Direct Routing agent or go immediately to selected backup. Defaults to `false`.
 
 
 <a id="nestedblock--media_settings_call"></a>
@@ -592,19 +597,11 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_call--sub_type_settings))
-
-<a id="nestedblock--media_settings_call--sub_type_settings"></a>
-### Nested Schema for `media_settings_call.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_callback"></a>
@@ -616,11 +613,11 @@ Optional:
 - `answering_machine_flow_id` (String) The inbound flow to transfer to if an answering machine is detected during the outbound call of a customer first callback when answeringMachineReactionType is set to TransferToFlow.
 - `answering_machine_reaction_type` (String) The action to take if an answering machine is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `auto_dial_delay_seconds` (Number) Auto Dial Delay Seconds.
-- `auto_end_delay_seconds` (Number) Auto End Delay Seconds.
+- `auto_dial_delay_seconds` (Number) Time in seconds after agent connects to callback before outgoing call is auto-dialed. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
+- `auto_end_delay_seconds` (Number) Time in seconds after agent disconnects from the outgoing call before the encasing callback is auto-ended. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
 - `edge_group_id` (String) The identifier of the edge group that will place the calls. Can be set to specify a custom edge group instead of the default one.
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
-- `enable_auto_dial_and_end` (Boolean) Auto Dial and End Defaults to `false`.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `enable_auto_dial_and_end` (Boolean) Flag to enable Auto-Dial and Auto-End automation for callbacks on this queue. Defaults to `false`.
 - `live_voice_flow_id` (String) The inbound flow to transfer to if a live voice is detected during the outbound call of a customer first callback.
 - `live_voice_reaction_type` (String) The action to take if a live voice is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
@@ -631,16 +628,6 @@ Optional:
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
 - `site_id` (String) The identifier of the site to be used for dialing. If omitted, the default telephony site for the organization is used.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_callback--sub_type_settings))
-
-<a id="nestedblock--media_settings_callback--sub_type_settings"></a>
-### Nested Schema for `media_settings_callback.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_chat"></a>
@@ -649,19 +636,11 @@ Required:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_chat--sub_type_settings))
-
-<a id="nestedblock--media_settings_chat--sub_type_settings"></a>
-### Nested Schema for `media_settings_chat.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_email"></a>
@@ -670,19 +649,11 @@ Required:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_email--sub_type_settings))
-
-<a id="nestedblock--media_settings_email--sub_type_settings"></a>
-### Nested Schema for `media_settings_email.sub_type_settings`
-
-Required:
-
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
-
 
 
 <a id="nestedblock--media_settings_message"></a>
@@ -691,12 +662,12 @@ Required:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
-- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. Defaults to `false`.
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
+- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. The API does not enforce this, so its essentially a no-op. You should drive this configuration via the "sub_type_settings" configuration for each media type
 - `inactivity_timeout_settings` (Block List, Max: 1) Inactivity timeout settings for messages. (see [below for nested schema](#nestedblock--media_settings_message--inactivity_timeout_settings))
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
+- `sub_type_settings` (Block List) Map of media subtype to media subtype specific settings. (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
 
 <a id="nestedblock--media_settings_message--inactivity_timeout_settings"></a>
 ### Nested Schema for `media_settings_message.inactivity_timeout_settings`
@@ -717,7 +688,11 @@ Optional:
 Required:
 
 - `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The name of the social media company
+- `media_type` (String) The media subtype key (e.g. webmessaging, instagram, whatsapp).
+
+Optional:
+
+- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for the given subtype.
 
 
 

--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -6,25 +6,20 @@ description: |-
 ---
 # genesyscloud_routing_queue (Resource)
 
-<!-- This document is automatically generated. Do not edit manually. Make changes to the schema, examples, or apis.md files in examples/resources/ and run 'make docs' to regenerate. -->
-
 Genesys Cloud Routing Queue
 
 ## API Usage
-
 The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Client has been granted the necessary scopes and permissions to perform these operations:
 
-* [GET /api/v2/routing/queues](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues)
-* [POST /api/v2/routing/queues](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues)
-* [DELETE /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#delete-api-v2-routing-queues--queueId-)
-* [GET /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId-)
-* [PUT /api/v2/routing/queues/{queueId}](https://developer.genesys.cloud/devapps/api-explorer#put-api-v2-routing-queues--queueId-)
-* [GET /api/v2/routing/queues/{queueId}/members](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId--members)
-* [POST /api/v2/routing/queues/{queueId}/members](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues--queueId--members)
-* [PATCH /api/v2/routing/queues/{queueId}/members/{memberId}](https://developer.genesys.cloud/devapps/api-explorer#patch-api-v2-routing-queues--queueId--members--memberId-)
-* [GET /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-routing-queues--queueId--wrapupcodes)
-* [POST /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-routing-queues--queueId--wrapupcodes)
-* [DELETE /api/v2/routing/queues/{queueId}/wrapupcodes/{codeId}](https://developer.genesys.cloud/devapps/api-explorer#delete-api-v2-routing-queues--queueId--wrapupcodes--codeId-)
+- [POST /api/v2/routing/queues](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues)
+- [GET /api/v2/routing/queues/{queueId}/members](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId--members)
+- [GET /api/v2/routing/queues/{queueId}](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId-)
+- [POST /api/v2/routing/queues/{queueId}/members](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues--queueId--members)
+- [PATCH /api/v2/routing/queues/{queueId}/members/{memberId}](https://developer.mypurecloud.com/api/rest/v2/routing/#patch-api-v2-routing-queues--queueId--members--memberId-)
+- [DELETE /api/v2/routing/queues/{queueId}](https://developer.mypurecloud.com/api/rest/v2/routing/#delete-api-v2-routing-queues--queueId-)
+- [GET /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.mypurecloud.com/api/rest/v2/routing/#get-api-v2-routing-queues--queueId--wrapupcodes)
+- [POST /api/v2/routing/queues/{queueId}/wrapupcodes](https://developer.mypurecloud.com/api/rest/v2/routing/#post-api-v2-routing-queues--queueId--wrapupcodes)
+- [DELETE /api/v2/routing/queues/{queueId}/wrapupcodes/{codeId}](https://developer.mypurecloud.com/api/rest/v2/routing/#delete-api-v2-routing-queues--queueId--wrapupcodes--codeId-)
 
 ## Permissions and Scopes
 
@@ -41,7 +36,6 @@ The following OAuth scopes are required to use this resource:
 
 * `routing`
 * `routing:readonly`
-
 ## Schema Migration: Routing Queue V1 to V2
 
 ### Migration Details
@@ -156,6 +150,7 @@ resource "genesyscloud_routing_queue" "example" {
 #### Action Required
 
 The state will be automatically upgraded when you run terraform init with version 1.60.0 or later of the provider. After this, you will have to update your config to remove these attributes from the `media_settings_call`, `media_settings_email`, `media_settings_chat`, and `media_settings_message` config blocks as they are no longer supported.
+
 
 ## Example Usage
 
@@ -379,19 +374,19 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 ### Optional
 
-- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW (Min: 1 sec, Max: 60 min). Can only be used when ACW is AGENT_REQUESTED, MANDATORY_TIMEOUT or MANDATORY_FORCED_TIMEOUT.
+- `acw_timeout_ms` (Number) The amount of time the agent can stay in ACW. Only set when ACW is MANDATORY_TIMEOUT, MANDATORY_FORCED_TIMEOUT or AGENT_REQUESTED.
 - `acw_wrapup_prompt` (String) This field controls how the UI prompts the agent for a wrapup (MANDATORY | OPTIONAL | MANDATORY_TIMEOUT | MANDATORY_FORCED_TIMEOUT | AGENT_REQUESTED). Defaults to `MANDATORY_TIMEOUT`.
-- `agent_owned_routing` (Block List, Max: 1) The Agent Owned Routing settings for the queue. (see [below for nested schema](#nestedblock--agent_owned_routing))
+- `agent_owned_routing` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--agent_owned_routing))
 - `auto_answer_only` (Boolean) Specifies whether the configured whisper should play for all ACD calls, or only for those which are auto-answered. Defaults to `true`.
 - `bullseye_rings` (Block List, Max: 6) The bullseye ring settings for the queue. (see [below for nested schema](#nestedblock--bullseye_rings))
 - `calling_party_name` (String) The name to use for caller identification for outbound calls from this queue.
 - `calling_party_number` (String) The phone number to use for caller identification for outbound calls from this queue.
-- `canned_response_libraries` (Block List, Max: 1) Canned response library IDs and mode with which they are associated with the queue. (see [below for nested schema](#nestedblock--canned_response_libraries))
+- `canned_response_libraries` (Block List, Max: 1) Agent Owned Routing. (see [below for nested schema](#nestedblock--canned_response_libraries))
 - `conditional_group_activation` (Block List, Max: 1) The Conditional Group Activation settings for the queue. (see [below for nested schema](#nestedblock--conditional_group_activation))
 - `conditional_group_routing_rules` (Block List, Max: 5) The Conditional Group Routing settings for the queue. **Important:** conditional_group_routing_rules is deprecated in genesyscloud_routing_queue. CGR is now a standalone resource, please set ENABLE_STANDALONE_CGR in your environment variables to enable and use genesyscloud_routing_queue_conditional_group_routing. When ENABLE_STANDALONE_CGR is set, this attribute will not be read or exported. The two approaches are mutually exclusive to prevent duplicate data during org exports. (see [below for nested schema](#nestedblock--conditional_group_routing_rules))
 - `default_script_ids` (Map of String) The default script IDs for each communication type. Communication types: (CALL | CALLBACK | CHAT | COBROWSE | EMAIL | MESSAGE | SOCIAL_EXPRESSION | VIDEO | SCREENSHARE)
 - `description` (String) Queue description.
-- `direct_routing` (Block List, Max: 1) The Direct Routing settings for the queue. (see [below for nested schema](#nestedblock--direct_routing))
+- `direct_routing` (Block List, Max: 1) Used by the System to set Direct Routing settings for a system Direct Routing queue. (see [below for nested schema](#nestedblock--direct_routing))
 - `division_id` (String) The division to which this queue will belong. If not set, the home division will be used.
 - `email_in_queue_flow_id` (String) The in-queue flow ID to use for email conversations waiting in queue.
 - `enable_audio_monitoring` (Boolean) Indicates whether audio monitoring is enabled for this queue.
@@ -433,9 +428,9 @@ resource "genesyscloud_routing_queue" "example_queue_with_conditional_group_acti
 
 Optional:
 
-- `enable_agent_owned_callbacks` (Boolean) Indicates if Agent Owned Callbacks are enabled for the queue.
-- `max_owned_callback_delay_hours` (Number) The max amount of time a callback can be scheduled out into the future (in hours). Allowable range 1 - 720 hour(s) (inclusive).
-- `max_owned_callback_hours` (Number) The max amount of time a callback can be owned (in hours). Allowable range 1 - 168 hour(s) (inclusive).
+- `enable_agent_owned_callbacks` (Boolean) Enable Agent Owned Callbacks
+- `max_owned_callback_delay_hours` (Number) Max Owned Call Back Delay Hours >= 7
+- `max_owned_callback_hours` (Number) Auto End Delay Seconds Must be >= 7
 
 
 <a id="nestedblock--bullseye_rings"></a>
@@ -583,12 +578,12 @@ Required:
 
 Optional:
 
-- `agent_wait_seconds` (Number) Time (in seconds) that a Direct Routing interaction will wait for Direct Routing agent before going to selected backup. Valid range [60, 864000]. Defaults to `60`.
-- `backup_queue_id` (String) ID of another queue to be used as the default backup if an agent does not have their Backup Settings configured. If not set, the current queue will be used as backup, but with Direct Routing criteria removed from the conversation.
+- `agent_wait_seconds` (Number) The queue default time a Direct Routing interaction will wait for an agent before it goes to configured backup. Defaults to `60`.
+- `backup_queue_id` (String) Direct Routing default backup queue id (if none supplied this queue will be used as backup).
 - `call_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for calls. Defaults to `true`.
 - `email_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for emails. Defaults to `true`.
 - `message_use_agent_address_outbound` (Boolean) Boolean indicating if user Direct Routing addresses should be used outbound on behalf of queue in place of Queue address for messages. Defaults to `true`.
-- `wait_for_agent` (Boolean) Flag indicating if Direct Routing interactions should wait for Direct Routing agent or go immediately to selected backup. Defaults to `false`.
+- `wait_for_agent` (Boolean) Boolean indicating if Direct Routing interactions should wait for the targeted agent by default. Defaults to `false`.
 
 
 <a id="nestedblock--media_settings_call"></a>
@@ -597,11 +592,19 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_call--sub_type_settings))
+
+<a id="nestedblock--media_settings_call--sub_type_settings"></a>
+### Nested Schema for `media_settings_call.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_callback"></a>
@@ -613,10 +616,11 @@ Optional:
 - `answering_machine_flow_id` (String) The inbound flow to transfer to if an answering machine is detected during the outbound call of a customer first callback when answeringMachineReactionType is set to TransferToFlow.
 - `answering_machine_reaction_type` (String) The action to take if an answering machine is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `auto_dial_delay_seconds` (Number) Time in seconds after agent connects to callback before outgoing call is auto-dialed. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
-- `auto_end_delay_seconds` (Number) Time in seconds after agent disconnects from the outgoing call before the encasing callback is auto-ended. Allowable values in range 0 - 1200 seconds. Defaults to 300 seconds.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `enable_auto_dial_and_end` (Boolean) Flag to enable Auto-Dial and Auto-End automation for callbacks on this queue. Defaults to `false`.
+- `auto_dial_delay_seconds` (Number) Auto Dial Delay Seconds.
+- `auto_end_delay_seconds` (Number) Auto End Delay Seconds.
+- `edge_group_id` (String) The identifier of the edge group that will place the calls. Can be set to specify a custom edge group instead of the default one.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `enable_auto_dial_and_end` (Boolean) Auto Dial and End Defaults to `false`.
 - `live_voice_flow_id` (String) The inbound flow to transfer to if a live voice is detected during the outbound call of a customer first callback.
 - `live_voice_reaction_type` (String) The action to take if a live voice is detected during the outbound call of a customer first callback. Valid values include: HangUp, TransferToQueue, TransferToFlow
 - `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
@@ -626,7 +630,17 @@ Optional:
 - `retry_delay_seconds` (Number) Delay in seconds between each retry of a customer first callback.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `site_id` (String) The identifier of the site to be used for dialing; can be set in place of an edge group.
+- `site_id` (String) The identifier of the site to be used for dialing. If omitted, the default telephony site for the organization is used.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_callback--sub_type_settings))
+
+<a id="nestedblock--media_settings_callback--sub_type_settings"></a>
+### Nested Schema for `media_settings_callback.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_chat"></a>
@@ -635,11 +649,19 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_chat--sub_type_settings))
+
+<a id="nestedblock--media_settings_chat--sub_type_settings"></a>
+### Nested Schema for `media_settings_chat.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_email"></a>
@@ -648,11 +670,19 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `auto_answer_alert_tone_seconds` (Number) How long to play the alerting tone for an auto-answer interaction.
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `manual_answer_alert_tone_seconds` (Number) How long to play the alerting tone for a manual-answer interaction.
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_email--sub_type_settings))
+
+<a id="nestedblock--media_settings_email--sub_type_settings"></a>
+### Nested Schema for `media_settings_email.sub_type_settings`
+
+Required:
+
+- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
+- `media_type` (String) The name of the social media company
+
 
 
 <a id="nestedblock--media_settings_message"></a>
@@ -661,12 +691,12 @@ Optional:
 Optional:
 
 - `alerting_timeout_sec` (Number) Alerting timeout in seconds. Must be >= 7
-- `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings. Defaults to `false`.
-- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. The API does not enforce this, so its essentially a no-op. You should drive this configuration via the "sub_type_settings" configuration for each media type
+- `enable_auto_answer` (Boolean) Auto-Answer for digital channels(Email, Message) Defaults to `false`.
+- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for all subtypes. Defaults to `false`.
 - `inactivity_timeout_settings` (Block List, Max: 1) Inactivity timeout settings for messages. (see [below for nested schema](#nestedblock--media_settings_message--inactivity_timeout_settings))
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
-- `sub_type_settings` (Block List) Map of media subtype to media subtype specific settings. (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
+- `sub_type_settings` (Block List) Auto-Answer for digital channels(Email, Message) (see [below for nested schema](#nestedblock--media_settings_message--sub_type_settings))
 
 <a id="nestedblock--media_settings_message--inactivity_timeout_settings"></a>
 ### Nested Schema for `media_settings_message.inactivity_timeout_settings`
@@ -687,11 +717,7 @@ Optional:
 Required:
 
 - `enable_auto_answer` (Boolean) Indicates if auto-answer is enabled for the given media type or subtype (default is false). Subtype settings take precedence over media type settings.
-- `media_type` (String) The media subtype key (e.g. webmessaging, instagram, whatsapp).
-
-Optional:
-
-- `enable_inactivity_timeout` (Boolean) Indicates if inactivity timeout is enabled for the given subtype.
+- `media_type` (String) The name of the social media company
 
 
 

--- a/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
+++ b/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
@@ -28,7 +28,7 @@ func runDataJourneyActionMapTestCase(t *testing.T, testCaseName string) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
-		Steps: generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
+		Steps:             generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
 	})
 }
 

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -321,10 +321,10 @@ func TestAccResourceRoutingEmailRouteSignature(t *testing.T) {
 		resp1ResourceLabel,
 		resp1Name,
 		[]string{"genesyscloud_responsemanagement_library." + libResourceLabel + ".id"},
-		util.NullValue,        // interaction_type
-		util.NullValue,        // substitutions_schema_id
-		`"Footer"`,            // response_type
-		[]string{},            // asset_ids
+		util.NullValue, // interaction_type
+		util.NullValue, // substitutions_schema_id
+		`"Footer"`,     // response_type
+		[]string{},     // asset_ids
 		responsemanagementResponse.GenerateTextsBlock("Email signature one", "text/plain", util.NullValue),
 		`footer { type = "Signature" }`,
 	)

--- a/genesyscloud/routing_queue/genesyscloud_routing_queue_init_test.go
+++ b/genesyscloud/routing_queue/genesyscloud_routing_queue_init_test.go
@@ -10,6 +10,8 @@ import (
 	routingSkill "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_skill"
 	routingSkillGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_skill_group"
 	routingWrapupcode "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_wrapupcode"
+	edgeGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_edge_group"
+	tbs "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_trunkbasesettings"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"
 	"sync"
 	"testing"
@@ -48,6 +50,8 @@ func (r *registerTestInstance) registerTestResources() {
 	providerResources[architect_user_prompt.ResourceType] = architect_user_prompt.ResourceArchitectUserPrompt()
 	providerResources[authDivision.ResourceType] = authDivision.ResourceAuthDivision()
 	providerResources[responseManagementLibrary.ResourceType] = responseManagementLibrary.ResourceResponsemanagementLibrary()
+	providerResources[edgeGroup.ResourceType] = edgeGroup.ResourceEdgeGroup()
+	providerResources[tbs.ResourceType] = tbs.ResourceTrunkBaseSettings()
 }
 
 // registerTestDataSources registers all data sources used in the tests.

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -22,6 +22,8 @@ import (
 	routingWrapupcode "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_wrapupcode"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/scripts"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/team"
+	edgeGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_edge_group"
+	edgeSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"
 )
 
@@ -266,6 +268,16 @@ var (
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(60, 86400),
+			},
+			"edge_group_id": {
+				Description: "The identifier of the edge group that will place the calls. Can be set to specify a custom edge group instead of the default one.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"site_id": {
+				Description: "The identifier of the site to be used for dialing. If omitted, the default telephony site for the organization is used.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 		},
 	}
@@ -880,6 +892,8 @@ func RoutingQueueExporter() *resourceExporter.ResourceExporter {
 			"media_settings_callback.live_voice_flow_id":        {RefType: architectFlow.ResourceType},
 			"media_settings_callback.answering_machine_flow_id": {RefType: architectFlow.ResourceType},
 			"media_settings_message.inactivity_timeout_settings.flow_id":                {RefType: architectFlow.ResourceType},
+			"media_settings_callback.edge_group_id":                                      {RefType: edgeGroup.ResourceType},
+			"media_settings_callback.site_id":                                            {RefType: edgeSite.ResourceType},
 			"conditional_group_activation.pilot_rule.conditions.simple_metric.queue_id": {RefType: ResourceType},
 			"conditional_group_activation.rules.conditions.simple_metric.queue_id":      {RefType: ResourceType},
 		},

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/scripts"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/team"
 	telephonyProvidersEdgesSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
+	edgeGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_edge_group"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"
 )
 
@@ -268,8 +269,13 @@ var (
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(60, 86400),
 			},
+			"edge_group_id": {
+				Description: "The identifier of the edge group that will place the calls. Can be set to specify a custom edge group instead of the default one.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
 			"site_id": {
-				Description: "The identifier of the site to be used for dialing; can be set in place of an edge group.",
+				Description: "The identifier of the site to be used for dialing. If omitted, the default telephony site for the organization is used.",
 				Type:        schema.TypeString,
 				Optional:    true,
 			},
@@ -886,6 +892,7 @@ func RoutingQueueExporter() *resourceExporter.ResourceExporter {
 			"media_settings_callback.live_voice_flow_id":        {RefType: architectFlow.ResourceType},
 			"media_settings_callback.answering_machine_flow_id": {RefType: architectFlow.ResourceType},
 			"media_settings_callback.site_id":                   {RefType: telephonyProvidersEdgesSite.ResourceType},
+			"media_settings_callback.edge_group_id":              {RefType: edgeGroup.ResourceType},
 			"media_settings_message.inactivity_timeout_settings.flow_id":                {RefType: architectFlow.ResourceType},
 			"conditional_group_activation.pilot_rule.conditions.simple_metric.queue_id": {RefType: ResourceType},
 			"conditional_group_activation.rules.conditions.simple_metric.queue_id":      {RefType: ResourceType},

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -22,8 +22,8 @@ import (
 	routingWrapupcode "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_wrapupcode"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/scripts"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/team"
-	telephonyProvidersEdgesSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	edgeGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_edge_group"
+	telephonyProvidersEdgesSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"
 )
 
@@ -892,7 +892,7 @@ func RoutingQueueExporter() *resourceExporter.ResourceExporter {
 			"media_settings_callback.live_voice_flow_id":        {RefType: architectFlow.ResourceType},
 			"media_settings_callback.answering_machine_flow_id": {RefType: architectFlow.ResourceType},
 			"media_settings_callback.site_id":                   {RefType: telephonyProvidersEdgesSite.ResourceType},
-			"media_settings_callback.edge_group_id":              {RefType: edgeGroup.ResourceType},
+			"media_settings_callback.edge_group_id":             {RefType: edgeGroup.ResourceType},
 			"media_settings_message.inactivity_timeout_settings.flow_id":                {RefType: architectFlow.ResourceType},
 			"conditional_group_activation.pilot_rule.conditions.simple_metric.queue_id": {RefType: ResourceType},
 			"conditional_group_activation.rules.conditions.simple_metric.queue_id":      {RefType: ResourceType},

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
@@ -1398,6 +1398,80 @@ func TestAccResourceRoutingQueueCallbackCustomerFirst(t *testing.T) {
 	})
 }
 
+func TestAccResourceRoutingQueueCallbackSiteId(t *testing.T) {
+	var (
+		queueResourceLabel = "test-queue-callback-site"
+		queueName          = "Terraform Test Queue Callback Site-" + uuid.NewString()
+		alertTimeout       = "7"
+		slPercent          = "0.5"
+		slDuration         = "1000"
+		callbackMode       = "CustomerFirst"
+	)
+
+	// Get managed site ID - skip test if no site available
+	siteID, err := getManagedSiteId()
+	if err != nil {
+		t.Skipf("Skipping test: could not find a managed site: %v", err)
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Create with site_id
+				Config: GenerateRoutingQueueResourceBasic(
+					queueResourceLabel,
+					queueName,
+					GenerateMediaSettingsCallBack(
+						"media_settings_callback",
+						alertTimeout,
+						util.FalseValue,
+						slPercent,
+						slDuration,
+						util.FalseValue,
+						"0",
+						"0",
+						"mode = "+strconv.Quote(callbackMode),
+						"live_voice_reaction_type = "+strconv.Quote("TransferToQueue"),
+						"answering_machine_reaction_type = "+strconv.Quote("HangUp"),
+						"site_id = "+strconv.Quote(siteID),
+					),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_queue."+queueResourceLabel, "name", queueName),
+					resource.TestCheckResourceAttr("genesyscloud_routing_queue."+queueResourceLabel, "media_settings_callback.0.mode", callbackMode),
+					resource.TestCheckResourceAttr("genesyscloud_routing_queue."+queueResourceLabel, "media_settings_callback.0.site_id", siteID),
+				),
+			},
+			{
+				// Import/Read
+				ResourceName:      "genesyscloud_routing_queue." + queueResourceLabel,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+		CheckDestroy: testVerifyQueuesDestroyed,
+	})
+}
+
+// getManagedSiteId returns the ID of a managed site (e.g., "PureCloud Voice - AWS")
+func getManagedSiteId() (string, error) {
+	sdkConfig, err := provider.AuthorizeSdk()
+	if err != nil {
+		return "", fmt.Errorf("error authorizing SDK: %v", err)
+	}
+	api := platformclientv2.NewTelephonyProvidersEdgeApiWithConfig(sdkConfig)
+	data, _, err := api.GetTelephonyProvidersEdgesSites(1, 1, "", "", "PureCloud Voice - AWS", "", true, nil)
+	if err != nil {
+		return "", fmt.Errorf("error querying sites: %v", err)
+	}
+	if data.Entities == nil || len(*data.Entities) == 0 {
+		return "", fmt.Errorf("no managed site found")
+	}
+	return *(*data.Entities)[0].Id, nil
+}
+
 func TestAccResourceRoutingQueueCannedResponseLibraryIds(t *testing.T) {
 	t.Parallel()
 	var (

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
@@ -21,6 +21,8 @@ import (
 	routingSkill "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_skill"
 	routingSkillGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_skill_group"
 	routingWrapupcode "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_wrapupcode"
+	edgeGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_edge_group"
+	tbs "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_trunkbasesettings"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	featureToggles "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
@@ -1398,29 +1400,86 @@ func TestAccResourceRoutingQueueCallbackCustomerFirst(t *testing.T) {
 	})
 }
 
-func TestAccResourceRoutingQueueCallbackSiteId(t *testing.T) {
+func TestAccResourceRoutingQueueCallbackEdgeGroupAndSite(t *testing.T) {
+	t.Parallel()
 	var (
-		queueResourceLabel = "test-queue-callback-site"
-		queueName          = "Terraform Test Queue Callback Site-" + uuid.NewString()
+		queueResourceLabel = "test-queue-callback-edgegroup-site"
+		queueName          = "TF Queue EdgeGroup Site " + uuid.NewString()
 		alertTimeout       = "7"
 		slPercent          = "0.5"
 		slDuration         = "1000"
 		callbackMode       = "CustomerFirst"
+
+		// Edge group prerequisites
+		trunkBaseResourceLabel = "trunk_base_for_eg"
+		trunkBaseName          = "TF Trunk Base " + uuid.NewString()
+		edgeGroupResourceLabel = "edge_group_for_queue"
+		edgeGroupName          = "TF Edge Group " + uuid.NewString()
 	)
 
-	// Get managed site ID - skip test if no site available
+	// Look up any managed site (no hardcoded name — works in all regions)
 	siteID, err := getManagedSiteId()
 	if err != nil {
 		t.Skipf("Skipping test: could not find a managed site: %v", err)
 	}
+
+	// Trunk base settings (required dependency for edge group)
+	trunkBaseConfig := tbs.GenerateTrunkBaseSettingsResourceWithCustomAttrs(
+		trunkBaseResourceLabel,
+		trunkBaseName,
+		"",
+		"phone_connections_webrtc.json",
+		"PHONE",
+		false,
+	)
+
+	// Edge group resource
+	edgeGroupConfig := edgeGroup.GenerateEdgeGroupResourceWithCustomAttrs(
+		edgeGroupResourceLabel,
+		edgeGroupName,
+		"test edge group for routing queue callback",
+		false,
+		false,
+		edgeGroup.GeneratePhoneTrunkBaseIds("genesyscloud_telephony_providers_edges_trunkbasesettings."+trunkBaseResourceLabel+".id"),
+	)
+
+	edgeGroupRef := "genesyscloud_telephony_providers_edges_edge_group." + edgeGroupResourceLabel + ".id"
+	queuePath := "genesyscloud_routing_queue." + queueResourceLabel
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
 		Steps: []resource.TestStep{
 			{
-				// Create with site_id
-				Config: GenerateRoutingQueueResourceBasic(
+				// Step 1: Create with edge_group_id
+				Config: trunkBaseConfig + edgeGroupConfig + GenerateRoutingQueueResourceBasic(
+					queueResourceLabel,
+					queueName,
+					GenerateMediaSettingsCallBack(
+						"media_settings_callback",
+						alertTimeout,
+						util.FalseValue,
+						slPercent,
+						slDuration,
+						util.FalseValue,
+						"0",
+						"0",
+						"mode = "+strconv.Quote(callbackMode),
+						"live_voice_reaction_type = "+strconv.Quote("TransferToQueue"),
+						"answering_machine_reaction_type = "+strconv.Quote("HangUp"),
+						"edge_group_id = "+edgeGroupRef,
+					),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(queuePath, "name", queueName),
+					resource.TestCheckResourceAttr(queuePath, "media_settings_callback.0.mode", callbackMode),
+					resource.TestCheckResourceAttrPair(queuePath, "media_settings_callback.0.edge_group_id",
+						"genesyscloud_telephony_providers_edges_edge_group."+edgeGroupResourceLabel, "id"),
+				),
+			},
+			{
+				// Step 2: Update — switch from edge_group_id to site_id
+				Config: trunkBaseConfig + edgeGroupConfig + GenerateRoutingQueueResourceBasic(
 					queueResourceLabel,
 					queueName,
 					GenerateMediaSettingsCallBack(
@@ -1439,14 +1498,15 @@ func TestAccResourceRoutingQueueCallbackSiteId(t *testing.T) {
 					),
 				),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("genesyscloud_routing_queue."+queueResourceLabel, "name", queueName),
-					resource.TestCheckResourceAttr("genesyscloud_routing_queue."+queueResourceLabel, "media_settings_callback.0.mode", callbackMode),
-					resource.TestCheckResourceAttr("genesyscloud_routing_queue."+queueResourceLabel, "media_settings_callback.0.site_id", siteID),
+					resource.TestCheckResourceAttr(queuePath, "name", queueName),
+					resource.TestCheckResourceAttr(queuePath, "media_settings_callback.0.mode", callbackMode),
+					resource.TestCheckResourceAttr(queuePath, "media_settings_callback.0.site_id", siteID),
+					resource.TestCheckResourceAttr(queuePath, "media_settings_callback.0.edge_group_id", ""),
 				),
 			},
 			{
-				// Import/Read
-				ResourceName:      "genesyscloud_routing_queue." + queueResourceLabel,
+				// Step 3: Import/Read
+				ResourceName:      queuePath,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -1455,19 +1515,20 @@ func TestAccResourceRoutingQueueCallbackSiteId(t *testing.T) {
 	})
 }
 
-// getManagedSiteId returns the ID of a managed site (e.g., "PureCloud Voice - AWS")
+// getManagedSiteId returns the ID of any managed site in the org.
+// Does not hardcode a site name — works across all regions and CI environments.
 func getManagedSiteId() (string, error) {
 	sdkConfig, err := provider.AuthorizeSdk()
 	if err != nil {
 		return "", fmt.Errorf("error authorizing SDK: %v", err)
 	}
 	api := platformclientv2.NewTelephonyProvidersEdgeApiWithConfig(sdkConfig)
-	data, _, err := api.GetTelephonyProvidersEdgesSites(1, 1, "", "", "PureCloud Voice - AWS", "", true, nil)
+	data, _, err := api.GetTelephonyProvidersEdgesSites(1, 1, "", "", "", "", true, nil)
 	if err != nil {
-		return "", fmt.Errorf("error querying sites: %v", err)
+		return "", fmt.Errorf("error querying managed sites: %v", err)
 	}
 	if data.Entities == nil || len(*data.Entities) == 0 {
-		return "", fmt.Errorf("no managed site found")
+		return "", fmt.Errorf("no managed site found in this org")
 	}
 	return *(*data.Entities)[0].Id, nil
 }

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
@@ -384,6 +384,8 @@ func TestUnitBuildSdkMediaSettingCallback(t *testing.T) {
 					"live_voice_flow_id":               "123",
 					"answering_machine_reaction_type":  "Transfer",
 					"answering_machine_flow_id":        "321",
+					"edge_group_id":                    "edge-group-123",
+					"site_id":                          "site-456",
 				},
 			},
 			expected: &platformclientv2.Callbackmediasettings{
@@ -401,6 +403,8 @@ func TestUnitBuildSdkMediaSettingCallback(t *testing.T) {
 				LiveVoiceFlow:                &platformclientv2.Domainentityref{Id: platformclientv2.String("123")},
 				AnsweringMachineReactionType: platformclientv2.String("Transfer"),
 				AnsweringMachineFlow:         &platformclientv2.Domainentityref{Id: platformclientv2.String("321")},
+				EdgeGroup:                    &platformclientv2.Domainentityref{Id: platformclientv2.String("edge-group-123")},
+				Site:                         &platformclientv2.Domainentityref{Id: platformclientv2.String("site-456")},
 			},
 		},
 		{
@@ -422,6 +426,8 @@ func TestUnitBuildSdkMediaSettingCallback(t *testing.T) {
 					"live_voice_flow_id":               "",
 					"answering_machine_reaction_type":  "",
 					"answering_machine_flow_id":        "",
+					"edge_group_id":                    "",
+					"site_id":                          "",
 				},
 			},
 			expected: &platformclientv2.Callbackmediasettings{
@@ -439,6 +445,8 @@ func TestUnitBuildSdkMediaSettingCallback(t *testing.T) {
 				LiveVoiceFlow:                nil,
 				AnsweringMachineReactionType: nil,
 				AnsweringMachineFlow:         nil,
+				EdgeGroup:                    nil,
+				Site:                         nil,
 			},
 		},
 		{
@@ -461,6 +469,8 @@ func TestUnitBuildSdkMediaSettingCallback(t *testing.T) {
 				LiveVoiceFlow:                nil,
 				AnsweringMachineReactionType: nil,
 				AnsweringMachineFlow:         nil,
+				EdgeGroup:                    nil,
+				Site:                         nil,
 			},
 		},
 	}

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -291,6 +291,8 @@ func buildSdkMediaSettingCallback(settings []interface{}) *platformclientv2.Call
 	callbackSettings.AnsweringMachineFlow = util.GetNillableDomainEntityRefFromMap(settingsMap, "answering_machine_flow_id")
 	callbackSettings.MaxRetryCount = resourcedata.GetNillableValueFromMap[int](settingsMap, "max_retry_count", false)
 	callbackSettings.RetryDelaySeconds = resourcedata.GetNillableValueFromMap[int](settingsMap, "retry_delay_seconds", false)
+	callbackSettings.EdgeGroup = util.GetNillableDomainEntityRefFromMap(settingsMap, "edge_group_id")
+	callbackSettings.Site = util.GetNillableDomainEntityRefFromMap(settingsMap, "site_id")
 
 	return &callbackSettings
 }
@@ -864,6 +866,8 @@ func flattenMediaSettingCallback(settings *platformclientv2.Callbackmediasetting
 	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "answering_machine_flow_id", settings.AnsweringMachineFlow)
 	resourcedata.SetMapValueIfNotNil(settingsMap, "max_retry_count", settings.MaxRetryCount)
 	resourcedata.SetMapValueIfNotNil(settingsMap, "retry_delay_seconds", settings.RetryDelaySeconds)
+	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "edge_group_id", settings.EdgeGroup)
+	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "site_id", settings.Site)
 
 	return []interface{}{settingsMap}
 }

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -291,6 +291,7 @@ func buildSdkMediaSettingCallback(settings []interface{}) *platformclientv2.Call
 	callbackSettings.AnsweringMachineFlow = util.GetNillableDomainEntityRefFromMap(settingsMap, "answering_machine_flow_id")
 	callbackSettings.MaxRetryCount = resourcedata.GetNillableValueFromMap[int](settingsMap, "max_retry_count", false)
 	callbackSettings.RetryDelaySeconds = resourcedata.GetNillableValueFromMap[int](settingsMap, "retry_delay_seconds", false)
+	callbackSettings.EdgeGroup = util.GetNillableDomainEntityRefFromMap(settingsMap, "edge_group_id")
 	callbackSettings.Site = util.GetNillableDomainEntityRefFromMap(settingsMap, "site_id")
 
 	return &callbackSettings
@@ -865,6 +866,7 @@ func flattenMediaSettingCallback(settings *platformclientv2.Callbackmediasetting
 	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "answering_machine_flow_id", settings.AnsweringMachineFlow)
 	resourcedata.SetMapValueIfNotNil(settingsMap, "max_retry_count", settings.MaxRetryCount)
 	resourcedata.SetMapValueIfNotNil(settingsMap, "retry_delay_seconds", settings.RetryDelaySeconds)
+	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "edge_group_id", settings.EdgeGroup)
 	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "site_id", settings.Site)
 
 	return []interface{}{settingsMap}


### PR DESCRIPTION
Adds `edge_group_id` and `site_id` optional fields to the `media_settings_callback` block
in `genesyscloud_routing_queue` resource.

These fields allow configuring custom outbound dialing routes for customer-first callbacks
on a per-queue basis.

## Changes

- **Schema:** added `edge_group_id` (TypeString, Optional) and `site_id` (TypeString, Optional)
- **Build/Flatten:** using existing `GetNillableDomainEntityRefFromMap` / `SetMapReferenceValueIfNotNil` patterns
- **Exporter:** added resource reference mappings for edge_group and site resources
- **Unit test:** extended `TestUnitBuildSdkMediaSettingCallback` with edge_group_id and site_id coverage
- **Acceptance test:** `TestAccResourceRoutingQueueCallbackEdgeGroupAndSite` — creates edge group, looks up a managed site, tests edge_group_id on create, switches to site_id on update, verifies import
- **Docs:** auto-generated via tfplugindocs
