### PR TITLE
bug - [RULES-1658] Queues not exported correctly in decision table rows

### DIFF
--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
@@ -1,6 +1,6 @@
 package business_rules_decision_table
 
-// @team: Avengers AI
+// @team: RuleBasedDecisions
 // @chat: #rule-based-decisions
 // @pm: Rob Blane
 // @jira: RULES

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
@@ -461,11 +461,18 @@ func BusinessRulesDecisionTableExporter() *resourceExporter.ResourceExporter {
 		},
 		// Note: To export routing queue resources that are referenced in decision tables,
 		// include "genesyscloud_routing_queue" in the export filter resources.
+		//
+		// IMPORTANT: Resolver paths are matched by exact string against the attribute
+		// path the exporter framework computes while walking the config (see
+		// sanitizeConfigMap / sanitizeConfigArray in genesyscloud/tfexporter). That path
+		// is dot-separated attribute names with no array indices and no wildcards, so a
+		// row literal value is looked up as "rows.inputs.literal.value" — anything with
+		// "*" or numeric segments will silently never match and the resolver will not run.
 		CustomAttributeResolver: map[string]*resourceExporter.RefAttrCustomResolver{
 			"columns.outputs.defaults_to.value": {ResolverFunc: QueueIdResolver},
 			"columns.inputs.defaults_to.value":  {ResolverFunc: QueueIdResolver},
-			"rows.*.inputs.*.literal.value":     {ResolverFunc: QueueIdResolver},
-			"rows.*.outputs.*.literal.value":    {ResolverFunc: QueueIdResolver},
+			"rows.inputs.literal.value":         {ResolverFunc: QueueIdResolver},
+			"rows.outputs.literal.value":        {ResolverFunc: QueueIdResolver},
 		},
 	}
 }

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_schema.go
@@ -1,5 +1,11 @@
 package business_rules_decision_table
 
