### PR TITLE
Don't mark user prompts as computed when BCP is running

### DIFF
--- a/genesyscloud/architect_user_prompt/resource_architect_user_prompt_schema.go
+++ b/genesyscloud/architect_user_prompt/resource_architect_user_prompt_schema.go
@@ -11,6 +11,7 @@ import (
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	registrar "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_register"
 	architectlanguages "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/architectlanguages"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
@@ -116,7 +117,7 @@ func ResourceArchitectUserPrompt() *schema.Resource {
 				Description: "Audio of TTS resources for the audio prompt.",
 				Type:        schema.TypeSet,
 				Optional:    true,
-				Computed:    true,
+				Computed:    !feature_toggles.BcpModeEnabledExists(), // false if BCP mode running, otherwise true
 				ConfigMode:  schema.SchemaConfigModeAttr,
 				Elem:        userPromptResource,
 			},


### PR DESCRIPTION
### Problem

When exporting `genesyscloud_architect_user_prompt` resources, audio files are downloaded to the `audio_prompts/` subdirectory but the exported configuration never includes the `filename` or `file_content_hash` attributes pointing to those files.

### Root Cause

The `resources` attribute is marked `Computed: true` in the schema. During export, the exporter framework excludes computed attributes from the config map, then restores it as an empty array via `AllowEmptyArrays`. When `ArchitectPromptAudioResolver` runs afterward, it finds an empty resources array and returns early without updating the filenames — even though the audio files were successfully downloaded moments earlier.

### Fix

Make `Computed` conditional on the `BCP_MODE_ENABLED` environment variable.

- **Normal operation** (no env var): `Computed: true` — preserves existing behavior. Server-side resources that aren't in the user's config won't cause perpetual plan diffs.
- **BCP/export mode** (env var set): `Computed: false` — the exporter retains the `resources` array in the config map, allowing the resolver to update filenames correctly.

This is consistent with how `BCP_MODE_ENABLED` is already used elsewhere in the provider (e.g., relaxing phone number validation during export).

### Testing

- Verify export with `BCP_MODE_ENABLED=true` produces config with `filename` and `file_content_hash` referencing downloaded audio files
- Verify normal plan/apply without the env var behaves identically to before (no perpetual diffs for server-managed resources)
