### PR TITLE
NO-JIRA: Fix bug where RequestLogHook injects canceled context into HTTP requests causing "context canceled" failures

### DIFF
--- a/genesyscloud/provider/provider_sdk_debug.go
+++ b/genesyscloud/provider/provider_sdk_debug.go
@@ -438,8 +438,6 @@ func newSDKDebugRequest(request *http.Request, count int) *sdkDebugRequest {
 		if storedCtx := getContextForRequest(); storedCtx != nil {
 			if rc, ok := storedCtx.Value(resourceContextKey{}).(*ResourceContext); ok && rc != nil {
 				resourceCtx = rc
-				// Inject the context into the request so it's available for the response hook
-				*request = *request.WithContext(storedCtx)
 			}
 		}
 	}
@@ -501,6 +499,15 @@ func newSDKDebugResponse(response *http.Response) *sdkDebugResponse {
 	if ctx := response.Request.Context(); ctx != nil {
 		if rc, ok := ctx.Value(resourceContextKey{}).(*ResourceContext); ok && rc != nil {
 			resourceCtx = rc
+		}
+	}
+
+	// If not found in request context, try goroutine-local storage
+	if resourceCtx == nil {
+		if storedCtx := getContextForRequest(); storedCtx != nil {
+			if rc, ok := storedCtx.Value(resourceContextKey{}).(*ResourceContext); ok && rc != nil {
+				resourceCtx = rc
+			}
 		}
 	}
 

--- a/genesyscloud/provider/provider_sdk_debug_test.go
+++ b/genesyscloud/provider/provider_sdk_debug_test.go
@@ -2,11 +2,15 @@ package provider
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // TestSdkDebugStatusNeedsErrorMirror covers sdkDebugStatusNeedsErrorMirror status boundaries (429, 5xx, 501 excluded, etc.).
@@ -259,4 +263,118 @@ type errReader struct {
 // Read always returns (0, err) for the configured errReader.err.
 func (e errReader) Read(_ []byte) (int, error) {
 	return 0, e.err
+}
+
+// TestNewSDKDebugRequest_CanceledStoredContext verifies that a canceled context
+// in goroutine-local storage does not get injected into the HTTP request.
+// This reproduces the bug where Terraform's r.read() defers cancel() on its
+// timeout context, leaving a canceled context in contextStorage that would
+// poison subsequent HTTP requests on the same goroutine.
+func TestNewSDKDebugRequest_CanceledStoredContext(t *testing.T) {
+	// Create a context with resource metadata and cancel it (simulating defer cancel() in r.read())
+	ctx, cancel := context.WithCancel(context.Background())
+	ctx = context.WithValue(ctx, resourceContextKey{}, &ResourceContext{
+		ResourceType: "genesyscloud_outbound_contact_list",
+		ResourceId:   "test-id-123",
+		ResourceName: "test-contact-list",
+	})
+	cancel() // Simulate Terraform's defer cancel()
+
+	// Store the canceled context in goroutine-local storage (simulates what autoInjectResourceContext does)
+	setContextForRequest(ctx)
+
+	// Create a bare HTTP request (simulates what the SDK does — no context attached)
+	request := &http.Request{
+		Method: "GET",
+		URL:    &url.URL{Path: "/api/v2/outbound/attemptlimits"},
+		Header: make(http.Header),
+	}
+
+	// Call the request hook
+	debugReq := newSDKDebugRequest(request, 0)
+
+	// The hook should still extract resource metadata for logging
+	assert.Equal(t, "genesyscloud_outbound_contact_list", debugReq.ResourceType)
+	assert.Equal(t, "test-id-123", debugReq.ResourceId)
+	assert.Equal(t, "test-contact-list", debugReq.ResourceName)
+
+	// The request's context must NOT be canceled — this is the critical assertion
+	assert.NoError(t, request.Context().Err(), "request context should not be canceled; the logging hook must not inject a canceled context into the HTTP request")
+
+	// Clean up goroutine-local storage
+	goroutineID := getGoroutineID()
+	contextStorage.Delete(goroutineID)
+}
+
+// TestNewSDKDebugRequest_ValidStoredContext verifies that when the stored context
+// is still valid, resource metadata is still extracted for logging.
+func TestNewSDKDebugRequest_ValidStoredContext(t *testing.T) {
+	// Create a valid (non-canceled) context with resource metadata
+	ctx := context.WithValue(context.Background(), resourceContextKey{}, &ResourceContext{
+		ResourceType: "genesyscloud_auth_division",
+		ResourceId:   "div-456",
+		ResourceName: "Marketing",
+	})
+
+	// Store in goroutine-local storage
+	setContextForRequest(ctx)
+
+	// Create a bare HTTP request
+	request := &http.Request{
+		Method: "GET",
+		URL:    &url.URL{Path: "/api/v2/authorization/divisions"},
+		Header: make(http.Header),
+	}
+
+	// Call the request hook
+	debugReq := newSDKDebugRequest(request, 0)
+
+	// Metadata should be extracted
+	assert.Equal(t, "genesyscloud_auth_division", debugReq.ResourceType)
+	assert.Equal(t, "div-456", debugReq.ResourceId)
+	assert.Equal(t, "Marketing", debugReq.ResourceName)
+
+	// Request context should not be canceled
+	assert.NoError(t, request.Context().Err())
+
+	// Clean up
+	goroutineID := getGoroutineID()
+	contextStorage.Delete(goroutineID)
+}
+
+// TestNewSDKDebugResponse_FallsBackToGoroutineLocalStorage verifies that the
+// response hook can find resource metadata from goroutine-local storage when
+// the request context doesn't have it (which is now the case since we no longer
+// inject context into requests).
+func TestNewSDKDebugResponse_FallsBackToGoroutineLocalStorage(t *testing.T) {
+	// Store resource context in goroutine-local storage
+	ctx := context.WithValue(context.Background(), resourceContextKey{}, &ResourceContext{
+		ResourceType: "genesyscloud_outbound_attempt_limit",
+		ResourceId:   "attempt-789",
+		ResourceName: "MyAttemptLimit",
+	})
+	setContextForRequest(ctx)
+
+	// Create a response whose request has NO resource context (bare context)
+	response := &http.Response{
+		StatusCode: 200,
+		Request: &http.Request{
+			Method: "GET",
+			URL:    &url.URL{Path: "/api/v2/outbound/attemptlimits"},
+			Header: make(http.Header),
+		},
+		Body: io.NopCloser(strings.NewReader(`{"id":"attempt-789","name":"MyAttemptLimit"}`)),
+	}
+
+	// Call the response hook
+	debugResp := newSDKDebugResponse(response)
+
+	// The response hook should find metadata via goroutine-local storage fallback
+	assert.Equal(t, "genesyscloud_outbound_attempt_limit", debugResp.ResourceType)
+	assert.Equal(t, "attempt-789", debugResp.ResourceId)
+	assert.Equal(t, "MyAttemptLimit", debugResp.ResourceName)
+
+	// Clean up
+	goroutineID := getGoroutineID()
+	contextStorage.Delete(goroutineID)
 }


### PR DESCRIPTION
## Bug: RequestLogHook injects canceled context into HTTP requests causing "context canceled" failures

### Problem

The SDK `RequestLogHook` in `provider_sdk_debug.go` was conflating two separate concerns: attaching resource metadata for debug logging, and setting the context that governs HTTP request lifecycle (cancellation and timeouts). It did this by injecting a goroutine-local stored context directly into HTTP requests via `*request = *request.WithContext(storedCtx)`.

The stored context has a lifetime tied to a Terraform operation scope (a single resource read with `defer cancel()`), while the HTTP request's context should have a lifetime tied to *that specific HTTP call*. By injecting one into the other, a completed (and properly cleaned up) Terraform operation would poison unrelated future HTTP requests that happened to run on the same goroutine, causing them to fail immediately with `"giving up after 1 attempt(s): context canceled"`.

This was especially seen in various edge cases when working with the BCP exporter.

### Debugging Root Cause

1. The BCP exporter (or any single-goroutine code path calling `RefreshWithoutUpgrade`) triggers a resource's `ReadContext`.
2. Terraform's plugin SDK wraps the call with a timeout context and defers its cancellation:
   ```go
   // terraform-plugin-sdk/v2/helper/schema/resource.go
   ctx, cancel := context.WithTimeout(ctx, d.Timeout(TimeoutRead))
   defer cancel()
   return r.ReadContext(ctx, d, meta)
   ```
3. Inside `ReadContext`, `runWithPooledClient` → `autoInjectResourceContext` → `setContextForRequest` stores this timeout context in a global `sync.Map` keyed by goroutine ID.
4. The read completes successfully. `r.read()` returns and `defer cancel()` fires — standard Go cleanup for timeout contexts. The stored context in `contextStorage` is now **canceled**.
5. A subsequent SDK API call runs on the **same goroutine** (e.g., the next resource type's `getAll` function).
6. The SDK fires the `RequestLogHook`, which retrieves the stale canceled context from `contextStorage` and injects it into the HTTP request: `*request = *request.WithContext(storedCtx)`.
7. `retryablehttp`'s `DefaultRetryPolicy` checks `ctx.Err()` on the request's context, finds it canceled, and returns immediately — producing: `"giving up after 1 attempt(s): context canceled"`.

### How to Reproduce

```hcl
resource "genesyscloud_bcp_tf_exporter" "analysis_export" {
  directory = "./exports"
  filename  = "export.json"
  include_filter_resources = [
    "genesyscloud_auth_division",
    "genesyscloud_outbound_attempt_limit",
    "genesyscloud_outbound_contact_list",
  ]
}
```

Run `terraform apply`. The export fails with:

```
Error: Failed to get page of attempt limit configs error: GET
https://api.mypurecloud.com/api/v2/outbound/attemptlimits?pageSize=100&pageNumber=1&allowEmptyResult=true
giving up after 1 attempt(s): context canceled
```

Removing any one of the three resource types changes Go's map iteration order and avoids the specific sequence where `outbound_contact_list` reads (which go through `ReadContext` → timeout context → `defer cancel()`) execute before `outbound_attempt_limit`'s `getAll` call on the same goroutine.

### Fix

**Removed** the line that injects the stored context into the HTTP request from `newSDKDebugRequest` (the `RequestLogHook`). A logging hook must never mutate `request.Context()` because that governs the HTTP request's cancellation and timeout behavior — fundamentally not a logging concern.

**Added** a goroutine-local storage fallback to `newSDKDebugResponse` (the `ResponseLogHook`) so it can still retrieve resource metadata for debug logging without relying on the request context being injected by the request hook.

### Tests

Three unit tests added to `provider_sdk_debug_test.go`:

- **`TestNewSDKDebugRequest_CanceledStoredContext`** — Reproduces the exact bug. Stores a canceled context in goroutine-local storage, calls the request hook, and asserts the HTTP request's context is NOT canceled. This test **fails** without the fix.
- **`TestNewSDKDebugRequest_ValidStoredContext`** — Verifies resource metadata is still extracted for logging when a valid context is stored.
- **`TestNewSDKDebugResponse_FallsBackToGoroutineLocalStorage`** — Verifies the response hook can find resource metadata via goroutine-local storage when the request context doesn't contain it.

### Files Changed

- `genesyscloud/provider/provider_sdk_debug.go` — Remove context injection from request hook; add goroutine-local fallback to response hook
- `genesyscloud/provider/provider_sdk_debug_test.go` — Add 3 unit tests

### AI Prompt Disclosure

This bug was diagnosed and fixed with the assistance of Amazon Q Developer. The investigation traced context propagation from Terraform's `r.read()` through `runWithPooledClient`, `autoInjectResourceContext`, `setContextForRequest`, the SDK's `RequestLogHook`, and `retryablehttp`'s `DefaultRetryPolicy`. The same analysis can be reproduced by following the context flow described above, or by running the `TestNewSDKDebugRequest_CanceledStoredContext` test against the pre-fix code.