+// @team: Avengers AI
+// @chat: #rule-based-decisions
+// @pm: Rob Blane
+// @jira: RULES
+// @description: Manages rule-based decision tables for Genesys Cloud. Provides a flexible way to define decision tables with inputs and outputs, and to manage their rows and columns.
+
 import (
 	"fmt"
 	"strconv"

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -2177,55 +2178,133 @@ func TestUnitBusinessRulesDecisionTableExporter(t *testing.T) {
 	assert.Equal(t, "genesyscloud_auth_division", exporter.RefAttrs["division_id"].RefType, "division_id should reference auth_division")
 	assert.Equal(t, "genesyscloud_business_rules_schema", exporter.RefAttrs["schema_id"].RefType, "schema_id should reference business_rules_schema")
 
-	// Test CustomAttributeResolver configuration
+	// Test CustomAttributeResolver configuration.
+	//
+	// The exporter framework matches resolver keys by exact string against the
+	// dot-separated attribute path it builds in sanitizeConfigMap — no array
+	// indices, no "*" wildcards. Any key containing those segments will silently
+	// never fire (this is exactly how the queue-in-rows resolution bug shipped:
+	// the keys were registered as "rows.*.inputs.*.literal.value" and never
+	// matched). These assertions lock in the correct path shape so a regression
+	// to the wildcard form fails the test instead of passing it.
 	assert.NotNil(t, exporter.CustomAttributeResolver, "CustomAttributeResolver should not be nil")
-	assert.Contains(t, exporter.CustomAttributeResolver, "columns.outputs.defaults_to.value", "outputs defaults_to.value should have custom resolver")
-	assert.Contains(t, exporter.CustomAttributeResolver, "columns.inputs.defaults_to.value", "inputs defaults_to.value should have custom resolver")
-	assert.Contains(t, exporter.CustomAttributeResolver, "rows.*.inputs.*.literal.value", "row inputs literal.value should have custom resolver")
-	assert.Contains(t, exporter.CustomAttributeResolver, "rows.*.outputs.*.literal.value", "row outputs literal.value should have custom resolver")
+	expectedResolverPaths := []string{
+		"columns.outputs.defaults_to.value",
+		"columns.inputs.defaults_to.value",
+		"rows.inputs.literal.value",
+		"rows.outputs.literal.value",
+	}
+	for _, path := range expectedResolverPaths {
+		assert.Contains(t, exporter.CustomAttributeResolver, path, "%q should have a custom resolver registered", path)
+		if resolver, ok := exporter.CustomAttributeResolver[path]; ok {
+			assert.NotNil(t, resolver.ResolverFunc, "resolver function should be set for %q", path)
+		}
+	}
 
-	// Test that resolver functions are set
-	assert.NotNil(t, exporter.CustomAttributeResolver["columns.outputs.defaults_to.value"].ResolverFunc, "outputs resolver function should be set")
-	assert.NotNil(t, exporter.CustomAttributeResolver["columns.inputs.defaults_to.value"].ResolverFunc, "inputs resolver function should be set")
-	assert.NotNil(t, exporter.CustomAttributeResolver["rows.*.inputs.*.literal.value"].ResolverFunc, "row inputs resolver function should be set")
-	assert.NotNil(t, exporter.CustomAttributeResolver["rows.*.outputs.*.literal.value"].ResolverFunc, "row outputs resolver function should be set")
+	// Guard: no key may contain "*" or numeric path segments — those would never
+	// match the framework's runtime lookup. See sanitizeConfigMap in
+	// genesyscloud/tfexporter/genesyscloud_resource_exporter.go.
+	for path := range exporter.CustomAttributeResolver {
+		assert.NotContains(t, path, "*", "resolver path %q must not contain wildcard segments — they never match at runtime", path)
+		for _, segment := range strings.Split(path, ".") {
+			if _, err := strconv.Atoi(segment); err == nil {
+				t.Errorf("resolver path %q contains numeric segment %q — array indices are not part of the runtime path", path, segment)
+			}
+		}
+	}
 }
 
-// Test the queue ID resolver function
-func TestUnitQueueIdResolver(t *testing.T) {
-	// Test with a valid queue ID
-	queueID := "test-queue-id"
-	queueName := "test-queue"
+// TestUnitQueueIdResolver_RewritesUUIDToReference exercises the resolver the way
+// the exporter framework actually invokes it — with a configMap representing a
+// single literal block (keys "value" / "type") and a populated exporters map
+// containing a genesyscloud_routing_queue entry whose SanitizedResourceMap
+// holds the UUID we want resolved. It asserts the resolver actually rewrites
+// the value to a Terraform reference, which the previous tautological test did
+// not do.
+func TestUnitQueueIdResolver_RewritesUUIDToReference(t *testing.T) {
+	const (
+		queueUUID  = "11111111-2222-3333-4444-555555555555"
+		queueLabel = "My_Queue"
+	)
 
-	// Create a mock resource map with queue information
-	resourceMap := map[string]interface{}{
-		"genesyscloud_routing_queue": map[string]interface{}{
-			queueID: map[string]interface{}{
-				"name": queueName,
+	configMap := map[string]interface{}{
+		"value": queueUUID,
+		"type":  "string",
+	}
+	exporters := map[string]*resourceExporter.ResourceExporter{
+		"genesyscloud_routing_queue": {
+			SanitizedResourceMap: resourceExporter.ResourceIDMetaMap{
+				queueUUID: &resourceExporter.ResourceMeta{BlockLabel: queueLabel},
 			},
 		},
 	}
 
-	// Create mock exporters map (required by the function signature)
-	exporters := map[string]*resourceExporter.ResourceExporter{}
+	err := QueueIdResolver(configMap, exporters, "genesyscloud_business_rules_decision_table")
+	assert.NoError(t, err)
+	assert.Equal(t, fmt.Sprintf("${genesyscloud_routing_queue.%s.id}", queueLabel), configMap["value"],
+		"resolver should rewrite a known queue UUID into a ${genesyscloud_routing_queue.<label>.id} reference")
+	assert.Equal(t, "string", configMap["type"], "resolver must not modify the literal type field")
+}
 
-	// Test queue ID resolution
-	err := QueueIdResolver(resourceMap, exporters, queueID)
-	assert.NoError(t, err, "Queue ID resolution should succeed")
+// TestUnitQueueIdResolver_LeavesNonMatchingValuesAlone covers the negative
+// paths: empty value, non-UUID-shaped string, UUID-shaped string with no
+// matching queue, and missing queue exporter. None of these should rewrite
+// the value or return an error.
+func TestUnitQueueIdResolver_LeavesNonMatchingValuesAlone(t *testing.T) {
+	const knownQueueUUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+	exportersWithQueue := map[string]*resourceExporter.ResourceExporter{
+		"genesyscloud_routing_queue": {
+			SanitizedResourceMap: resourceExporter.ResourceIDMetaMap{
+				knownQueueUUID: &resourceExporter.ResourceMeta{BlockLabel: "Known_Queue"},
+			},
+		},
+	}
 
-	// Test with non-queue value (should succeed)
-	nonQueueValue := "priority_high"
-	err2 := QueueIdResolver(resourceMap, exporters, nonQueueValue)
-	assert.NoError(t, err2, "Non-queue value should be handled without error")
+	cases := []struct {
+		name      string
+		configMap map[string]interface{}
+		exporters map[string]*resourceExporter.ResourceExporter
+		wantValue interface{}
+	}{
+		{
+			name:      "empty value is a no-op",
+			configMap: map[string]interface{}{"value": "", "type": "string"},
+			exporters: exportersWithQueue,
+			wantValue: "",
+		},
+		{
+			name:      "missing value key is a no-op",
+			configMap: map[string]interface{}{"type": "string"},
+			exporters: exportersWithQueue,
+			wantValue: nil,
+		},
+		{
+			name:      "non-UUID string is untouched",
+			configMap: map[string]interface{}{"value": "Premium Support", "type": "string"},
+			exporters: exportersWithQueue,
+			wantValue: "Premium Support",
+		},
+		{
+			name:      "UUID-shaped string with no matching queue is untouched",
+			configMap: map[string]interface{}{"value": "ffffffff-0000-0000-0000-000000000000", "type": "string"},
+			exporters: exportersWithQueue,
+			wantValue: "ffffffff-0000-0000-0000-000000000000",
+		},
+		{
+			name:      "no routing_queue exporter registered is a no-op",
+			configMap: map[string]interface{}{"value": knownQueueUUID, "type": "string"},
+			exporters: map[string]*resourceExporter.ResourceExporter{},
+			wantValue: knownQueueUUID,
+		},
+	}
 
-	// Test with empty value
-	emptyValue := ""
-	err3 := QueueIdResolver(resourceMap, exporters, emptyValue)
-	assert.NoError(t, err3, "Empty value should be handled without error")
-
-	// Test with nil resource map
-	err4 := QueueIdResolver(nil, exporters, queueID)
-	assert.NoError(t, err4, "Should handle nil resource map without error")
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := QueueIdResolver(tc.configMap, tc.exporters, "genesyscloud_business_rules_decision_table")
+			assert.NoError(t, err)
+			assert.Equal(t, tc.wantValue, tc.configMap["value"])
+		})
+	}
 }
 
 // Test the data source functionality

--- a/genesyscloud/business_rules_schema/data_source_genesyscloud_business_rules_schema.go
+++ b/genesyscloud/business_rules_schema/data_source_genesyscloud_business_rules_schema.go
@@ -1,6 +1,6 @@
 package business_rules_schema
 
-// @team: Avengers AI
+// @team: RuleBasedDecisions
 // @chat: #rule-based-decisions
 // @pm: Rob Blane
 // @jira: RULES

--- a/genesyscloud/business_rules_schema/data_source_genesyscloud_business_rules_schema.go
+++ b/genesyscloud/business_rules_schema/data_source_genesyscloud_business_rules_schema.go
@@ -1,5 +1,11 @@
 package business_rules_schema
 
+// @team: Avengers AI
+// @chat: #rule-based-decisions
+// @pm: Rob Blane
+// @jira: RULES
+// @description: Manages rule-based schemas for Genesys Cloud. Provides a flexible way to define schemas with properties for use in decision tables.
+
 import (
 	"context"
 	"fmt"

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -2467,7 +2467,10 @@ func TestAccResourceTfExportBusinessRulesDecisionTableQueueReferences(t *testing
 	}
 
 	var (
-		uniqueSuffix = strings.ReplaceAll(uuid.NewString(), "-", "_")
+		// Schema name is capped at 50 chars by the platform, so keep the suffix
+		// short. The first 8 hex chars of a UUID give us enough uniqueness for
+		// concurrent test runs without overflowing the schema-name limit.
+		uniqueSuffix = uuid.NewString()[:8]
 
 		// Use snake_case names so the sanitized resource block labels equal the
 		// raw names; that makes the expected ${...} reference strings predictable
@@ -2559,11 +2562,29 @@ func TestAccResourceTfExportBusinessRulesDecisionTableQueueReferences(t *testing
 // resource's own acceptance tests so this test bails cleanly on orgs without
 // the decision table feature toggle. Inlined here to avoid exporting a
 // test-only helper from the business_rules_decision_table package.
+//
+// The tfexporter package's TestMain does not authorize the SDK (unlike the
+// business_rules_decision_table package), so we authorize explicitly here -
+// otherwise the probe runs against an unauthenticated client and every org
+// looks like it has the feature disabled.
 func businessRulesDecisionTableExportFtEnabled(t *testing.T) bool {
 	t.Helper()
+	if _, err := provider.AuthorizeSdk(); err != nil {
+		t.Logf("Failed to authorize SDK for decision table feature probe: %v", err)
+		return false
+	}
 	businessRulesAPI := platformclientv2.NewBusinessRulesApi()
 	_, resp, err := businessRulesAPI.GetBusinessrulesDecisiontables("", "", nil, "")
-	if err != nil || resp == nil || resp.StatusCode != 200 {
+	if err != nil {
+		t.Logf("Decision table probe error: %v", err)
+		return false
+	}
+	if resp == nil || resp.StatusCode != 200 {
+		status := 0
+		if resp != nil {
+			status = resp.StatusCode
+		}
+		t.Logf("Decision table probe returned status %d", status)
 		return false
 	}
 	return true

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export_test.go
@@ -37,6 +37,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/mypurecloud/platform-client-sdk-go/v188/platformclientv2"
 	"gonum.org/v1/gonum/graph/simple"
 	"gonum.org/v1/gonum/graph/topo"
 )
@@ -2439,4 +2440,311 @@ resource "genesyscloud_integration_credential" "%s" {
 		},
 		CheckDestroy: testVerifyExportsDestroyedFunc(exportTestDir),
 	})
+}
+
+// TestAccResourceTfExportBusinessRulesDecisionTableQueueReferences exercises the
+// end-to-end exporter pipeline for a decision table that references routing
+// queues in both columns (column defaults) AND rows (row literal values).
+//
+// It is the regression test for the queue-in-rows resolution bug: the exporter
+// registered a QueueIdResolver for row literal paths under the keys
+// "rows.*.inputs.*.literal.value" and "rows.*.outputs.*.literal.value", but the
+// export framework matches resolver keys by exact string against a dot-only
+// path it constructs while walking the config. Wildcard segments never appear in
+// that runtime path, so the resolver silently never fired and exported decision
+// tables wrote raw queue UUIDs into row cells instead of
+// ${genesyscloud_routing_queue.<label>.id} references — meaning the exported
+// HCL could not be applied to another org without manual fix-up.
+//
+// The four assertions below cover the four queue-bearing locations on the
+// resource. The column assertions guard the previously-working paths; the row
+// assertions are the ones that fail against the pre-fix code.
+func TestAccResourceTfExportBusinessRulesDecisionTableQueueReferences(t *testing.T) {
+	testSetup(t)
+
+	if !businessRulesDecisionTableExportFtEnabled(t) {
+		t.Skip("Business rules decision table feature toggle is not enabled in this test org; skipping export round-trip test")
+	}
+
+	var (
+		uniqueSuffix = strings.ReplaceAll(uuid.NewString(), "-", "_")
+
+		// Use snake_case names so the sanitized resource block labels equal the
+		// raw names; that makes the expected ${...} reference strings predictable
+		// without going through the sanitizer at assertion time.
+		schemaName    = "tf_test_dt_export_schema_" + uniqueSuffix
+		queueAName    = "tf_test_dt_export_queue_a_" + uniqueSuffix
+		queueBName    = "tf_test_dt_export_queue_b_" + uniqueSuffix
+		tableName     = "tf_test_dt_export_table_" + uniqueSuffix
+		exportTestDir = testrunner.GetTestTempPath(".terraform_dt_export_" + uuid.NewString())
+		configPath    = filepath.Join(exportTestDir, defaultTfJSONFile)
+	)
+
+	defer func(path string) {
+		if err := os.RemoveAll(path); err != nil {
+			t.Logf("failed to remove dir %s: %s", path, err)
+		}
+	}(exportTestDir)
+
+	baseConfig := buildDecisionTableQueueExportBaseConfig(schemaName, queueAName, queueBName, tableName)
+
+	expectedQueueARef := fmt.Sprintf("${genesyscloud_routing_queue.%s.id}", queueAName)
+	expectedQueueBRef := fmt.Sprintf("${genesyscloud_routing_queue.%s.id}", queueBName)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
+		Steps: []resource.TestStep{
+			{
+				// Step 1: create the schema, queues, and decision table.
+				Config: baseConfig,
+			},
+			{
+				// Step 2: run the export — include the queue, schema, and decision
+				// table so the QueueIdResolver has a populated SanitizedResourceMap
+				// to resolve row UUIDs against.
+				Config: baseConfig + generateExportResourceIncludeFilterWithEnableDepRes(
+					"dt_export",
+					exportTestDir,
+					util.TrueValue,        // include_state_file
+					strconv.Quote("json"), // export_format
+					util.TrueValue,        // enable_dependency_resolution
+					[]string{
+						strconv.Quote("genesyscloud_business_rules_decision_table::" + tableName),
+						strconv.Quote("genesyscloud_routing_queue::" + queueAName),
+						strconv.Quote("genesyscloud_routing_queue::" + queueBName),
+						strconv.Quote("genesyscloud_business_rules_schema::" + schemaName),
+					},
+					[]string{
+						"genesyscloud_business_rules_decision_table.test_table",
+						"genesyscloud_routing_queue.queue_a",
+						"genesyscloud_routing_queue.queue_b",
+						"genesyscloud_business_rules_schema.test_schema",
+					},
+				),
+				Check: resource.ComposeTestCheckFunc(
+					// Column defaults — these worked before the fix because their
+					// resolver paths had no wildcards. Asserting them ensures the
+					// fix didn't regress the existing behavior.
+					assertDecisionTableQueueReference(
+						configPath, tableName,
+						[]string{"columns", "0", "inputs", "0", "defaults_to", "0", "value"},
+						expectedQueueARef,
+					),
+					assertDecisionTableQueueReference(
+						configPath, tableName,
+						[]string{"columns", "0", "outputs", "0", "defaults_to", "0", "value"},
+						expectedQueueBRef,
+					),
+					// Row literals — these are the regression assertions. Against
+					// the pre-fix exporter they hold raw UUIDs.
+					assertDecisionTableQueueReference(
+						configPath, tableName,
+						[]string{"rows", "0", "inputs", "0", "literal", "0", "value"},
+						expectedQueueARef,
+					),
+					assertDecisionTableQueueReference(
+						configPath, tableName,
+						[]string{"rows", "0", "outputs", "0", "literal", "0", "value"},
+						expectedQueueBRef,
+					),
+				),
+			},
+		},
+		CheckDestroy: testVerifyExportsDestroyedFunc(exportTestDir),
+	})
+}
+
+// businessRulesDecisionTableExportFtEnabled mirrors the skip-check used by the
+// resource's own acceptance tests so this test bails cleanly on orgs without
+// the decision table feature toggle. Inlined here to avoid exporting a
+// test-only helper from the business_rules_decision_table package.
+func businessRulesDecisionTableExportFtEnabled(t *testing.T) bool {
+	t.Helper()
+	businessRulesAPI := platformclientv2.NewBusinessRulesApi()
+	_, resp, err := businessRulesAPI.GetBusinessrulesDecisiontables("", "", nil, "")
+	if err != nil || resp == nil || resp.StatusCode != 200 {
+		return false
+	}
+	return true
+}
+
+// buildDecisionTableQueueExportBaseConfig produces a minimal decision table
+// scenario: a schema with two businessRulesQueue properties, two queues, and a
+// single-row table whose columns and row reference both queues. Two queues
+// (rather than one) are used so the test can independently verify the inputs
+// and outputs branches resolve to the correct queue reference rather than
+// accidentally matching the same value at both ends.
+func buildDecisionTableQueueExportBaseConfig(schemaName, queueAName, queueBName, tableName string) string {
+	return fmt.Sprintf(`
+data "genesyscloud_auth_division_home" "home" {}
+
+resource "genesyscloud_routing_queue" "queue_a" {
+  name        = "%[2]s"
+  division_id = data.genesyscloud_auth_division_home.home.id
+  description = "Queue A for decision table export round-trip test"
+}
+
+resource "genesyscloud_routing_queue" "queue_b" {
+  name        = "%[3]s"
+  division_id = data.genesyscloud_auth_division_home.home.id
+  description = "Queue B for decision table export round-trip test"
+}
+
+resource "genesyscloud_business_rules_schema" "test_schema" {
+  enabled     = true
+  name        = "%[1]s"
+  description = "Schema for decision table export round-trip test"
+  properties = jsonencode({
+    "transfer_queue" : {
+      "allOf" : [{ "$ref" : "#/definitions/businessRulesQueue" }],
+      "title" : "transfer_queue",
+      "description" : "Input column queue reference"
+    },
+    "second_queue" : {
+      "allOf" : [{ "$ref" : "#/definitions/businessRulesQueue" }],
+      "title" : "second_queue",
+      "description" : "Output column queue reference"
+    }
+  })
+}
+
+resource "genesyscloud_business_rules_decision_table" "test_table" {
+  name        = "%[4]s"
+  description = "Decision table for export round-trip test"
+  division_id = data.genesyscloud_auth_division_home.home.id
+  schema_id   = genesyscloud_business_rules_schema.test_schema.id
+
+  columns {
+    inputs {
+      defaults_to {
+        value = genesyscloud_routing_queue.queue_a.id
+      }
+      expression {
+        contractual {
+          schema_property_key = "transfer_queue"
+          contractual {
+            schema_property_key = "queue"
+            contractual {
+              schema_property_key = "id"
+            }
+          }
+        }
+        comparator = "Equals"
+      }
+    }
+
+    outputs {
+      defaults_to {
+        value = genesyscloud_routing_queue.queue_b.id
+      }
+      value {
+        schema_property_key = "second_queue"
+        properties {
+          schema_property_key = "queue"
+          properties {
+            schema_property_key = "id"
+          }
+        }
+      }
+    }
+  }
+
+  rows {
+    inputs {
+      literal {
+        value = genesyscloud_routing_queue.queue_a.id
+        type  = "string"
+      }
+    }
+    outputs {
+      literal {
+        value = genesyscloud_routing_queue.queue_b.id
+        type  = "string"
+      }
+    }
+  }
+}
+`, schemaName, queueAName, queueBName, tableName)
+}
+
+// assertDecisionTableQueueReference walks the exported JSON config and asserts
+// that the value at the given nested path on the named decision table equals
+// expectedRef AND is not a raw UUID. The path is the sequence of JSON keys
+// and array indices (as strings) under
+// resource.genesyscloud_business_rules_decision_table.<tableName>.
+//
+// The not-a-UUID check is deliberately separate from the equality check so
+// failures surface the symptom clearly: "we found a raw UUID where a reference
+// was expected" is far more diagnostic than "got X, want Y" for this class of
+// bug.
+func assertDecisionTableQueueReference(filename, tableName string, path []string, expectedRef string) resource.TestCheckFunc {
+	uuidPattern := regexp.MustCompile(`^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$`)
+	return func(state *terraform.State) error {
+		if _, err := os.Stat(filename); err != nil {
+			return fmt.Errorf("export file not found at %s: %v", filename, err)
+		}
+		exportData, err := util.LoadJsonFileToMap(filename)
+		if err != nil {
+			return fmt.Errorf("failed to load export file %s: %v", filename, err)
+		}
+
+		resources, ok := exportData["resource"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf(`exported config missing top-level "resource" map`)
+		}
+		tables, ok := resources["genesyscloud_business_rules_decision_table"].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("no genesyscloud_business_rules_decision_table resources exported")
+		}
+		table, ok := tables[tableName].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("decision table %q was not exported (found tables: %v)", tableName, keysOf(tables))
+		}
+
+		var current interface{} = table
+		for i, segment := range path {
+			switch typed := current.(type) {
+			case map[string]interface{}:
+				current, ok = typed[segment]
+				if !ok {
+					return fmt.Errorf("path segment %q (index %d) not found under decision table %q; remaining path: %v", segment, i, tableName, path[i:])
+				}
+			case []interface{}:
+				idx, parseErr := strconv.Atoi(segment)
+				if parseErr != nil {
+					return fmt.Errorf("path segment %q (index %d) is not a valid array index but the current node is an array", segment, i)
+				}
+				if idx < 0 || idx >= len(typed) {
+					return fmt.Errorf("array index %d out of bounds (len=%d) at path segment %d", idx, len(typed), i)
+				}
+				current = typed[idx]
+			default:
+				return fmt.Errorf("cannot descend into %T at path segment %q (index %d)", current, segment, i)
+			}
+		}
+
+		got, ok := current.(string)
+		if !ok {
+			return fmt.Errorf("value at path %v is %T, expected string", path, current)
+		}
+		if uuidPattern.MatchString(got) {
+			return fmt.Errorf("value at path %v on table %q is a raw UUID %q — the QueueIdResolver did not resolve it to a ${genesyscloud_routing_queue.<label>.id} reference. This is the queue-in-rows regression.", path, tableName, got)
+		}
+		if got != expectedRef {
+			return fmt.Errorf("value at path %v on table %q: got %q, want %q", path, tableName, got, expectedRef)
+		}
+		return nil
+	}
+}
+
+// keysOf returns the keys of a string-keyed map, used purely for error
+// messages so failures hint at what was exported when the expected table
+// is missing.
+func keysOf(m map[string]interface{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }


### PR DESCRIPTION
The row resolver keys (`rows.*.inputs.*.literal.value`, `rows.*.outputs.*.literal.value`) used wildcard segments the framework never produces, so the `QueueIdResolver` silently never ran and row cells were exported as raw UUIDs. Drop the wildcards. Adds unit-test guard against */numeric segments in resolver keys, a real `QueueIdResolver` rewrite test, and an end-to-end export round-trip acceptance test.