### PR TITLE
DEVTOOLING-1617: Add regression test for stable integration action ex…

### DIFF
--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -50,6 +50,12 @@ resource "genesyscloud_routing_email_route" "example_route" {
     name  = "Supervisors"
     email = "support_supervisors@${genesyscloud_routing_email_domain.example_domain_com.domain_id}"
   }
+  signature {
+    enabled            = false
+    canned_response_id = genesyscloud_responsemanagement_response.example_signature_response.id
+    always_included    = false
+    inclusion_type     = "FirstResponseOnly"
+  }
 }
 
 resource "genesyscloud_routing_email_route" "example_route_reference_other_route" {

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils_test.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 )
 
 func strPtr(s string) *string { return &s }
@@ -129,4 +130,72 @@ func TestBuildIntegrationActionBlockLabel(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestSameNameDifferentCategoryProducesStableDistinctLabels is a regression test for
+// the bug where two integration actions with the same name but different categories
+// would get non-deterministic labels on export, causing destructive plan changes.
+//
+// The fix includes the category in the BlockLabel so that same-named actions in
+// different categories never collide in the sanitizer.
+//
+// This test runs the full pipeline: buildIntegrationActionBlockLabel -> sanitizer,
+// and verifies the resulting labels are distinct AND stable across multiple iterations.
+func TestSameNameDifferentCategoryProducesStableDistinctLabels(t *testing.T) {
+	// Simulate two custom actions with the same name in different categories
+	actionProd := platformclientv2.Action{
+		Id:            strPtr("custom_-_aaaa-1111-bbbb-2222"),
+		Name:          strPtr("Log Call"),
+		Category:      strPtr("Navigator Data Actions - Production"),
+		IntegrationId: strPtr("integ-prod"),
+	}
+	actionStag := platformclientv2.Action{
+		Id:            strPtr("custom_-_cccc-3333-dddd-4444"),
+		Name:          strPtr("Log Call"),
+		Category:      strPtr("Navigator Data Actions - Staging"),
+		IntegrationId: strPtr("integ-stag"),
+	}
+
+	// Run 100 iterations to confirm labels never flip (the old bug was non-deterministic)
+	var firstLabelProd, firstLabelStag string
+
+	for i := 0; i < 100; i++ {
+		// Build labels the same way getAllIntegrationActions does
+		idMetaMap := resourceExporter.ResourceIDMetaMap{
+			*actionProd.Id: &resourceExporter.ResourceMeta{
+				BlockLabel: buildIntegrationActionBlockLabel(actionProd, nil),
+			},
+			*actionStag.Id: &resourceExporter.ResourceMeta{
+				BlockLabel: buildIntegrationActionBlockLabel(actionStag, nil),
+			},
+		}
+
+		// Run through the sanitizer (same as the exporter does)
+		sanitizer := resourceExporter.NewSanitizerProvider()
+		sanitizer.S.Sanitize(idMetaMap)
+
+		labelProd := idMetaMap[*actionProd.Id].BlockLabel
+		labelStag := idMetaMap[*actionStag.Id].BlockLabel
+
+		// Labels must be different
+		if labelProd == labelStag {
+			t.Fatalf("iteration %d: both actions got the same label %q — category not differentiating", i, labelProd)
+		}
+
+		// Labels must be stable across iterations
+		if i == 0 {
+			firstLabelProd = labelProd
+			firstLabelStag = labelStag
+		} else {
+			if labelProd != firstLabelProd {
+				t.Fatalf("iteration %d: Production label changed from %q to %q — labels are non-deterministic", i, firstLabelProd, labelProd)
+			}
+			if labelStag != firstLabelStag {
+				t.Fatalf("iteration %d: Staging label changed from %q to %q — labels are non-deterministic", i, firstLabelStag, labelStag)
+			}
+		}
+	}
+
+	t.Logf("Production label (stable across 100 runs): %s", firstLabelProd)
+	t.Logf("Staging label (stable across 100 runs):    %s", firstLabelStag)
 }

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
@@ -160,8 +160,8 @@ func readOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta inte
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "dynamic_contact_queueing_settings", campaign.DynamicContactQueueingSettings, flattenSettings)
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "dynamic_line_balancing_settings", campaign.DynamicLineBalancingSettings, flattenLineBalancingSettings)
 		if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
