### PR TITLE
bug/LM-4688-DNC-entries-fix

### DIFF
--- a/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist.go
+++ b/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist.go
@@ -152,19 +152,27 @@ func updateOutboundDncList(ctx context.Context, d *schema.ResourceData, meta int
 			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update Outbound DNC list %s error: %s", name, updateErr), response)
 		}
 		if d.HasChange("entries") {
-			if outboundDncList.DncSourceType == nil || *outboundDncList.DncSourceType != "rds" {
-				return nil, util.BuildDiagnosticError(ResourceType, "Phone numbers can only be uploaded to internal DNC lists.", fmt.Errorf("phone numbers can only be uploaded to internal DNC Lists"))
-			}
+			// Only modify entries when the user explicitly included them in config.
+			// When entries is omitted (Computed), GetRawConfig returns a null value and
+			// we must not touch the API — otherwise we would wipe all phone numbers.
+			entriesConfigVal := d.GetRawConfig().GetAttr("entries")
+			if entriesConfigVal.IsNull() || !entriesConfigVal.IsKnown() {
+				// entries omitted from config — do not touch existing API entries
+			} else {
+				if outboundDncList.DncSourceType == nil || *outboundDncList.DncSourceType != "rds" {
+					return nil, util.BuildDiagnosticError(ResourceType, "Phone numbers can only be uploaded to internal DNC lists.", fmt.Errorf("phone numbers can only be uploaded to internal DNC Lists"))
+				}
 
-			resp, err := proxy.deleteOutboundDnclistPhoneEntries(ctx, d.Id(), false)
-			if err != nil {
-				return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to delete phone entries from Outbound DNC list %s error: %v", name, err), resp)
-			}
-
-			for _, entry := range entries {
-				resp, err := proxy.uploadPhoneEntriesToDncList(outboundDncList, entry)
+				resp, err := proxy.deleteOutboundDnclistPhoneEntries(ctx, d.Id(), false)
 				if err != nil {
-					return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update Outbound DNC list %s error: %v", name, err), resp)
+					return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to delete phone entries from Outbound DNC list %s error: %v", name, err), resp)
+				}
+
+				for _, entry := range entries {
+					resp, err := proxy.uploadPhoneEntriesToDncList(outboundDncList, entry)
+					if err != nil {
+						return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update Outbound DNC list %s error: %v", name, err), resp)
+					}
 				}
 			}
 		}

--- a/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_schema.go
+++ b/genesyscloud/outbound_dnclist/resource_genesyscloud_outbound_dnclist_schema.go
@@ -97,6 +97,7 @@ func ResourceOutboundDncList() *schema.Resource {
 			`entries`: {
 				Description: `Rows to add to the DNC list. To emulate removing phone numbers, you can set expiration_date to a date in the past.`,
 				Optional:    true,
+				Computed:    true,
 				Type:        schema.TypeList,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{


### PR DESCRIPTION
This PR focuses on this ticket:
https://inindca.atlassian.net/browse/LM-4688?atlOrigin=eyJpIjoiNDc2MGY3ODk1NmRhNGNiYzhmZWIyYjM4ZDhmMzkwMmYiLCJwIjoiaiJ9

Issue is when entries are not specified they are deleted from DNC. 
Added compute:true to mitigate that and logic to guard changes to entities if no value is provided.

I saw that this was mentioned in the comment in this PR but never implemented: 
https://github.com/MyPureCloud/terraform-provider-genesyscloud/commit/6ec087183
"Updated schema to mark 'entries' as computed."

