### PR TITLE
OBR-1026: Add preview_auto_end field to outbound_campaign resource

### DIFF
--- a/docs/resources/outbound_campaign.md
+++ b/docs/resources/outbound_campaign.md
@@ -131,6 +131,7 @@ resource "genesyscloud_outbound_campaign" "campaign2" {
 - `max_calls_per_agent` (Number) The maximum number of calls that can be placed per agent on this campaign. Must be >= 1. Supports decimal values (e.g., 1.5, 2.3).
 - `no_answer_timeout` (Number) How long to wait before dispositioning a call as 'no-answer'. Default 30 seconds. Only applicable to non-preview campaigns.
 - `outbound_line_count` (Number) The number of outbound lines to be concurrently dialed. Only applicable to non-preview campaigns; only required for agentless.
+- `preview_auto_end` (Boolean) When enabled, the preview will automatically end and the call will be placed after the preview timeout (preview_time_out_seconds). Only applicable to preview campaigns. Defaults to `false`.
 - `preview_time_out_seconds` (Number) The number of seconds before a call will be automatically placed on a preview. A value of 0 indicates no automatic placement of calls. Only applicable to preview campaigns.
 - `priority` (Number) The priority of this campaign relative to other campaigns that are running on the same queue. 5 is the highest priority, 1 the lowest.
 - `queue_id` (String) The Queue for this Campaign to route calls to. Required for all dialing modes except agentless.

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
@@ -148,6 +148,7 @@ func readOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta inte
 		}
 		resourcedata.SetNillableValue(d, "skip_preview_disabled", campaign.SkipPreviewDisabled)
 		resourcedata.SetNillableValue(d, "preview_time_out_seconds", campaign.PreviewTimeOutSeconds)
+		resourcedata.SetNillableValue(d, "preview_auto_end", campaign.PreviewAutoEnd)
 		resourcedata.SetNillableValue(d, "always_running", campaign.AlwaysRunning)
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "contact_sorts", campaign.ContactSorts, flattenContactSorts)
 		resourcedata.SetNillableValue(d, "no_answer_timeout", campaign.NoAnswerTimeout)

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_schema.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_schema.go
@@ -210,6 +210,12 @@ func ResourceOutboundCampaign() *schema.Resource {
 				Optional:    true,
 				Type:        schema.TypeInt,
 			},
+			`preview_auto_end`: {
+				Description: `When enabled, the preview will automatically end and the call will be placed after the preview timeout (preview_time_out_seconds). Only applicable to preview campaigns.`,
+				Optional:    true,
+				Default:     false,
+				Type:        schema.TypeBool,
+			},
 			`always_running`: {
 				Description: `Indicates (when true) that the campaign will remain on after contacts are depleted, allowing additional contacts to be appended/added to the contact list and processed by the still-running campaign. The campaign can still be turned off manually.`,
 				Optional:    true,

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_test.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_test.go
@@ -1363,6 +1363,174 @@ func TestAccResourceOutboundCampaignPredictiveDiagnosticsSettings(t *testing.T) 
 	})
 }
 
