### PR TITLE
NO-JIRA - Reorder computed attribute exclusion checks on export for correctness

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -2103,19 +2103,21 @@ func (g *GenesysCloudResourceExporter) collectSchemaBasedExcludedAttributes(reso
 		if prefix != "" {
 			fullPath = prefix + "." + name
 		}
-		// Remove any computed attributes if export computed exporter config not set
-		if s.Computed == true && !g.exportComputed {
-			tflog.Debug(g.ctx, fmt.Sprintf("Marking the '%s' attribute to be excluded from the '%s' resource type export because it is a computed attribute", fullPath, resourceType))
-			excludedAttributes = append(excludedAttributes, fullPath)
-			continue
-		}
 		// Remove any computed read-only attributes from being exported regardless of exporter config
 		// because they cannot be set by a user when reapplying the configuration in a different org
 		if s.Computed == true && s.Optional == false {
-			tflog.Debug(g.ctx, fmt.Sprintf("Marking the '%s' attribute to be excluded from the '%s' resource type export because it is a computed attribute", fullPath, resourceType))
+			tflog.Debug(g.ctx, fmt.Sprintf("Marking the '%s' attribute to be excluded from the '%s' resource type export because it is a read-only computed attribute", fullPath, resourceType))
 			excludedAttributes = append(excludedAttributes, fullPath)
 			continue
 		}
+
+		// Remove any computed but optional attributes if export computed exporter config not set
+		if s.Computed == true && !g.exportComputed {
+			tflog.Debug(g.ctx, fmt.Sprintf("Marking the '%s' attribute to be excluded from the '%s' resource type export because it is a computed, but optional attribute and exclude_computed was set", fullPath, resourceType))
+			excludedAttributes = append(excludedAttributes, fullPath)
+			continue
+		}
+
 		// Remove deprecated attributes if export_deprecated is set to false
 		if s.Deprecated != "" && !g.exportDeprecated {
 			tflog.Debug(g.ctx, fmt.Sprintf("Marking the '%s' attribute to be excluded from the '%s' resource type export because it is a deprecated attribute", fullPath, resourceType))

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter_test.go
@@ -2121,6 +2121,81 @@ func TestUnitCollectSchemaBasedExcludedAttributes(t *testing.T) {
 			},
 			expected: []string{"routing.rules.internal_id", "routing.rules.old_weight", "routing.timeout"},
 		},
+		{
+			name:             "Read-only computed excluded before computed+optional check when exportComputed is false",
+			exportComputed:   false,
+			exportDeprecated: true,
+			schemaMap: map[string]*schema.Schema{
+				"read_only_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: false,
+				},
+				"computed_optional": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: true,
+				},
+				"normal": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+			expected: []string{"read_only_id", "computed_optional"},
+		},
+		{
+			name:             "Read-only computed excluded but computed+optional kept when exportComputed is true",
+			exportComputed:   true,
+			exportDeprecated: true,
+			schemaMap: map[string]*schema.Schema{
+				"read_only_id": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: false,
+				},
+				"computed_optional": {
+					Type:     schema.TypeString,
+					Computed: true,
+					Optional: true,
+				},
+				"normal": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+			},
+			expected: []string{"read_only_id"},
+		},
+		{
+			name:             "Nested read-only computed always excluded regardless of exportComputed",
+			exportComputed:   true,
+			exportDeprecated: true,
+			schemaMap: map[string]*schema.Schema{
+				"block": {
+					Type:     schema.TypeList,
+					Optional: true,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"server_id": {
+								Type:     schema.TypeString,
+								Computed: true,
+								Optional: false,
+							},
+							"default_value": {
+								Type:     schema.TypeString,
+								Computed: true,
+								Optional: true,
+							},
+							"user_value": {
+								Type:     schema.TypeString,
+								Optional: true,
+							},
+						},
+					},
+				},
+			},
+			// server_id is read-only computed (always excluded), default_value is computed+optional (kept when exportComputed=true)
+			expected: []string{"block.server_id"},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

Reorders the attribute exclusion logic in `collectSchemaBasedExcludedAttributes` so that read-only computed attributes are unconditionally excluded before checking the `exportComputed` configuration flag.

## Problem

The previous ordering checked `Computed && !exportComputed` first, which would match read-only attributes (Computed=true, Optional=false) when `exportComputed` was false. This caused:
- Since the log messages were the same, this was essentially a no-op, until you tried to determine which path was taken
- The `Computed && !Optional` check was only reachable when `exportComputed=true`

## Change

Swapped the order of the two checks:
1. **First:** `Computed && !Optional` — always exclude read-only computed attributes
2. **Second:** `Computed && !exportComputed` — exclude computed+optional attributes only when the config says to
3. Added distinct logs to ensure the correct path could be traced

No behavioral change — the same set of attributes is excluded for all input combinations.

## Testing

Added 3 unit tests to `TestUnitCollectSchemaBasedExcludedAttributes`:
- Read-only computed excluded alongside computed+optional when `exportComputed=false`
- Read-only computed excluded but computed+optional kept when `exportComputed=true`
- Nested read-only computed always excluded regardless of `exportComputed`
