### PR TITLE
POSTINO-4233 Add support for email signature

### DIFF
--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -91,6 +91,7 @@ resource "genesyscloud_routing_email_route" "example_route_reference_other_route
 - `priority` (Number) The priority to use for routing.
 - `queue_id` (String) The queue to route the emails to. This should not be set if a flow_id is specified.
 - `reply_email_address` (Block List, Max: 1) The route to use for email replies. This should not be set if from_email or auto_bcc are specified. (see [below for nested schema](#nestedblock--reply_email_address))
+- `signature` (Block List, Max: 1) The configuration for the canned response signature that will be appended to outbound emails sent via this route. (see [below for nested schema](#nestedblock--signature))
 - `skill_ids` (Set of String) The skills to use for routing.
 - `spam_flow_id` (String) The flow to use for processing inbound emails that have been marked as spam.
 
@@ -119,4 +120,15 @@ Optional:
 - `route_id` (String) ID of the route.
 - `self_reference_route` (Boolean) Use this route as the reply email address. If true you will use the route id for this resource as the reply and you
 							              can not set a route. If you set this value to false (or leave the attribute off) you must set a route id and matching domain. Defaults to `false`.
+
+
+<a id="nestedblock--signature"></a>
+### Nested Schema for `signature`
+
+Optional:
+
+- `always_included` (Boolean) A toggle that defines if a signature is always included or only set on the first email in an email chain.
+- `canned_response_id` (String) The identifier referring to an email signature canned response.
+- `enabled` (Boolean) A toggle to enable the signature on email send.
+- `inclusion_type` (String) The configuration to indicate when the signature of a conversation has to be included.
 

--- a/examples/resources/genesyscloud_routing_email_route/locals.tf
+++ b/examples/resources/genesyscloud_routing_email_route/locals.tf
@@ -6,6 +6,7 @@ locals {
       "../genesyscloud_routing_skill/resource.tf",
       "../genesyscloud_routing_language/resource.tf",
       "../genesyscloud_flow/resource.tf",
+      "../genesyscloud_responsemanagement_response/resource.tf",
     ]
     simplest_resource = [
       "../genesyscloud_routing_email_domain/resource.tf"

--- a/examples/resources/genesyscloud_routing_email_route/resource.tf
+++ b/examples/resources/genesyscloud_routing_email_route/resource.tf
@@ -13,7 +13,7 @@ resource "genesyscloud_routing_email_route" "example_route" {
   }
   signature {
     enabled            = false
-    canned_response_id = "<canned-response-id>"
+    canned_response_id = genesyscloud_responsemanagement_response.example_signature_response.id
     always_included    = false
     inclusion_type     = "FirstResponseOnly"
   }

--- a/examples/resources/genesyscloud_routing_email_route/resource.tf
+++ b/examples/resources/genesyscloud_routing_email_route/resource.tf
@@ -11,6 +11,12 @@ resource "genesyscloud_routing_email_route" "example_route" {
     name  = "Supervisors"
     email = "support_supervisors@${genesyscloud_routing_email_domain.example_domain_com.domain_id}"
   }
+  signature {
+    enabled            = false
+    canned_response_id = "<canned-response-id>"
+    always_included    = false
+    inclusion_type     = "FirstResponseOnly"
+  }
 }
 
 resource "genesyscloud_routing_email_route" "example_route_reference_other_route" {

--- a/genesyscloud/routing_email_route/genesyscloud_routing_email_route_init_test.go
+++ b/genesyscloud/routing_email_route/genesyscloud_routing_email_route_init_test.go
@@ -1,14 +1,16 @@
 package routing_email_route
 
 import (
-	routingSkillGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_skill_group"
 	"sync"
 
 	architectFlow "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/architect_flow"
+	respmanagementLibrary "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/responsemanagement_library"
+	responsemanagementResponse "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/responsemanagement_response"
 	routingEmailDomain "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_email_domain"
 	routingLanguage "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_language"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"
 	routingSkill "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_skill"
+	routingSkillGroup "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_skill_group"
 
 	"testing"
 
@@ -43,6 +45,8 @@ func (r *registerTestInstance) registerTestResources() {
 	providerResources[routingSkill.ResourceType] = routingSkill.ResourceRoutingSkill()
 	providerResources[architectFlow.ResourceType] = architectFlow.ResourceArchitectFlow()
 	providerResources[routingSkillGroup.ResourceType] = routingSkillGroup.ResourceRoutingSkillGroup()
+	providerResources[responsemanagementResponse.ResourceType] = responsemanagementResponse.ResourceResponsemanagementResponse()
+	providerResources[respmanagementLibrary.ResourceType] = respmanagementLibrary.ResourceResponsemanagementLibrary()
 }
 
 // registerTestDataSources registers all data sources used in the tests.

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
@@ -128,6 +128,8 @@ func readRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta int
 		resourcedata.SetNillableReference(d, "spam_flow_id", route.SpamFlow)
 		resourcedata.SetNillableValue(d, "allow_multiple_actions", route.AllowMultipleActions)
 
+		_ = d.Set("signature", flattenSignature(route.Signature))
+
 		if route.Skills != nil {
 			_ = d.Set("skill_ids", util.SdkDomainEntityRefArrToSet(*route.Skills))
 		} else {

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route.go
@@ -127,8 +127,7 @@ func readRoutingEmailRoute(ctx context.Context, d *schema.ResourceData, meta int
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "auto_bcc", route.AutoBcc, flattenAutoBccEmailAddress)
 		resourcedata.SetNillableReference(d, "spam_flow_id", route.SpamFlow)
 		resourcedata.SetNillableValue(d, "allow_multiple_actions", route.AllowMultipleActions)
-
-		_ = d.Set("signature", flattenSignature(route.Signature))
+		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "signature", route.Signature, flattenSignature)
 
 		if route.Skills != nil {
 			_ = d.Set("skill_ids", util.SdkDomainEntityRefArrToSet(*route.Skills))

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_schema.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_schema.go
@@ -35,6 +35,32 @@ var (
 			},
 		},
 	}
+
+	signatureResource = &schema.Resource{
+		Schema: map[string]*schema.Schema{
+			"enabled": {
+				Description: "A toggle to enable the signature on email send.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
+			"canned_response_id": {
+				Description: "The identifier referring to an email signature canned response.",
+				Type:        schema.TypeString,
+				Optional:    true,
+			},
+			"always_included": {
+				Description: "A toggle that defines if a signature is always included or only set on the first email in an email chain.",
+				Type:        schema.TypeBool,
+				Optional:    true,
+			},
+			"inclusion_type": {
+				Description:  "The configuration to indicate when the signature of a conversation has to be included.",
+				Type:         schema.TypeString,
+				Optional:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Never", "Always", "FirstResponseOnly"}, false),
+			},
+		},
+	}
 )
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
@@ -165,6 +191,13 @@ func ResourceRoutingEmailRoute() *schema.Resource {
 				Description: "The flow to use for processing inbound emails that have been marked as spam.",
 				Type:        schema.TypeString,
 				Optional:    true,
+			},
+			"signature": {
+				Description: "The configuration for the canned response signature that will be appended to outbound emails sent via this route.",
+				Type:        schema.TypeList,
+				MaxItems:    1,
+				Optional:    true,
+				Elem:        signatureResource,
 			},
 		},
 	}

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_schema.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_schema.go
@@ -235,6 +235,7 @@ func RoutingEmailRouteExporter() *resourceExporter.ResourceExporter {
 			"spam_flow_id":                  {RefType: "genesyscloud_flow"},
 			"reply_email_address.domain_id": {RefType: "genesyscloud_routing_email_domain"},
 			"reply_email_address.route_id":  {RefType: "genesyscloud_routing_email_route"},
+			"signature.canned_response_id":  {RefType: "genesyscloud_responsemanagement_response"},
 		},
 		RemoveIfMissing: map[string][]string{
 			"reply_email_address": {"route_id", "self_reference_route"},

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -269,6 +269,114 @@ func TestAccResourceRoutingEmailRoute(t *testing.T) {
 	})
 }
 
+func TestAccResourceRoutingEmailRouteSignature(t *testing.T) {
+	var (
+		domainResourceLabel = "routing-domain-sig"
+		domainId            = fmt.Sprintf("terraformroutes.%s.com", strings.ReplaceAll(uuid.NewString(), "-", ""))
+		routeResourceLabel  = "email-route-sig"
+		routePattern        = "terraformsig" + strings.ReplaceAll(uuid.NewString(), "-", "")[:8]
+		fromName            = "Sig Terraform"
+		fromEmail           = "sig@test.com"
+
+		// initial signature values
+		sigEnabled1       = true
+		sigCannedRespId1  = uuid.NewString()
+		sigAlwaysIncl1    = false
+		sigInclusionType1 = "Always"
+
+		// updated signature values
+		sigEnabled2       = false
+		sigCannedRespId2  = uuid.NewString()
+		sigAlwaysIncl2    = true
+		sigInclusionType2 = "FirstResponseOnly"
+	)
+
+	CleanupRoutingEmailDomains()
+
+	domainId = fmt.Sprintf("terraformroutes.%s.com", strings.ReplaceAll(uuid.NewString(), "-", ""))
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, nil),
+		Steps: []resource.TestStep{
+			{
+				// Create route with a signature block
+				Config: routingEmailDomain.GenerateRoutingEmailDomainResource(
+					domainResourceLabel,
+					domainId,
+					util.FalseValue,
+					util.NullValue,
+				) + GenerateRoutingEmailRouteResource(
+					routeResourceLabel,
+					"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
+					routePattern,
+					fromName,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail),
+					generateRoutingSignature(sigEnabled1, sigCannedRespId1, sigAlwaysIncl1, sigInclusionType1),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "domain_id", domainId),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "pattern", routePattern),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "from_name", fromName),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "from_email", fromEmail),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.enabled", fmt.Sprintf("%t", sigEnabled1)),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.canned_response_id", sigCannedRespId1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.always_included", fmt.Sprintf("%t", sigAlwaysIncl1)),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.inclusion_type", sigInclusionType1),
+				),
+			},
+			{
+				// Update signature values
+				Config: routingEmailDomain.GenerateRoutingEmailDomainResource(
+					domainResourceLabel,
+					domainId,
+					util.FalseValue,
+					util.NullValue,
+				) + GenerateRoutingEmailRouteResource(
+					routeResourceLabel,
+					"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
+					routePattern,
+					fromName,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail),
+					generateRoutingSignature(sigEnabled2, sigCannedRespId2, sigAlwaysIncl2, sigInclusionType2),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.enabled", fmt.Sprintf("%t", sigEnabled2)),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.canned_response_id", sigCannedRespId2),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.always_included", fmt.Sprintf("%t", sigAlwaysIncl2)),
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.inclusion_type", sigInclusionType2),
+				),
+			},
+			{
+				// Remove signature block entirely
+				Config: routingEmailDomain.GenerateRoutingEmailDomainResource(
+					domainResourceLabel,
+					domainId,
+					util.FalseValue,
+					util.NullValue,
+				) + GenerateRoutingEmailRouteResource(
+					routeResourceLabel,
+					"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
+					routePattern,
+					fromName,
+					fmt.Sprintf("from_email = \"%s\"", fromEmail),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "pattern", routePattern),
+					resource.TestCheckNoResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.enabled"),
+				),
+			},
+			{
+				// Import/Read
+				ResourceName:        "genesyscloud_routing_email_route." + routeResourceLabel,
+				ImportState:         true,
+				ImportStateVerify:   true,
+				ImportStateIdPrefix: domainId + "/",
+			},
+		},
+		CheckDestroy: testVerifyRoutingEmailRouteDestroyed,
+	})
+}
+
 func generateRoutingEmailQueueSettings(
 	queueId string,
 	priority string,
@@ -312,6 +420,21 @@ func generateRoutingReplyEmail(
         }
 	`, domainID, routeID)
 	}
+}
+
+func generateRoutingSignature(
+	enabled bool,
+	cannedResponseId string,
+	alwaysIncluded bool,
+	inclusionType string) string {
+	return fmt.Sprintf(`
+        signature {
+            enabled            = %t
+            canned_response_id = "%s"
+            always_included    = %t
+            inclusion_type     = "%s"
+        }
+	`, enabled, cannedResponseId, alwaysIncluded, inclusionType)
 }
 
 func testVerifyRoutingEmailRouteDestroyed(state *terraform.State) error {

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
+	respmanagementLibrary "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/responsemanagement_library"
+	responsemanagementResponse "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/responsemanagement_response"
 	routingEmailDomain "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_email_domain"
 	routingLanguage "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_language"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"
@@ -278,17 +280,59 @@ func TestAccResourceRoutingEmailRouteSignature(t *testing.T) {
 		fromName            = "Sig Terraform"
 		fromEmail           = "sig@test.com"
 
+		// responsemanagement library shared by both responses
+		libResourceLabel = "sig-resp-library"
+		libName          = "Terraform Sig Library " + uuid.NewString()
+
+		// initial canned response resource
+		resp1ResourceLabel = "sig-canned-response-1"
+		resp1Name          = "Terraform Sig Response 1 " + uuid.NewString()
+
+		// updated canned response resource
+		resp2ResourceLabel = "sig-canned-response-2"
+		resp2Name          = "Terraform Sig Response 2 " + uuid.NewString()
+
 		// initial signature values
 		sigEnabled1       = true
-		sigCannedRespId1  = uuid.NewString()
 		sigAlwaysIncl1    = false
 		sigInclusionType1 = "Always"
 
 		// updated signature values
 		sigEnabled2       = false
-		sigCannedRespId2  = uuid.NewString()
 		sigAlwaysIncl2    = true
 		sigInclusionType2 = "FirstResponseOnly"
+	)
+
+	// shared config blocks reused across steps
+	domainConfig := routingEmailDomain.GenerateRoutingEmailDomainResource(
+		domainResourceLabel,
+		domainId,
+		util.FalseValue,
+		util.NullValue,
+	)
+	libConfig := respmanagementLibrary.GenerateResponseManagementLibraryResource(
+		libResourceLabel,
+		libName,
+	)
+	resp1Config := responsemanagementResponse.GenerateResponseManagementResponseResource(
+		resp1ResourceLabel,
+		resp1Name,
+		[]string{"genesyscloud_responsemanagement_library." + libResourceLabel + ".id"},
+		util.NullValue, // interaction_type
+		util.NullValue, // substitutions_schema_id
+		util.NullValue, // response_type
+		[]string{},     // asset_ids
+		responsemanagementResponse.GenerateTextsBlock("Email signature one", "text/plain", util.NullValue),
+	)
+	resp2Config := responsemanagementResponse.GenerateResponseManagementResponseResource(
+		resp2ResourceLabel,
+		resp2Name,
+		[]string{"genesyscloud_responsemanagement_library." + libResourceLabel + ".id"},
+		util.NullValue,
+		util.NullValue,
+		util.NullValue,
+		[]string{},
+		responsemanagementResponse.GenerateTextsBlock("Email signature two", "text/plain", util.NullValue),
 	)
 
 	CleanupRoutingEmailDomains()
@@ -299,67 +343,65 @@ func TestAccResourceRoutingEmailRouteSignature(t *testing.T) {
 		ProviderFactories: provider.GetProviderFactories(providerResources, nil),
 		Steps: []resource.TestStep{
 			{
-				// Create route with a signature block
-				Config: routingEmailDomain.GenerateRoutingEmailDomainResource(
-					domainResourceLabel,
-					domainId,
-					util.FalseValue,
-					util.NullValue,
-				) + GenerateRoutingEmailRouteResource(
-					routeResourceLabel,
-					"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
-					routePattern,
-					fromName,
-					fmt.Sprintf("from_email = \"%s\"", fromEmail),
-					generateRoutingSignature(sigEnabled1, sigCannedRespId1, sigAlwaysIncl1, sigInclusionType1),
-				),
+				// Create route with a signature block referencing canned response 1
+				Config: domainConfig + libConfig + resp1Config + resp2Config +
+					GenerateRoutingEmailRouteResource(
+						routeResourceLabel,
+						"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
+						routePattern,
+						fromName,
+						fmt.Sprintf("from_email = \"%s\"", fromEmail),
+						generateRoutingSignature(
+							sigEnabled1,
+							"genesyscloud_responsemanagement_response."+resp1ResourceLabel+".id",
+							sigAlwaysIncl1,
+							sigInclusionType1,
+						),
+					),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "domain_id", domainId),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "pattern", routePattern),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "from_name", fromName),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "from_email", fromEmail),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.enabled", fmt.Sprintf("%t", sigEnabled1)),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.canned_response_id", sigCannedRespId1),
+					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.canned_response_id", "genesyscloud_responsemanagement_response."+resp1ResourceLabel, "id"),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.always_included", fmt.Sprintf("%t", sigAlwaysIncl1)),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.inclusion_type", sigInclusionType1),
 				),
 			},
 			{
-				// Update signature values
-				Config: routingEmailDomain.GenerateRoutingEmailDomainResource(
-					domainResourceLabel,
-					domainId,
-					util.FalseValue,
-					util.NullValue,
-				) + GenerateRoutingEmailRouteResource(
-					routeResourceLabel,
-					"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
-					routePattern,
-					fromName,
-					fmt.Sprintf("from_email = \"%s\"", fromEmail),
-					generateRoutingSignature(sigEnabled2, sigCannedRespId2, sigAlwaysIncl2, sigInclusionType2),
-				),
+				// Update signature to reference canned response 2
+				Config: domainConfig + libConfig + resp1Config + resp2Config +
+					GenerateRoutingEmailRouteResource(
+						routeResourceLabel,
+						"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
+						routePattern,
+						fromName,
+						fmt.Sprintf("from_email = \"%s\"", fromEmail),
+						generateRoutingSignature(
+							sigEnabled2,
+							"genesyscloud_responsemanagement_response."+resp2ResourceLabel+".id",
+							sigAlwaysIncl2,
+							sigInclusionType2,
+						),
+					),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.enabled", fmt.Sprintf("%t", sigEnabled2)),
-					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.canned_response_id", sigCannedRespId2),
+					resource.TestCheckResourceAttrPair("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.canned_response_id", "genesyscloud_responsemanagement_response."+resp2ResourceLabel, "id"),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.always_included", fmt.Sprintf("%t", sigAlwaysIncl2)),
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.inclusion_type", sigInclusionType2),
 				),
 			},
 			{
 				// Remove signature block entirely
-				Config: routingEmailDomain.GenerateRoutingEmailDomainResource(
-					domainResourceLabel,
-					domainId,
-					util.FalseValue,
-					util.NullValue,
-				) + GenerateRoutingEmailRouteResource(
-					routeResourceLabel,
-					"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
-					routePattern,
-					fromName,
-					fmt.Sprintf("from_email = \"%s\"", fromEmail),
-				),
+				Config: domainConfig + libConfig + resp1Config + resp2Config +
+					GenerateRoutingEmailRouteResource(
+						routeResourceLabel,
+						"genesyscloud_routing_email_domain."+domainResourceLabel+".id",
+						routePattern,
+						fromName,
+						fmt.Sprintf("from_email = \"%s\"", fromEmail),
+					),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "pattern", routePattern),
 					resource.TestCheckNoResourceAttr("genesyscloud_routing_email_route."+routeResourceLabel, "signature.0.enabled"),
@@ -424,17 +466,17 @@ func generateRoutingReplyEmail(
 
 func generateRoutingSignature(
 	enabled bool,
-	cannedResponseId string,
+	cannedResponseIdRef string,
 	alwaysIncluded bool,
 	inclusionType string) string {
 	return fmt.Sprintf(`
         signature {
             enabled            = %t
-            canned_response_id = "%s"
+            canned_response_id = %s
             always_included    = %t
             inclusion_type     = "%s"
         }
-	`, enabled, cannedResponseId, alwaysIncluded, inclusionType)
+	`, enabled, cannedResponseIdRef, alwaysIncluded, inclusionType)
 }
 
 func testVerifyRoutingEmailRouteDestroyed(state *terraform.State) error {

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_unit_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_unit_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
 )
 
