### PR TITLE
fix: updated sdk dependecies from 189 to 193

### DIFF
--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_create_unit_test.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_create_unit_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v188/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
+++ b/genesyscloud/business_rules_decision_table/resource_genesyscloud_business_rules_decision_table_unit_test.go
@@ -292,7 +292,7 @@ func TestUnitResourceBusinessRulesDecisionTableCreate(t *testing.T) {
 				Id: &tDivisionId,
 			},
 			Contract: &platformclientv2.Decisiontablecontract{
-				ParentSchema: &platformclientv2.Domainentityref{
+				ParentSchema: &platformclientv2.Businessrulesparentschemaref{
 					Id: &tSchemaId,
 				},
 			},
@@ -539,7 +539,7 @@ func TestUnitResourceBusinessRulesDecisionTableRead(t *testing.T) {
 				Id: &tDivisionId,
 			},
 			Contract: &platformclientv2.Decisiontablecontract{
-				ParentSchema: &platformclientv2.Domainentityref{
+				ParentSchema: &platformclientv2.Businessrulesparentschemaref{
 					Id: &tSchemaId,
 				},
 			},
@@ -838,7 +838,7 @@ func TestUnitResourceBusinessRulesDecisionTableUpdateNameDescription(t *testing.
 				Id: &tDivisionId,
 			},
 			Contract: &platformclientv2.Decisiontablecontract{
-				ParentSchema: &platformclientv2.Domainentityref{
+				ParentSchema: &platformclientv2.Businessrulesparentschemaref{
 					Id: &tSchemaId,
 				},
 			},
@@ -1007,7 +1007,7 @@ func TestUnitResourceBusinessRulesDecisionTableUpdateRows(t *testing.T) {
 				Id: &tDivisionId,
 			},
 			Contract: &platformclientv2.Decisiontablecontract{
-				ParentSchema: &platformclientv2.Domainentityref{
+				ParentSchema: &platformclientv2.Businessrulesparentschemaref{
 					Id: &tSchemaId,
 				},
 			},
@@ -1549,7 +1549,7 @@ func TestUnitResourceBusinessRulesDecisionTableUpdateRowFailureRollback(t *testi
 				Version: platformclientv2.Int(1),
 			},
 			PublishedContract: &platformclientv2.Decisiontablecontract{
-				ParentSchema: &platformclientv2.Domainentityref{
+				ParentSchema: &platformclientv2.Businessrulesparentschemaref{
 					Id: &tSchemaId,
 				},
 			},
@@ -1597,7 +1597,7 @@ func TestUnitResourceBusinessRulesDecisionTableUpdateRowFailureRollback(t *testi
 				Id: &tDivisionId,
 			},
 			Contract: &platformclientv2.Decisiontablecontract{
-				ParentSchema: &platformclientv2.Domainentityref{
+				ParentSchema: &platformclientv2.Businessrulesparentschemaref{
 					Id: &tSchemaId,
 				},
 			},

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_unit_test.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_unit_test.go
@@ -5,7 +5,7 @@ import (
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v192/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
 )
 
 // TestFlattenActionMapOpenAction verifies flattenActionMap sets open_action_fields.open_action


### PR DESCRIPTION
Title: Fix unit test SDK version mismatches breaking go vet

Description:

Summary
Unit tests in business_rules_decision_table and journey_action_map were importing outdated SDK versions, causing go vet to fail across the entire repo and blocking CI on all PRs.

Problem
business_rules_decision_table create test imported platform-client-sdk-go/v188 while the main code uses v193
business_rules_decision_table unit test used *Domainentityref for ParentSchema but v193 changed the type to *Businessrulesparentschemaref
journey_action_map unit test imported v192 while the main code uses v193
Fix
Updated SDK import versions to match the main code (v193)
Replaced Domainentityref → Businessrulesparentschemaref in 6 places where the struct type changed
Files Changed
resource_genesyscloud_business_rules_decision_table_create_unit_test.go
resource_genesyscloud_business_rules_decision_table_unit_test.go
resource_genesyscloud_journey_action_map_unit_test.go
Testing
go vet ./genesyscloud/... → clean
All unit tests in both packages pass