### PR TITLE
Bug/devtooling 1721

### DIFF
--- a/docs/resources/routing_queue.md
+++ b/docs/resources/routing_queue.md
@@ -626,6 +626,7 @@ Optional:
 - `retry_delay_seconds` (Number) Delay in seconds between each retry of a customer first callback.
 - `service_level_duration_ms` (Number) Service Level target in milliseconds. Must be >= 1000
 - `service_level_percentage` (Number) The desired Service Level. A float value between 0 and 1.
+- `site_id` (String) The identifier of the site to be used for dialing; can be set in place of an edge group.
 
 
 <a id="nestedblock--media_settings_chat"></a>

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_schema.go
@@ -22,6 +22,7 @@ import (
 	routingWrapupcode "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_wrapupcode"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/scripts"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/team"
+	telephonyProvidersEdgesSite "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/telephony_providers_edges_site"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"
 )
 
@@ -266,6 +267,11 @@ var (
 				Type:         schema.TypeInt,
 				Optional:     true,
 				ValidateFunc: validation.IntBetween(60, 86400),
+			},
+			"site_id": {
+				Description: "The identifier of the site to be used for dialing; can be set in place of an edge group.",
+				Type:        schema.TypeString,
+				Optional:    true,
 			},
 		},
 	}
@@ -879,6 +885,7 @@ func RoutingQueueExporter() *resourceExporter.ResourceExporter {
 			"canned_response_libraries.library_ids":             {RefType: responseManagementLibrary.ResourceType},
 			"media_settings_callback.live_voice_flow_id":        {RefType: architectFlow.ResourceType},
 			"media_settings_callback.answering_machine_flow_id": {RefType: architectFlow.ResourceType},
+			"media_settings_callback.site_id":                   {RefType: telephonyProvidersEdgesSite.ResourceType},
 			"media_settings_message.inactivity_timeout_settings.flow_id":                {RefType: architectFlow.ResourceType},
 			"conditional_group_activation.pilot_rule.conditions.simple_metric.queue_id": {RefType: ResourceType},
 			"conditional_group_activation.rules.conditions.simple_metric.queue_id":      {RefType: ResourceType},

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
@@ -492,6 +492,40 @@ func TestUnitBuildSdkMediaSettingCallback(t *testing.T) {
 	}
 }
 
+// This test proves that the site_id field from the API is preserved through
+// the flatten (read) and build (write) round-trip.
+func TestUnitFlattenAndBuildCallbackSiteId(t *testing.T) {
+	siteId := "test-site-uuid-12345"
+
+	// Simulate what the API returns: callback settings with a Site reference
+	apiResponse := &platformclientv2.Callbackmediasettings{
+		AlertingTimeoutSeconds: platformclientv2.Int(30),
+		ServiceLevel: &platformclientv2.Servicelevel{
+			Percentage: platformclientv2.Float64(0.8),
+			DurationMs: platformclientv2.Int(20000),
+		},
+		EnableAutoAnswer: platformclientv2.Bool(false),
+		Mode:             platformclientv2.String("CustomerFirst"),
+		Site:             &platformclientv2.Domainentityref{Id: &siteId},
+	}
+
+	// FLATTEN: Simulate reading from API → Terraform state
+	flattened := flattenMediaSettingCallback(apiResponse)
+	assert.NotNil(t, flattened)
+	assert.Len(t, flattened, 1)
+
+	flatMap := flattened[0].(map[string]interface{})
+	flatSiteId, exists := flatMap["site_id"]
+	assert.True(t, exists, "site_id should exist in flattened callback settings")
+	assert.Equal(t, siteId, flatSiteId, "site_id should match the API value")
+
+	// BUILD: Simulate writing from Terraform state → API request
+	rebuilt := buildSdkMediaSettingCallback(flattened)
+	assert.NotNil(t, rebuilt)
+	assert.NotNil(t, rebuilt.Site, "Site should not be nil after round-trip")
+	assert.Equal(t, siteId, *rebuilt.Site.Id, "Site ID should survive the round-trip")
+}
+
 func buildRoutingQueueResourceMap(tId string, tName string, testRoutingQueue platformclientv2.Createqueuerequest) map[string]interface{} {
 	resourceDataMap := map[string]interface{}{
 		"id":                                tId,

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -291,6 +291,7 @@ func buildSdkMediaSettingCallback(settings []interface{}) *platformclientv2.Call
 	callbackSettings.AnsweringMachineFlow = util.GetNillableDomainEntityRefFromMap(settingsMap, "answering_machine_flow_id")
 	callbackSettings.MaxRetryCount = resourcedata.GetNillableValueFromMap[int](settingsMap, "max_retry_count", false)
 	callbackSettings.RetryDelaySeconds = resourcedata.GetNillableValueFromMap[int](settingsMap, "retry_delay_seconds", false)
+	callbackSettings.Site = util.GetNillableDomainEntityRefFromMap(settingsMap, "site_id")
 
 	return &callbackSettings
 }
@@ -864,6 +865,7 @@ func flattenMediaSettingCallback(settings *platformclientv2.Callbackmediasetting
 	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "answering_machine_flow_id", settings.AnsweringMachineFlow)
 	resourcedata.SetMapValueIfNotNil(settingsMap, "max_retry_count", settings.MaxRetryCount)
 	resourcedata.SetMapValueIfNotNil(settingsMap, "retry_delay_seconds", settings.RetryDelaySeconds)
+	resourcedata.SetMapReferenceValueIfNotNil(settingsMap, "site_id", settings.Site)
 
 	return []interface{}{settingsMap}
 }


### PR DESCRIPTION
Title: DEVTOOLING-1721: Add site_id to routing queue callback media settings

Description:

Summary
Exposes the site_id property in media_settings_callback for the genesyscloud_routing_queue resource. This field specifies which telephony site to use for outbound callback dialing (configurable on the Callback tab in the UI). The SDK already supported it but the provider never wired it up.

Changes
Added site_id schema field to queueCallbackMediaSettingsResource
Added flatten logic to read Site from API into Terraform state
Added build logic to send site_id from Terraform state to API
Added exporter RefAttr to resolve site references on export
Added unit test for round-trip (flatten → build) verification
Files Changed
resource_genesyscloud_routing_queue_schema.go
resource_genesyscloud_routing_queue_utils.go
resource_genesyscloud_routing_queue_unit_test.go
Testing
TestUnitFlattenAndBuildCallbackSiteId — passes
All existing routing queue unit tests — pass
Manual: terraform validate accepts site_id in media_settings_callback block