@@ -58,4 +59,139 @@ func TestUnitGetAllRoutingEmailRoutes(t *testing.T) {
 	if len(resourceMap) > 0 {
 		t.Errorf("Expected resource map length to be 0, got %d", len(resourceMap))
 	}
+}
+
+// TestUnitBuildSignature verifies that buildSignature correctly maps Terraform state to the SDK struct
+func TestUnitBuildSignature(t *testing.T) {
+	t.Run("returns nil when signature block is absent", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, ResourceRoutingEmailRoute().Schema, map[string]interface{}{})
+		result := buildSignature(d)
+		if result != nil {
+			t.Errorf("expected nil, got %+v", result)
+		}
+	})
+
+	t.Run("maps all fields correctly", func(t *testing.T) {
+		cannedID := "canned-abc-123"
+		inclusionType := "Always"
+		d := schema.TestResourceDataRaw(t, ResourceRoutingEmailRoute().Schema, map[string]interface{}{
+			"signature": []interface{}{
+				map[string]interface{}{
+					"enabled":            true,
+					"canned_response_id": cannedID,
+					"always_included":    false,
+					"inclusion_type":     inclusionType,
+				},
+			},
+		})
+
+		result := buildSignature(d)
+		if result == nil {
+			t.Fatal("expected non-nil Signature, got nil")
+		}
+		if result.Enabled == nil || *result.Enabled != true {
+			t.Errorf("expected Enabled=true, got %v", result.Enabled)
+		}
+		if result.CannedResponseId == nil || *result.CannedResponseId != cannedID {
+			t.Errorf("expected CannedResponseId=%q, got %v", cannedID, result.CannedResponseId)
+		}
+		if result.AlwaysIncluded == nil || *result.AlwaysIncluded != false {
+			t.Errorf("expected AlwaysIncluded=false, got %v", result.AlwaysIncluded)
+		}
+		if result.InclusionType == nil || *result.InclusionType != inclusionType {
+			t.Errorf("expected InclusionType=%q, got %v", inclusionType, result.InclusionType)
+		}
+	})
+
+	t.Run("omits canned_response_id when empty string", func(t *testing.T) {
+		d := schema.TestResourceDataRaw(t, ResourceRoutingEmailRoute().Schema, map[string]interface{}{
+			"signature": []interface{}{
+				map[string]interface{}{
+					"enabled":            false,
+					"canned_response_id": "",
+					"always_included":    true,
+					"inclusion_type":     "",
+				},
+			},
+		})
+
+		result := buildSignature(d)
+		if result == nil {
+			t.Fatal("expected non-nil Signature, got nil")
+		}
+		if result.CannedResponseId != nil {
+			t.Errorf("expected CannedResponseId to be nil when empty, got %q", *result.CannedResponseId)
+		}
+		if result.InclusionType != nil {
+			t.Errorf("expected InclusionType to be nil when empty, got %q", *result.InclusionType)
+		}
+	})
+}
+
+// TestUnitFlattenSignature verifies that flattenSignature correctly maps the SDK struct to Terraform state
+func TestUnitFlattenSignature(t *testing.T) {
+	t.Run("returns nil when signature is nil", func(t *testing.T) {
+		result := flattenSignature(nil)
+		if result != nil {
+			t.Errorf("expected nil, got %+v", result)
+		}
+	})
+
+	t.Run("maps all fields correctly", func(t *testing.T) {
+		enabled := true
+		cannedID := "canned-xyz-456"
+		alwaysIncluded := false
+		inclusionType := "FirstResponseOnly"
+
+		sig := &platformclientv2.Signature{
+			Enabled:          &enabled,
+			CannedResponseId: &cannedID,
+			AlwaysIncluded:   &alwaysIncluded,
+			InclusionType:    &inclusionType,
+		}
+
+		result := flattenSignature(sig)
+		if len(result) != 1 {
+			t.Fatalf("expected slice of length 1, got %d", len(result))
+		}
+		sigMap, ok := result[0].(map[string]interface{})
+		if !ok {
+			t.Fatal("expected result[0] to be map[string]interface{}")
+		}
+		if sigMap["enabled"] != enabled {
+			t.Errorf("expected enabled=%v, got %v", enabled, sigMap["enabled"])
+		}
+		if sigMap["canned_response_id"] != cannedID {
+			t.Errorf("expected canned_response_id=%q, got %v", cannedID, sigMap["canned_response_id"])
+		}
+		if sigMap["always_included"] != alwaysIncluded {
+			t.Errorf("expected always_included=%v, got %v", alwaysIncluded, sigMap["always_included"])
+		}
+		if sigMap["inclusion_type"] != inclusionType {
+			t.Errorf("expected inclusion_type=%q, got %v", inclusionType, sigMap["inclusion_type"])
+		}
+	})
+
+	t.Run("handles partially nil fields", func(t *testing.T) {
+		enabled := false
+		sig := &platformclientv2.Signature{
+			Enabled: &enabled,
+			// CannedResponseId, AlwaysIncluded, InclusionType intentionally nil
+		}
+
+		result := flattenSignature(sig)
+		if len(result) != 1 {
+			t.Fatalf("expected slice of length 1, got %d", len(result))
+		}
+		sigMap := result[0].(map[string]interface{})
+		if sigMap["canned_response_id"] != nil {
+			t.Errorf("expected canned_response_id to be nil, got %v", sigMap["canned_response_id"])
+		}
+		if sigMap["always_included"] != nil {
+			t.Errorf("expected always_included to be nil, got %v", sigMap["always_included"])
+		}
+		if sigMap["inclusion_type"] != nil {
+			t.Errorf("expected inclusion_type to be nil, got %v", sigMap["inclusion_type"])
+		}
+	})
 }

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_utils.go
@@ -32,6 +32,7 @@ func getRoutingEmailRouteFromResourceData(d *schema.ResourceData) platformclient
 		Flow:      util.BuildSdkDomainEntityRef(d, "flow_id"),
 		AutoBcc:   buildAutoBccEmailAddresses(d),
 		SpamFlow:  util.BuildSdkDomainEntityRef(d, "spam_flow_id"),