+func TestAccResourceOutboundCampaignPreviewAutoEnd(t *testing.T) {
+	t.Parallel()
+	var (
+		resourceLabel            = "campaign_preview_auto_end"
+		name                     = "TF PreviewAutoEnd " + uuid.NewString()
+		dialingMode              = "preview"
+		callerName               = "Test Name"
+		callerAddress            = "+353371111111"
+		contactListResourceLabel = "contact_list"
+		queueResourceLabel       = "queue"
+
+		resourcePath = ResourceType + "." + resourceLabel
+	)
+
+	scriptId, err := getPublishedScriptId()
+	if err != nil || scriptId == "" {
+		t.Skip("Skipping as a published script ID is needed to run this test")
+	}
+
+	referencedResources := GenerateReferencedResourcesForOutboundCampaignTests(
+		contactListResourceLabel,
+		"",
+		queueResourceLabel,
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+		"",
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: Create preview campaign WITHOUT preview_auto_end (omitted = defaults to false)
+				Config: referencedResources +
+					generateOutboundCampaign(
+						resourceLabel,
+						name,
+						dialingMode,
+						strconv.Quote(callerName),
+						strconv.Quote(callerAddress),
+						"genesyscloud_outbound_contact_list."+contactListResourceLabel+".id",
+						util.NullValue,
+						util.NullValue,
+						strconv.Quote(scriptId),
+						"genesyscloud_routing_queue."+queueResourceLabel+".id",
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						[]string{},
+						[]string{},
+						[]string{},
+						[]string{},
+						util.FalseValue,
+						generatePhoneColumnNoTypeBlock("Cell"),
+					),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "name", name),
+					resource.TestCheckResourceAttr(resourcePath, "dialing_mode", dialingMode),
+					resource.TestCheckResourceAttr(resourcePath, "preview_auto_end", util.FalseValue),
+				),
+			},
+			{
+				// Step 2: Update to enable preview_auto_end with explicit preview_time_out_seconds
+				Config: referencedResources +
+					generateOutboundCampaign(
+						resourceLabel,
+						name,
+						dialingMode,
+						strconv.Quote(callerName),
+						strconv.Quote(callerAddress),
+						"genesyscloud_outbound_contact_list."+contactListResourceLabel+".id",
+						util.NullValue,
+						util.NullValue,
+						strconv.Quote(scriptId),
+						"genesyscloud_routing_queue."+queueResourceLabel+".id",
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						"10",
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						[]string{},
+						[]string{},
+						[]string{},
+						[]string{},
+						util.FalseValue,
+						generatePhoneColumnNoTypeBlock("Cell"),
+						"preview_auto_end = true",
+					),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "name", name),
+					resource.TestCheckResourceAttr(resourcePath, "preview_auto_end", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "preview_time_out_seconds", "10"),
+				),
+			},
+			{
+				// Step 3: Disable preview_auto_end
+				Config: referencedResources +
+					generateOutboundCampaign(
+						resourceLabel,
+						name,
+						dialingMode,
+						strconv.Quote(callerName),
+						strconv.Quote(callerAddress),
+						"genesyscloud_outbound_contact_list."+contactListResourceLabel+".id",
+						util.NullValue,
+						util.NullValue,
+						strconv.Quote(scriptId),
+						"genesyscloud_routing_queue."+queueResourceLabel+".id",
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						util.NullValue,
+						[]string{},
+						[]string{},
+						[]string{},
+						[]string{},
+						util.FalseValue,
+						generatePhoneColumnNoTypeBlock("Cell"),
+						"preview_auto_end = false",
+					),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "name", name),
+					resource.TestCheckResourceAttr(resourcePath, "preview_auto_end", util.FalseValue),
+				),
+			},
+			{
+				// Import/Read
+				ResourceName:      resourcePath,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+		CheckDestroy: testVerifyOutboundCampaignDestroyed,
+	})
+}
+
 // TestAccResourceOutboundCampaignDiagnosticsSettingsInvalidDialingMode tests that diagnostics_settings fails validation for unsupported dialing modes
 func TestAccResourceOutboundCampaignDiagnosticsSettingsInvalidDialingMode(t *testing.T) {
 	t.Parallel()

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_utils.go
@@ -33,6 +33,7 @@ func getOutboundCampaignFromResourceData(d *schema.ResourceData) platformclientv
 	outboundLineCount := d.Get("outbound_line_count").(int)
 	skipPreviewDisabled := d.Get("skip_preview_disabled").(bool)
 	previewTimeOutSeconds := d.Get("preview_time_out_seconds").(int)
+	previewAutoEnd := d.Get("preview_auto_end").(bool)
 	alwaysRunning := d.Get("always_running").(bool)
 	noAnswerTimeout := d.Get("no_answer_timeout").(int)
 	callAnalysisLanguage := d.Get("call_analysis_language").(string)
@@ -58,6 +59,7 @@ func getOutboundCampaignFromResourceData(d *schema.ResourceData) platformclientv
 		CallAnalysisResponseSet:        util.BuildSdkDomainEntityRef(d, "call_analysis_response_set_id"),
 		RuleSets:                       util.BuildSdkDomainEntityRefArr(d, "rule_set_ids"),
 		SkipPreviewDisabled:            &skipPreviewDisabled,
+		PreviewAutoEnd:                 &previewAutoEnd,
 		AlwaysRunning:                  &alwaysRunning,
 		ContactSorts:                   buildContactSorts(d.Get("contact_sorts").([]interface{})),
 		ContactListFilters:             util.BuildSdkDomainEntityRefArr(d, "contact_list_filter_ids"),


### PR DESCRIPTION
Adds `preview_auto_end` optional boolean field to `genesyscloud_outbound_campaign` resource.

When enabled, the preview will automatically end and the call will be placed after the preview timeout. Only applicable to preview campaigns.

## Changes

- **Schema:** added `preview_auto_end` (TypeBool, Optional)
- **Build:** set `PreviewAutoEnd` in campaign struct
- **Read:** flatten with `SetNillableValue`
- **Acceptance test:** `TestAccResourceOutboundCampaignPreviewAutoEnd` — creates preview campaign with preview_auto_end=true, updates to false, verifies import
- **Docs:** auto-generated