-            resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "diagnostics_settings", campaign.DiagnosticsSettings, flattenDiagnosticsSettings)
-        }
+			resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "diagnostics_settings", campaign.DiagnosticsSettings, flattenDiagnosticsSettings)
+		}
 		if campaign.SkillColumns != nil && len(*campaign.SkillColumns) > 0 {
 			_ = d.Set("skill_columns", *campaign.SkillColumns)
 		}

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_unit_test.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_unit_test.go
@@ -1,174 +1,174 @@
 package outbound_campaign
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-    "github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
-    "github.com/stretchr/testify/assert"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestUnitReadDiagnosticsSettingsOnlyForPowerAndPredictive verifies that diagnostics_settings
 // is only populated in state when the campaign's dialing mode is "power" or "predictive".
 // This tests the core conditional logic extracted from readOutboundCampaign.
 func TestUnitReadDiagnosticsSettingsOnlyForPowerAndPredictive(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    tests := []struct {
-        name                        string
-        dialingMode                 string
-        expectDiagnosticsSettingsSet bool
-    }{
-        {
-            name:                        "power mode should have diagnostics_settings",
-            dialingMode:                 "power",
-            expectDiagnosticsSettingsSet: true,
-        },
-        {
-            name:                        "predictive mode should have diagnostics_settings",
-            dialingMode:                 "predictive",
-            expectDiagnosticsSettingsSet: true,
-        },
-        {
-            name:                        "preview mode should NOT have diagnostics_settings",
-            dialingMode:                 "preview",
-            expectDiagnosticsSettingsSet: false,
-        },
-        {
-            name:                        "progressive mode should NOT have diagnostics_settings",
-            dialingMode:                 "progressive",
-            expectDiagnosticsSettingsSet: false,
-        },
-        {
-            name:                        "agentless mode should NOT have diagnostics_settings",
-            dialingMode:                 "agentless",
-            expectDiagnosticsSettingsSet: false,
-        },
-        {
-            name:                        "external mode should NOT have diagnostics_settings",
-            dialingMode:                 "external",
-            expectDiagnosticsSettingsSet: false,
-        },
-    }
+	tests := []struct {
+		name                         string
+		dialingMode                  string
+		expectDiagnosticsSettingsSet bool
+	}{
+		{
+			name:                         "power mode should have diagnostics_settings",
+			dialingMode:                  "power",
+			expectDiagnosticsSettingsSet: true,
+		},
+		{
+			name:                         "predictive mode should have diagnostics_settings",
+			dialingMode:                  "predictive",
+			expectDiagnosticsSettingsSet: true,
+		},
+		{
+			name:                         "preview mode should NOT have diagnostics_settings",
+			dialingMode:                  "preview",
+			expectDiagnosticsSettingsSet: false,
+		},
+		{
+			name:                         "progressive mode should NOT have diagnostics_settings",
+			dialingMode:                  "progressive",
+			expectDiagnosticsSettingsSet: false,
+		},
+		{
+			name:                         "agentless mode should NOT have diagnostics_settings",
+			dialingMode:                  "agentless",
+			expectDiagnosticsSettingsSet: false,
+		},
+		{
+			name:                         "external mode should NOT have diagnostics_settings",
+			dialingMode:                  "external",
+			expectDiagnosticsSettingsSet: false,
+		},
+	}
 
-    for _, tc := range tests {
-        tc := tc
-        t.Run(tc.name, func(t *testing.T) {
-            t.Parallel()
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-            // Build a campaign with DiagnosticsSettings always populated from the API
-            campaign := &platformclientv2.Campaign{
-                Id:             platformclientv2.String("test-campaign-id"),
-                Name:           platformclientv2.String("Test Campaign"),
-                DialingMode:    platformclientv2.String(tc.dialingMode),
-                CampaignStatus: platformclientv2.String("off"),
-                PhoneColumns: &[]platformclientv2.Phonecolumn{
-                    {ColumnName: platformclientv2.String("Cell")},
-                },
-                ContactList: &platformclientv2.Domainentityref{
-                    Id: platformclientv2.String("contact-list-id"),
-                },
-                DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
-                    ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
-                },
-            }
+			// Build a campaign with DiagnosticsSettings always populated from the API
+			campaign := &platformclientv2.Campaign{
+				Id:             platformclientv2.String("test-campaign-id"),
+				Name:           platformclientv2.String("Test Campaign"),
+				DialingMode:    platformclientv2.String(tc.dialingMode),
+				CampaignStatus: platformclientv2.String("off"),
+				PhoneColumns: &[]platformclientv2.Phonecolumn{
+					{ColumnName: platformclientv2.String("Cell")},
+				},
+				ContactList: &platformclientv2.Domainentityref{
+					Id: platformclientv2.String("contact-list-id"),
+				},
+				DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
+					ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
+				},
+			}
 
-            // Create ResourceData from the resource schema
-            resourceSchema := ResourceOutboundCampaign()
-            d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
-                "name":            "Test Campaign",
-                "dialing_mode":    tc.dialingMode,
-                "contact_list_id": "contact-list-id",
-                "phone_columns": []interface{}{
-                    map[string]interface{}{"column_name": "Cell"},
-                },
-            })
-            d.SetId("test-campaign-id")
+			// Create ResourceData from the resource schema
+			resourceSchema := ResourceOutboundCampaign()
+			d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
+				"name":            "Test Campaign",
+				"dialing_mode":    tc.dialingMode,
+				"contact_list_id": "contact-list-id",
+				"phone_columns": []interface{}{
+					map[string]interface{}{"column_name": "Cell"},
+				},
+			})
+			d.SetId("test-campaign-id")
 