+		Signature: buildSignature(d),
 	}
 
 	if d.Get("history_inclusion") != "" {
@@ -50,6 +51,28 @@ func buildFromEmail(d *schema.ResourceData) *string {
 		return platformclientv2.String(d.Get("from_email").(string))
 	}
 	return nil
+}
+
+func buildSignature(d *schema.ResourceData) *platformclientv2.Signature {
+	sigList := d.Get("signature").([]interface{})
+	if len(sigList) == 0 {
+		return nil
+	}
+	sigMap := sigList[0].(map[string]interface{})
+	signature := &platformclientv2.Signature{}
+	if v, ok := sigMap["enabled"].(bool); ok {
+		signature.Enabled = &v
+	}
+	if v, ok := sigMap["canned_response_id"].(string); ok && v != "" {
+		signature.CannedResponseId = &v
+	}
+	if v, ok := sigMap["always_included"].(bool); ok {
+		signature.AlwaysIncluded = &v
+	}
+	if v, ok := sigMap["inclusion_type"].(string); ok && v != "" {
+		signature.InclusionType = &v
+	}
+	return signature
 }
 
 func buildAutoBccEmailAddresses(d *schema.ResourceData) *[]platformclientv2.Emailaddress {
@@ -85,6 +108,18 @@ func buildReplyEmailAddress(domainID string, routeID string, pattern string) *pl
 }
 
 // Flatten Functions
