### PR TITLE
NO-JIRA Retry export write functions that fail up to three times 

### DIFF
--- a/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_utils.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_architect_flow_utils.go
@@ -81,6 +81,7 @@ func architectFlowResolver(flowId, exportDirectory, subDirectory string, configM
 	ctx := context.Background()
 	filename := fmt.Sprintf("%s.yaml", flowId)
 
+	log.Printf("Retrieving flow '%s' for export to file", flowId)
 	flow, resp, err := proxy.GetFlow(ctx, flowId)
 	if err != nil {
 		log.Printf("Failed to read flow '%s'. Flow name and type will not be included in the file name. Error: %s. API Response: %s", flowId, err.Error(), resp)
@@ -101,6 +102,7 @@ func architectFlowResolver(flowId, exportDirectory, subDirectory string, configM
 		return fmt.Errorf("flow '%s' has no published version and cannot be exported", flowId)
 	}
 
+	log.Printf("Generating download URL for flow '%s' version '%s'", flowId, flowVersion)
 	downloadUrl, err := proxy.generateDownloadUrl(flowId, flowVersion)
 	if err != nil {
 		return err

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -879,12 +879,28 @@ func (g *GenesysCloudResourceExporter) customWriteAttributes(jsonResult util.Jso
 		if diagnostics.HasError() {
 			return
 		}
-		if err := resourceFilesWriterFunc(resource.State.ID, exportDir, exporters[resource.Type].CustomFileWriter.SubDirectory, jsonResult, g.meta, resource); err != nil {
-			tflog.Error(g.ctx, fmt.Sprintf("An error has occurred while trying invoking the RetrieveAndWriteFilesFunc for resource type %s and id %s: %v", resource.Type, resource.State.ID, err))
+
+		maxRetries := 3
+		var lastErr error
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			if err := resourceFilesWriterFunc(resource.State.ID, exportDir, exporters[resource.Type].CustomFileWriter.SubDirectory, jsonResult, g.meta, resource); err != nil {
+				lastErr = err
+				if attempt < maxRetries-1 {
+					backoff := time.Duration(1<<attempt) * time.Second
+					tflog.Warn(g.ctx, fmt.Sprintf("RetrieveAndWriteFilesFunc failed for resource type %s and id %s (attempt %d/%d). Retrying in %v. Error: %v", resource.Type, resource.State.ID, attempt+1, maxRetries, backoff, err))
+					time.Sleep(backoff)
+				}
+			} else {
+				lastErr = nil
+				break
+			}
+		}
+		if lastErr != nil {
+			tflog.Error(g.ctx, fmt.Sprintf("An error has occurred while trying invoking the RetrieveAndWriteFilesFunc for resource type %s and id %s after %d attempts: %v", resource.Type, resource.State.ID, maxRetries, lastErr))
 			diagnostics = append(diagnostics, diag.Diagnostic{
 				Severity: diag.Error,
 				Summary:  fmt.Sprintf("Failed to invoke %s custom resolver method.", resource.Type),
-				Detail:   err.Error(),
+				Detail:   lastErr.Error(),
 			})
 		}
 	}


### PR DESCRIPTION
Retry export write functions that fail up to three times to address transient issues that can crop up with Flow exports