-            // Replicate the conditional logic from readOutboundCampaign
-            if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
-                _ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
-            }
+			// Replicate the conditional logic from readOutboundCampaign
+			if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
+				_ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
+			}
 
-            // Verify the result
-            diagSettings := d.Get("diagnostics_settings").([]interface{})
-            if tc.expectDiagnosticsSettingsSet {
-                assert.Equal(t, 1, len(diagSettings),
-                    "diagnostics_settings should be set for %s mode", tc.dialingMode)
-                settingsMap := diagSettings[0].(map[string]interface{})
-                assert.Equal(t, true, settingsMap["report_low_max_calls_per_agent_alert"])
-            } else {
-                assert.Equal(t, 0, len(diagSettings),
-                    "diagnostics_settings should NOT be set for %s mode", tc.dialingMode)
-            }
-        })
-    }
+			// Verify the result
+			diagSettings := d.Get("diagnostics_settings").([]interface{})
+			if tc.expectDiagnosticsSettingsSet {
+				assert.Equal(t, 1, len(diagSettings),
+					"diagnostics_settings should be set for %s mode", tc.dialingMode)
+				settingsMap := diagSettings[0].(map[string]interface{})
+				assert.Equal(t, true, settingsMap["report_low_max_calls_per_agent_alert"])
+			} else {
+				assert.Equal(t, 0, len(diagSettings),
+					"diagnostics_settings should NOT be set for %s mode", tc.dialingMode)
+			}
+		})
+	}
 }
 
 // TestUnitDiagnosticsSettingsNilDialingMode verifies safe handling when DialingMode is nil
 func TestUnitDiagnosticsSettingsNilDialingMode(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    campaign := &platformclientv2.Campaign{
-        Id:             platformclientv2.String("test-campaign-id"),
-        Name:           platformclientv2.String("Test Campaign"),
-        DialingMode:    nil, // nil DialingMode
-        CampaignStatus: platformclientv2.String("off"),
-        DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
-            ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
-        },
-    }
+	campaign := &platformclientv2.Campaign{
+		Id:             platformclientv2.String("test-campaign-id"),
+		Name:           platformclientv2.String("Test Campaign"),
+		DialingMode:    nil, // nil DialingMode
+		CampaignStatus: platformclientv2.String("off"),
+		DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
+			ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
+		},
+	}
 
