### PR TITLE
[No Jira] Bug Fixes and MRMO Improvements

### DIFF
--- a/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
+++ b/genesyscloud/telephony_providers_edges_phone/resource_genesyscloud_telephony_providers_edges_phone.go
@@ -108,15 +108,15 @@ func readPhone(ctx context.Context, d *schema.ResourceData, meta interface{}) di
 			_ = d.Set("state", *currentPhone.State)
 		}
 
-		if currentPhone.LineBaseSettings != nil {
+		if currentPhone.LineBaseSettings != nil && currentPhone.LineBaseSettings.Id != nil {
 			_ = d.Set("line_base_settings_id", *currentPhone.LineBaseSettings.Id)
 		}
 
-		if currentPhone.PhoneMetaBase != nil {
+		if currentPhone.PhoneMetaBase != nil && currentPhone.PhoneMetaBase.Id != nil {
 			_ = d.Set("phone_meta_base_id", *currentPhone.PhoneMetaBase.Id)
 		}
 
-		if currentPhone.WebRtcUser != nil {
+		if currentPhone.WebRtcUser != nil && currentPhone.WebRtcUser.Id != nil {
 			_ = d.Set("web_rtc_user_id", *currentPhone.WebRtcUser.Id)
 		}
 

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -126,21 +126,22 @@ type GenesysCloudResourceExporter struct {
 
 	// 4-byte alignment
 	// .. Mutex
-	buildSecondDepsMutex       sync.RWMutex
-	cyclicDependsListMutex     sync.Mutex
-	dataSourceTypesMapsMutex   sync.RWMutex
-	dependsListMutex           sync.RWMutex
-	exMutex                    sync.RWMutex
-	exportersMutex             sync.RWMutex
-	filterListMutex            sync.RWMutex
-	flowResourcesListMutex     sync.RWMutex
-	replaceWithDatasourceMutex sync.Mutex
-	resourceErrorsMutex        sync.RWMutex
-	resourcesMutex             sync.Mutex
-	resourceStateMutex         sync.Mutex
-	resourceTypesMapsMutex     sync.RWMutex
-	unresolvedAttrsMutex       sync.Mutex
-	attributesDecodedMutex     sync.Mutex
+	buildSecondDepsMutex          sync.RWMutex
+	cyclicDependsListMutex        sync.Mutex
+	dataSourceTypesMapsMutex      sync.RWMutex
+	dependsListMutex              sync.RWMutex
+	exMutex                       sync.RWMutex
+	exportersMutex                sync.RWMutex
+	filterListMutex               sync.RWMutex
+	flowResourcesListMutex        sync.RWMutex
+	replaceWithDatasourceMutex    sync.Mutex
+	resourceErrorsMutex           sync.RWMutex
+	resourcesExportedForMrMoMutex sync.Mutex
+	resourcesMutex                sync.Mutex
+	resourceStateMutex            sync.Mutex
+	resourceTypesMapsMutex        sync.RWMutex
+	unresolvedAttrsMutex          sync.Mutex
+	attributesDecodedMutex        sync.Mutex
 
 	// .. Int
 	maxConcurrentOps int // New field to control concurrency
@@ -224,6 +225,7 @@ func NewGenesysCloudResourceExporter(ctx context.Context, d *schema.ResourceData
 		ctx:                      ctx,
 		meta:                     meta,
 		maxConcurrentOps:         d.Get("max_concurrent_threads").(int), // Default to 10 concurrent operations
+		resourceErrors:           make(map[string][]ResourceErrorInfo),
 	}
 
 	// Only fall back to provider's MaxClients if max_concurrent_threads was not explicitly set
@@ -280,6 +282,7 @@ func NewThreadSafeGenesysCloudResourceExporter(d *schema.ResourceData, ctx conte
 		exportComputed:           d.Get("export_computed").(bool),
 		exportOmitUnresolvedRefs: d.Get("export_omit_unresolved_refs").(bool),
 		maxConcurrentOps:         10, // Default to 10 concurrent operations
+		resourceErrors:           make(map[string][]ResourceErrorInfo),
 	}
 
 	// Set max concurrent operations based on configuration if available
@@ -2168,15 +2171,7 @@ func (g *GenesysCloudResourceExporter) getResourceState(ctx context.Context, res
 	}
 
 	if mrmo.IsActive() {
-		g.resourceExportedForMrMo = resource.Data(state)
-		if g.resourcesExportedForMrMo == nil {
-			tmp := make(map[string][]*schema.ResourceData, 0)
-			g.resourcesExportedForMrMo = &tmp
-		}
-		if (*g.resourcesExportedForMrMo)[resType] == nil {
-			(*g.resourcesExportedForMrMo)[resType] = make([]*schema.ResourceData, 0)
-		}
-		(*g.resourcesExportedForMrMo)[resType] = append((*g.resourcesExportedForMrMo)[resType], resource.Data(state))
+		g.recordMrMoResourceExport(resType, resource.Data(state))
 	}
 
 	tflog.Debug(g.ctx, fmt.Sprintf("Successfully retrieved state for resource %s with ID: %s", resID, state.ID))
@@ -2931,6 +2926,37 @@ func (g *GenesysCloudResourceExporter) matchesExportFormat(formats ...string) bo
 		}
 	}
 	return false
+}
+
+// recordMrMoResourceExport appends refreshed resource state for MRMO export-by-type.
+// getResourcesForType invokes getResourceState concurrently per instance, so writes
+// to the shared MRMO export maps must be serialized.
+func (g *GenesysCloudResourceExporter) recordMrMoResourceExport(resType string, resourceData *schema.ResourceData) {
+	g.resourcesExportedForMrMoMutex.Lock()
+	defer g.resourcesExportedForMrMoMutex.Unlock()
+
+	g.resourceExportedForMrMo = resourceData
+	if g.resourcesExportedForMrMo == nil {
+		tmp := make(map[string][]*schema.ResourceData)
+		g.resourcesExportedForMrMo = &tmp
+	}
+	if (*g.resourcesExportedForMrMo)[resType] == nil {
+		(*g.resourcesExportedForMrMo)[resType] = make([]*schema.ResourceData, 0)
+	}
+	(*g.resourcesExportedForMrMo)[resType] = append((*g.resourcesExportedForMrMo)[resType], resourceData)
+}
+
+func (g *GenesysCloudResourceExporter) mrMoResourceDataList(resType string) []*schema.ResourceData {
+	g.resourcesExportedForMrMoMutex.Lock()
+	defer g.resourcesExportedForMrMoMutex.Unlock()
+
+	if g.resourcesExportedForMrMo == nil {
+		return make([]*schema.ResourceData, 0)
+	}
+	if list := (*g.resourcesExportedForMrMo)[resType]; list != nil {
+		return list
+	}
+	return make([]*schema.ResourceData, 0)
 }
 
 // Helper methods for thread-safe access to shared state

--- a/genesyscloud/tfexporter/mr_mo_concurrency_test.go
+++ b/genesyscloud/tfexporter/mr_mo_concurrency_test.go
@@ -1,0 +1,91 @@
+package tfexporter
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/mrmo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestConcurrentMrMoResourceExportWrites(t *testing.T) {
+	t.Setenv(mrmo.MRMO_CXASCODE_INTEGRATION_ENABLED, "true")
+	t.Cleanup(mrmo.Reset)
+
+	const (
+		workers    = 50
+		resType    = "genesyscloud_auth_division"
+		iterations = 3
+	)
+
+	exporter := &GenesysCloudResourceExporter{}
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for worker := 0; worker < workers; worker++ {
+		go func(worker int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				id := worker*iterations + i
+				resourceData := &schema.ResourceData{}
+				resourceData.SetId(string(rune('a' + (id % 26))))
+				exporter.recordMrMoResourceExport(resType, resourceData)
+			}
+		}(worker)
+	}
+
+	wg.Wait()
+
+	list := exporter.mrMoResourceDataList(resType)
+	assert.Len(t, list, workers*iterations)
+}
+
+func TestMrMoResourceExportWritesAreSafeAcrossResourceTypes(t *testing.T) {
+	t.Setenv(mrmo.MRMO_CXASCODE_INTEGRATION_ENABLED, "true")
+	t.Cleanup(mrmo.Reset)
+
+	exporter := &GenesysCloudResourceExporter{}
+	resourceTypes := []string{
+		"genesyscloud_auth_division",
+		"genesyscloud_knowledge_knowledgebase",
+		"genesyscloud_telephony_providers_edges_phone",
+	}
+
+	const workers = 20
+	var wg sync.WaitGroup
+	wg.Add(workers * len(resourceTypes))
+
+	for _, resType := range resourceTypes {
+		for worker := 0; worker < workers; worker++ {
+			go func(resType string, worker int) {
+				defer wg.Done()
+				resourceData := &schema.ResourceData{}
+				resourceData.SetId(string(rune('A'+worker%26)) + resType)
+				exporter.recordMrMoResourceExport(resType, resourceData)
+			}(resType, worker)
+		}
+	}
+
+	wg.Wait()
+
+	for _, resType := range resourceTypes {
+		assert.Len(t, exporter.mrMoResourceDataList(resType), workers)
+	}
+}
+
+func TestNewGenesysCloudResourceExporterInitializesResourceErrors(t *testing.T) {
+	exporter := &GenesysCloudResourceExporter{
+		resourceErrors: make(map[string][]ResourceErrorInfo),
+	}
+
+	require.NotNil(t, exporter.resourceErrors)
+	exporter.resourceErrorsMutex.Lock()
+	exporter.resourceErrors["genesyscloud_knowledge_knowledgebase"] = []ResourceErrorInfo{
+		{ResourceID: "kb-1", ErrorMessage: "test"},
+	}
+	exporter.resourceErrorsMutex.Unlock()
+
+	assert.Len(t, exporter.resourceErrors["genesyscloud_knowledge_knowledgebase"], 1)
+}

--- a/genesyscloud/tfexporter/mr_mo_utils.go
+++ b/genesyscloud/tfexporter/mr_mo_utils.go
@@ -277,12 +277,7 @@ func (g *GenesysCloudResourceExporter) ExportByTypeForMrMo(resType string, gener
 		}
 	}
 
-	var resourceDataList []*schema.ResourceData
-	if g.resourcesExportedForMrMo == nil {
-		resourceDataList = make([]*schema.ResourceData, 0)
-	} else {
-		resourceDataList = (*g.resourcesExportedForMrMo)[resType]
-	}
+	resourceDataList := g.mrMoResourceDataList(resType)
 
 	return &MrMoExportByTypeResponse{
 		Config: util.JsonMap{


### PR DESCRIPTION
Added `resourcesExportedForMrMoMutex` as `getResourceState` wrote to `resourcesExportedForMrMo` and `resourceExportedForMrMo` with no synchronization.

Initialized `resourceErrors` in `NewGenesysCloudResourceExporter` and `NewThreadSafeGenesysCloudResourceExporter` as it was only initialized in Export()

Fixed nil pointer in telephony phone export