+
+func flattenSignature(sig *platformclientv2.Signature) []interface{} {
+	if sig == nil {
+		return nil
+	}
+	sigMap := make(map[string]interface{})
+	resourcedata.SetMapValueIfNotNil(sigMap, "enabled", sig.Enabled)
+	resourcedata.SetMapValueIfNotNil(sigMap, "canned_response_id", sig.CannedResponseId)
+	resourcedata.SetMapValueIfNotNil(sigMap, "always_included", sig.AlwaysIncluded)
+	resourcedata.SetMapValueIfNotNil(sigMap, "inclusion_type", sig.InclusionType)
+	return []interface{}{sigMap}
+}
 
 func flattenAutoBccEmailAddress(emailAddress *[]platformclientv2.Emailaddress) []interface{} {
 	if len(*emailAddress) == 0 {


### PR DESCRIPTION
This PR fixes [POSTINO-4233](https://inindca.atlassian.net/browse/POSTINO-4233) ticket.
It updates the domain route configuration to include email signature info.
Schema is updated from the client lib data available:

> go doc github.com/mypurecloud/platform-client-sdk-go/v192/platformclientv2.Signature

```
package platformclientv2 // import "github.com/mypurecloud/platform-client-sdk-go/v192/platformclientv2"

type Signature struct {
        // SetFieldNames defines the list of fields to use for controlled JSON serialization
        SetFieldNames map[string]bool `json:"-"`
        // Enabled - A toggle to enable the signature on email send.
        Enabled *bool `json:"enabled,omitempty"`

        // CannedResponseId - The identifier referring to an email signature canned response.
        CannedResponseId *string `json:"cannedResponseId,omitempty"`

        // AlwaysIncluded - A toggle that defines if a signature is always included or only set on the first email in an email chain.
        AlwaysIncluded *bool `json:"alwaysIncluded,omitempty"`

        // InclusionType - The configuration to indicate when the signature of a conversation has to be included
        InclusionType *string `json:"inclusionType,omitempty"`
}
    Signature
```

- Added UTs
- Updated doc (`make docs`)
- Update existing example


[POSTINO-4233]: https://inindca.atlassian.net/browse/POSTINO-4233?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