-    resourceSchema := ResourceOutboundCampaign()
-    d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
-        "name":            "Test Campaign",
-        "dialing_mode":    "power",
-        "contact_list_id": "contact-list-id",
-        "phone_columns": []interface{}{
-            map[string]interface{}{"column_name": "Cell"},
-        },
-    })
-    d.SetId("test-campaign-id")
+	resourceSchema := ResourceOutboundCampaign()
+	d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
+		"name":            "Test Campaign",
+		"dialing_mode":    "power",
+		"contact_list_id": "contact-list-id",
+		"phone_columns": []interface{}{
+			map[string]interface{}{"column_name": "Cell"},
+		},
+	})
+	d.SetId("test-campaign-id")
 
-    // Should not panic when DialingMode is nil
-    if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
-        _ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
-    }
+	// Should not panic when DialingMode is nil
+	if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
+		_ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
+	}
 
-    diagSettings := d.Get("diagnostics_settings").([]interface{})
-    assert.Equal(t, 0, len(diagSettings), "diagnostics_settings should NOT be set when DialingMode is nil")
+	diagSettings := d.Get("diagnostics_settings").([]interface{})
+	assert.Equal(t, 0, len(diagSettings), "diagnostics_settings should NOT be set when DialingMode is nil")
 }
 
 // TestUnitFlattenDiagnosticsSettingsNil verifies flattenDiagnosticsSettings handles nil safely
 func TestUnitFlattenDiagnosticsSettingsNil(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    result := flattenDiagnosticsSettings(nil)
-    assert.Nil(t, result, "flattenDiagnosticsSettings(nil) should return nil")
+	result := flattenDiagnosticsSettings(nil)
+	assert.Nil(t, result, "flattenDiagnosticsSettings(nil) should return nil")
 }
 
 // TestUnitBuildDiagnosticsSettings verifies building diagnostics settings from resource data
 func TestUnitBuildDiagnosticsSettings(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    t.Run("with settings", func(t *testing.T) {
-        input := []interface{}{
-            map[string]interface{}{
-                "report_low_max_calls_per_agent_alert": true,
-            },
-        }
-        result := buildDiagnosticsSettings(input)
-        assert.NotNil(t, result)
-        assert.Equal(t, true, *result.ReportLowMaxCallsPerAgentAlert)
-    })
+	t.Run("with settings", func(t *testing.T) {
+		input := []interface{}{
+			map[string]interface{}{
+				"report_low_max_calls_per_agent_alert": true,
+			},
+		}
+		result := buildDiagnosticsSettings(input)
+		assert.NotNil(t, result)
+		assert.Equal(t, true, *result.ReportLowMaxCallsPerAgentAlert)
+	})
 
-    t.Run("with empty list", func(t *testing.T) {
-        result := buildDiagnosticsSettings([]interface{}{})
-        assert.Nil(t, result)
-    })
+	t.Run("with empty list", func(t *testing.T) {
+		result := buildDiagnosticsSettings([]interface{}{})
+		assert.Nil(t, result)
+	})
 
-    t.Run("with nil", func(t *testing.T) {
-        result := buildDiagnosticsSettings(nil)
-        assert.Nil(t, result)
-    })
+	t.Run("with nil", func(t *testing.T) {
+		result := buildDiagnosticsSettings(nil)
+		assert.Nil(t, result)
+	})
 }


### PR DESCRIPTION
Title: DEVTOOLING-1617: Add regression test for stable integration action export labels

**Summary:**
Adds a regression test (TestSameNameDifferentCategoryProducesStableDistinctLabels) that verifies the fix for non-deterministic export labels when two integration actions share the same name but belong to different categories.

**Problem:**
In v1.75.1, the exporter used only action.Name as the BlockLabel. When two actions had the same name (e.g., "Log Call") in different categories, the sanitizer would randomly assign which one got the bare label vs a hash suffix — causing destructive plan changes on every export/apply cycle.

**Fix (already shipped):**
The BlockLabel now includes the category: category + "_" + name, ensuring same-named actions in different categories always produce distinct, stable labels.

**What this PR adds:**
A unit test that runs the full buildIntegrationActionBlockLabel → sanitizer pipeline 100 times and asserts:
Labels for same-named actions in different categories are always distinct
Labels are stable (identical across all iterations)

**Testing:**
go test -v -run TestSameNameDifferentCategoryProducesStableDistinctLabels ./genesyscloud/integration_action/
