### PR TITLE
LM-4593: Support name field on CallableTime and new SDK fields for CallableTimeColumnName/ContactableTimeColumnName

### DIFF
--- a/examples/resources/genesyscloud_outbound_callabletimeset/resource.tf
+++ b/examples/resources/genesyscloud_outbound_callabletimeset/resource.tf
@@ -1,6 +1,7 @@
 resource "genesyscloud_outbound_callabletimeset" "example_callable_time_set" {
   name = "Example Callable time set"
   callable_times {
+    name = "Africa/Abidjan"
     time_zone_id = "Africa/Abidjan"
     time_slots {
       start_time = "07:00:00"
@@ -14,6 +15,7 @@ resource "genesyscloud_outbound_callabletimeset" "example_callable_time_set" {
     }
   }
   callable_times {
+    name = "Europe/Dublin"
     time_zone_id = "Europe/Dublin"
     time_slots {
       start_time = "05:30:30"

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_schema.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_schema.go
@@ -56,6 +56,11 @@ var timeSlotResource = &schema.Resource{
 			Type:        schema.TypeSet,
 			Elem:        campaignTimeslotResource,
 		},
+		`name`: {
+			Description: `The name for the callable time.`,
+			Optional:    true,
+			Type:        schema.TypeString,
+		},
 		`time_zone_id`: {
 			Description: `The time zone for the time slots; for example, Africa/Abidjan`,
 			Required:    true,

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_test.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v191/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v192/platformclientv2"
 )
 
 func TestAccResourceOutboundCallabletimeset(t *testing.T) {
@@ -99,6 +99,31 @@ func TestAccResourceOutboundCallabletimeset(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_outbound_callabletimeset."+resourceLabel, "callable_times.1.time_slots.1.start_time", "01:00:00"),
 					resource.TestCheckResourceAttr("genesyscloud_outbound_callabletimeset."+resourceLabel, "callable_times.1.time_slots.1.stop_time", "12:00:00"),
 					resource.TestCheckResourceAttr("genesyscloud_outbound_callabletimeset."+resourceLabel, "callable_times.1.time_slots.1.day", "4"),
+				),
+			},
+			{
+				// Update with named callable times
+				Config: GenerateOutboundCallabletimeset(
+					resourceLabel,
+					name1,
+					GenerateCallableTimesBlock(
+						timeZone1,
+						`name = "America-NewYork-Morning"`,
+						GenerateTimeSlotsBlock("09:00:00", "12:00:00", "1"),
+					),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(
+						"genesyscloud_outbound_callabletimeset."+resourceLabel, "name", name1,
+					),
+					resource.TestCheckTypeSetElemNestedAttrs(
+						"genesyscloud_outbound_callabletimeset."+resourceLabel,
+						"callable_times.*",
+						map[string]string{
+							"name":         "America-NewYork-Morning",
+							"time_zone_id": timeZone1,
+						},
+					),
 				),
 			},
 			{

--- a/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_utils.go
+++ b/genesyscloud/outbound_callabletimeset/resource_genesyscloud_outbound_callabletimeset_utils.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v191/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v192/platformclientv2"
 )
 
 /*
@@ -68,6 +68,9 @@ func buildCallableTimes(callabletime *schema.Set) *[]platformclientv2.Callableti
 		if timeSlots := callabletimeMap["time_slots"]; timeSlots != nil {
 			sdkCallabletime.TimeSlots = buildCampaignTimeslots(timeSlots.(*schema.Set))
 		}
+		if name := callabletimeMap["name"].(string); name != "" {
+			sdkCallabletime.Name = &name
+		}
 		if timeZoneId := callabletimeMap["time_zone_id"].(string); timeZoneId != "" {
 			sdkCallabletime.TimeZoneId = &timeZoneId
 		}
@@ -115,6 +118,9 @@ func flattenCallableTimes(callabletimes []platformclientv2.Callabletime) *schema
 		}
 		if callabletime.TimeZoneId != nil {
 			callabletimeMap["time_zone_id"] = *callabletime.TimeZoneId
+		}
+		if callabletime.Name != nil {
+			callabletimeMap["name"] = *callabletime.Name
 		}
 
 		callabletimeSet.Add(callabletimeMap)

--- a/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
+++ b/genesyscloud/outbound_contact_list/resource_genesyscloud_outbound_contact_list_utils.go
@@ -21,7 +21,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v191/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v192/platformclientv2"
 )
 
 type outboundContactListRawResponse struct {
@@ -106,7 +106,7 @@ func buildSdkOutboundContactListContactPhoneNumberColumnSlice(contactPhoneNumber
 			sdkContactPhoneNumberColumn.VarType = &varType
 		}
 		if callableTimeColumnName, ok := contactPhoneNumberColumnMap["callable_time_column_name"].(string); ok && callableTimeColumnName != "" {
-			sdkContactPhoneNumberColumn.CallableTimeColumn = &callableTimeColumnName
+			sdkContactPhoneNumberColumn.CallableTimeColumnName = &callableTimeColumnName
 		} else if callableTimeColumn := contactPhoneNumberColumnMap["callable_time_column"].(string); callableTimeColumn != "" {
 			sdkContactPhoneNumberColumn.CallableTimeColumn = &callableTimeColumn
 		}
@@ -135,8 +135,11 @@ func flattenSdkOutboundContactListContactPhoneNumberColumnSlice(contactPhoneNumb
 		if contactPhoneNumberColumn.VarType != nil {
 			contactPhoneNumberColumnMap["type"] = *contactPhoneNumberColumn.VarType
 		}
-		if contactPhoneNumberColumn.CallableTimeColumn != nil {
+		if contactPhoneNumberColumn.CallableTimeColumnName != nil {
 			// Keep legacy + new fields in sync while users migrate.
+			contactPhoneNumberColumnMap["callable_time_column_name"] = *contactPhoneNumberColumn.CallableTimeColumnName
+			contactPhoneNumberColumnMap["callable_time_column"] = *contactPhoneNumberColumn.CallableTimeColumnName
+		} else if contactPhoneNumberColumn.CallableTimeColumn != nil {
 			contactPhoneNumberColumnMap["callable_time_column_name"] = *contactPhoneNumberColumn.CallableTimeColumn
 			contactPhoneNumberColumnMap["callable_time_column"] = *contactPhoneNumberColumn.CallableTimeColumn
 		} else if callableTimeColumnNameIndex != nil && key != "" {
@@ -221,7 +224,7 @@ func buildSdkOutboundContactListContactEmailAddressColumnSlice(contactEmailAddre
 
 		// Safely handle contactable_time_column
 		if contactableTimeColumnName, ok := contactEmailAddressColumnMap["contactable_time_column_name"].(string); ok && contactableTimeColumnName != "" {
-			sdkContactEmailAddressColumn.ContactableTimeColumn = &contactableTimeColumnName
+			sdkContactEmailAddressColumn.ContactableTimeColumnName = &contactableTimeColumnName
 		} else if contactableTimeColumn, ok := contactEmailAddressColumnMap["contactable_time_column"].(string); ok && contactableTimeColumn != "" {
 			sdkContactEmailAddressColumn.ContactableTimeColumn = &contactableTimeColumn
 		}
@@ -250,8 +253,10 @@ func flattenSdkOutboundContactListContactEmailAddressColumnSlice(contactEmailAdd
 		if contactEmailAddressColumn.VarType != nil {
 			contactEmailAddressColumnMap["type"] = *contactEmailAddressColumn.VarType
 		}
-		if contactEmailAddressColumn.ContactableTimeColumn != nil {
-			// Keep legacy + new fields in sync while users migrate.
+		if contactEmailAddressColumn.ContactableTimeColumnName != nil {
+			contactEmailAddressColumnMap["contactable_time_column_name"] = *contactEmailAddressColumn.ContactableTimeColumnName
+			contactEmailAddressColumnMap["contactable_time_column"] = *contactEmailAddressColumn.ContactableTimeColumnName
+		} else if contactEmailAddressColumn.ContactableTimeColumn != nil {
 			contactEmailAddressColumnMap["contactable_time_column_name"] = *contactEmailAddressColumn.ContactableTimeColumn
 			contactEmailAddressColumnMap["contactable_time_column"] = *contactEmailAddressColumn.ContactableTimeColumn
 		} else if contactableTimeColumnNameIndex != nil && key != "" {

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_utils.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_utils.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v191/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v192/platformclientv2"
 )
 
 type outboundContactListTemplateRawResponse struct {
@@ -124,7 +124,7 @@ func buildSdkOutboundContactListTemplateContactPhoneNumberColumnSlice(contactPho
 			sdkContactPhoneNumberColumn.VarType = &varType
 		}
 		if callableTimeColumnName, ok := contactPhoneNumberColumnMap["callable_time_column_name"].(string); ok && callableTimeColumnName != "" {
-			sdkContactPhoneNumberColumn.CallableTimeColumn = &callableTimeColumnName
+			sdkContactPhoneNumberColumn.CallableTimeColumnName = &callableTimeColumnName
 		} else if callableTimeColumn := contactPhoneNumberColumnMap["callable_time_column"].(string); callableTimeColumn != "" {
 			sdkContactPhoneNumberColumn.CallableTimeColumn = &callableTimeColumn
 		}
@@ -159,7 +159,9 @@ func flattenSdkOutboundContactListTemplateContactPhoneNumberColumnSlice(
 		}
 
 		var tz string
-		if contactPhoneNumberColumn.CallableTimeColumn != nil && *contactPhoneNumberColumn.CallableTimeColumn != "" {
+		if contactPhoneNumberColumn.CallableTimeColumnName != nil && *contactPhoneNumberColumn.CallableTimeColumnName != "" {
+			tz = *contactPhoneNumberColumn.CallableTimeColumnName
+		} else if contactPhoneNumberColumn.CallableTimeColumn != nil && *contactPhoneNumberColumn.CallableTimeColumn != "" {
 			tz = *contactPhoneNumberColumn.CallableTimeColumn
 		} else if callableTimeColumnNameIndex != nil && key != "" {
 			if v, ok := callableTimeColumnNameIndex[key]; ok && v != "" {
@@ -199,7 +201,7 @@ func buildSdkOutboundContactListContactEmailAddressColumnSlice(contactEmailAddre
 			sdkContactEmailAddressColumn.VarType = &varType
 		}
 		if contactableTimeColumnName, ok := contactEmailAddressColumnMap["contactable_time_column_name"].(string); ok && contactableTimeColumnName != "" {
-			sdkContactEmailAddressColumn.ContactableTimeColumn = &contactableTimeColumnName
+			sdkContactEmailAddressColumn.ContactableTimeColumnName = &contactableTimeColumnName
 		} else if contactableTimeColumn := contactEmailAddressColumnMap["contactable_time_column"].(string); contactableTimeColumn != "" {
 			sdkContactEmailAddressColumn.ContactableTimeColumn = &contactableTimeColumn
 		}
@@ -234,7 +236,9 @@ func flattenSdkOutboundContactListTemplateContactEmailAddressColumnSlice(
 		}
 
 		var tz string
-		if contactEmailAddressColumn.ContactableTimeColumn != nil && *contactEmailAddressColumn.ContactableTimeColumn != "" {
+		if contactEmailAddressColumn.ContactableTimeColumnName != nil && *contactEmailAddressColumn.ContactableTimeColumnName != "" {
+			tz = *contactEmailAddressColumn.ContactableTimeColumnName
+		} else if contactEmailAddressColumn.ContactableTimeColumn != nil && *contactEmailAddressColumn.ContactableTimeColumn != "" {
 			tz = *contactEmailAddressColumn.ContactableTimeColumn
 		} else if contactableTimeColumnNameIndex != nil && key != "" {
 			if v, ok := contactableTimeColumnNameIndex[key]; ok && v != "" {


### PR DESCRIPTION
LM-4593: Support callable time name fields (PURE-7121)
Adds support for new fields introduced in Go SDK v192:

genesyscloud_outbound_callabletimeset: Added optional name field to callable_times blocks
genesyscloud_outbound_contact_list / genesyscloud_outbound_contact_list_template: Updated phone and email column build/flatten logic to use new CallableTimeColumnName and ContactableTimeColumnName SDK fields, with fallback to legacy fields for backward compatibility

Requires SDK bump from v191 → v192 