### PR TITLE
Fix stale routing_email_route docs and gofmt drift on dev

### DIFF
--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -50,6 +50,12 @@ resource "genesyscloud_routing_email_route" "example_route" {
     name  = "Supervisors"
     email = "support_supervisors@${genesyscloud_routing_email_domain.example_domain_com.domain_id}"
   }
+  signature {
+    enabled            = false
+    canned_response_id = genesyscloud_responsemanagement_response.example_signature_response.id
+    always_included    = false
+    inclusion_type     = "Send"
+  }
 }
 
 resource "genesyscloud_routing_email_route" "example_route_reference_other_route" {

--- a/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
+++ b/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
@@ -28,7 +28,7 @@ func runDataJourneyActionMapTestCase(t *testing.T, testCaseName string) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
-		Steps: generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
+		Steps:             generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
 	})
 }
 

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign.go
@@ -160,8 +160,8 @@ func readOutboundCampaign(ctx context.Context, d *schema.ResourceData, meta inte
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "dynamic_contact_queueing_settings", campaign.DynamicContactQueueingSettings, flattenSettings)
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "dynamic_line_balancing_settings", campaign.DynamicLineBalancingSettings, flattenLineBalancingSettings)
 		if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
-            resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "diagnostics_settings", campaign.DiagnosticsSettings, flattenDiagnosticsSettings)
-        }
+			resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "diagnostics_settings", campaign.DiagnosticsSettings, flattenDiagnosticsSettings)
+		}
 		if campaign.SkillColumns != nil && len(*campaign.SkillColumns) > 0 {
 			_ = d.Set("skill_columns", *campaign.SkillColumns)
 		}

--- a/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_unit_test.go
+++ b/genesyscloud/outbound_campaign/resource_genesyscloud_outbound_campaign_unit_test.go
@@ -1,174 +1,174 @@
 package outbound_campaign
 
 import (
-    "testing"
+	"testing"
 
-    "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-    "github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
-    "github.com/stretchr/testify/assert"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestUnitReadDiagnosticsSettingsOnlyForPowerAndPredictive verifies that diagnostics_settings
 // is only populated in state when the campaign's dialing mode is "power" or "predictive".
 // This tests the core conditional logic extracted from readOutboundCampaign.
 func TestUnitReadDiagnosticsSettingsOnlyForPowerAndPredictive(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    tests := []struct {
-        name                        string
-        dialingMode                 string
-        expectDiagnosticsSettingsSet bool
-    }{
-        {
-            name:                        "power mode should have diagnostics_settings",
-            dialingMode:                 "power",
-            expectDiagnosticsSettingsSet: true,
-        },
-        {
-            name:                        "predictive mode should have diagnostics_settings",
-            dialingMode:                 "predictive",
-            expectDiagnosticsSettingsSet: true,
-        },
-        {
-            name:                        "preview mode should NOT have diagnostics_settings",
-            dialingMode:                 "preview",
-            expectDiagnosticsSettingsSet: false,
-        },
-        {
-            name:                        "progressive mode should NOT have diagnostics_settings",
-            dialingMode:                 "progressive",
-            expectDiagnosticsSettingsSet: false,
-        },
-        {
-            name:                        "agentless mode should NOT have diagnostics_settings",
-            dialingMode:                 "agentless",
-            expectDiagnosticsSettingsSet: false,
-        },
-        {
-            name:                        "external mode should NOT have diagnostics_settings",
-            dialingMode:                 "external",
-            expectDiagnosticsSettingsSet: false,
-        },
-    }
+	tests := []struct {
+		name                         string
+		dialingMode                  string
+		expectDiagnosticsSettingsSet bool
+	}{
+		{
+			name:                         "power mode should have diagnostics_settings",
+			dialingMode:                  "power",
+			expectDiagnosticsSettingsSet: true,
+		},
+		{
+			name:                         "predictive mode should have diagnostics_settings",
+			dialingMode:                  "predictive",
+			expectDiagnosticsSettingsSet: true,
+		},
+		{
+			name:                         "preview mode should NOT have diagnostics_settings",
+			dialingMode:                  "preview",
+			expectDiagnosticsSettingsSet: false,
+		},
+		{
+			name:                         "progressive mode should NOT have diagnostics_settings",
+			dialingMode:                  "progressive",
+			expectDiagnosticsSettingsSet: false,
+		},
+		{
+			name:                         "agentless mode should NOT have diagnostics_settings",
+			dialingMode:                  "agentless",
+			expectDiagnosticsSettingsSet: false,
+		},
+		{
+			name:                         "external mode should NOT have diagnostics_settings",
+			dialingMode:                  "external",
+			expectDiagnosticsSettingsSet: false,
+		},
+	}
 
-    for _, tc := range tests {
-        tc := tc
-        t.Run(tc.name, func(t *testing.T) {
-            t.Parallel()
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
 
-            // Build a campaign with DiagnosticsSettings always populated from the API
-            campaign := &platformclientv2.Campaign{
-                Id:             platformclientv2.String("test-campaign-id"),
-                Name:           platformclientv2.String("Test Campaign"),
-                DialingMode:    platformclientv2.String(tc.dialingMode),
-                CampaignStatus: platformclientv2.String("off"),
-                PhoneColumns: &[]platformclientv2.Phonecolumn{
-                    {ColumnName: platformclientv2.String("Cell")},
-                },
-                ContactList: &platformclientv2.Domainentityref{
-                    Id: platformclientv2.String("contact-list-id"),
-                },
-                DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
-                    ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
-                },
-            }
+			// Build a campaign with DiagnosticsSettings always populated from the API
+			campaign := &platformclientv2.Campaign{
+				Id:             platformclientv2.String("test-campaign-id"),
+				Name:           platformclientv2.String("Test Campaign"),
+				DialingMode:    platformclientv2.String(tc.dialingMode),
+				CampaignStatus: platformclientv2.String("off"),
+				PhoneColumns: &[]platformclientv2.Phonecolumn{
+					{ColumnName: platformclientv2.String("Cell")},
+				},
+				ContactList: &platformclientv2.Domainentityref{
+					Id: platformclientv2.String("contact-list-id"),
+				},
+				DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
+					ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
+				},
+			}
 
-            // Create ResourceData from the resource schema
-            resourceSchema := ResourceOutboundCampaign()
-            d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
-                "name":            "Test Campaign",
-                "dialing_mode":    tc.dialingMode,
-                "contact_list_id": "contact-list-id",
-                "phone_columns": []interface{}{
-                    map[string]interface{}{"column_name": "Cell"},
-                },
-            })
-            d.SetId("test-campaign-id")
+			// Create ResourceData from the resource schema
+			resourceSchema := ResourceOutboundCampaign()
+			d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
+				"name":            "Test Campaign",
+				"dialing_mode":    tc.dialingMode,
+				"contact_list_id": "contact-list-id",
+				"phone_columns": []interface{}{
+					map[string]interface{}{"column_name": "Cell"},
+				},
+			})
+			d.SetId("test-campaign-id")
 
-            // Replicate the conditional logic from readOutboundCampaign
-            if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
-                _ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
-            }
+			// Replicate the conditional logic from readOutboundCampaign
+			if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
+				_ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
+			}
 
-            // Verify the result
-            diagSettings := d.Get("diagnostics_settings").([]interface{})
-            if tc.expectDiagnosticsSettingsSet {
-                assert.Equal(t, 1, len(diagSettings),
-                    "diagnostics_settings should be set for %s mode", tc.dialingMode)
-                settingsMap := diagSettings[0].(map[string]interface{})
-                assert.Equal(t, true, settingsMap["report_low_max_calls_per_agent_alert"])
-            } else {
-                assert.Equal(t, 0, len(diagSettings),
-                    "diagnostics_settings should NOT be set for %s mode", tc.dialingMode)
-            }
-        })
-    }
+			// Verify the result
+			diagSettings := d.Get("diagnostics_settings").([]interface{})
+			if tc.expectDiagnosticsSettingsSet {
+				assert.Equal(t, 1, len(diagSettings),
+					"diagnostics_settings should be set for %s mode", tc.dialingMode)
+				settingsMap := diagSettings[0].(map[string]interface{})
+				assert.Equal(t, true, settingsMap["report_low_max_calls_per_agent_alert"])
+			} else {
+				assert.Equal(t, 0, len(diagSettings),
+					"diagnostics_settings should NOT be set for %s mode", tc.dialingMode)
+			}
+		})
+	}
 }
 
 // TestUnitDiagnosticsSettingsNilDialingMode verifies safe handling when DialingMode is nil
 func TestUnitDiagnosticsSettingsNilDialingMode(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    campaign := &platformclientv2.Campaign{
-        Id:             platformclientv2.String("test-campaign-id"),
-        Name:           platformclientv2.String("Test Campaign"),
-        DialingMode:    nil, // nil DialingMode
-        CampaignStatus: platformclientv2.String("off"),
-        DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
-            ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
-        },
-    }
+	campaign := &platformclientv2.Campaign{
+		Id:             platformclientv2.String("test-campaign-id"),
+		Name:           platformclientv2.String("Test Campaign"),
+		DialingMode:    nil, // nil DialingMode
+		CampaignStatus: platformclientv2.String("off"),
+		DiagnosticsSettings: &platformclientv2.Diagnosticssettings{
+			ReportLowMaxCallsPerAgentAlert: platformclientv2.Bool(true),
+		},
+	}
 
-    resourceSchema := ResourceOutboundCampaign()
-    d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
-        "name":            "Test Campaign",
-        "dialing_mode":    "power",
-        "contact_list_id": "contact-list-id",
-        "phone_columns": []interface{}{
-            map[string]interface{}{"column_name": "Cell"},
-        },
-    })
-    d.SetId("test-campaign-id")
+	resourceSchema := ResourceOutboundCampaign()
+	d := schema.TestResourceDataRaw(t, resourceSchema.Schema, map[string]interface{}{
+		"name":            "Test Campaign",
+		"dialing_mode":    "power",
+		"contact_list_id": "contact-list-id",
+		"phone_columns": []interface{}{
+			map[string]interface{}{"column_name": "Cell"},
+		},
+	})
+	d.SetId("test-campaign-id")
 
-    // Should not panic when DialingMode is nil
-    if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
-        _ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
-    }
+	// Should not panic when DialingMode is nil
+	if campaign.DialingMode != nil && (*campaign.DialingMode == "power" || *campaign.DialingMode == "predictive") {
+		_ = d.Set("diagnostics_settings", flattenDiagnosticsSettings(campaign.DiagnosticsSettings))
+	}
 
-    diagSettings := d.Get("diagnostics_settings").([]interface{})
-    assert.Equal(t, 0, len(diagSettings), "diagnostics_settings should NOT be set when DialingMode is nil")
+	diagSettings := d.Get("diagnostics_settings").([]interface{})
+	assert.Equal(t, 0, len(diagSettings), "diagnostics_settings should NOT be set when DialingMode is nil")
 }
 
 // TestUnitFlattenDiagnosticsSettingsNil verifies flattenDiagnosticsSettings handles nil safely
 func TestUnitFlattenDiagnosticsSettingsNil(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    result := flattenDiagnosticsSettings(nil)
-    assert.Nil(t, result, "flattenDiagnosticsSettings(nil) should return nil")
+	result := flattenDiagnosticsSettings(nil)
+	assert.Nil(t, result, "flattenDiagnosticsSettings(nil) should return nil")
 }
 
 // TestUnitBuildDiagnosticsSettings verifies building diagnostics settings from resource data
 func TestUnitBuildDiagnosticsSettings(t *testing.T) {
-    t.Parallel()
+	t.Parallel()
 
-    t.Run("with settings", func(t *testing.T) {
-        input := []interface{}{
-            map[string]interface{}{
-                "report_low_max_calls_per_agent_alert": true,
-            },
-        }
-        result := buildDiagnosticsSettings(input)
-        assert.NotNil(t, result)
-        assert.Equal(t, true, *result.ReportLowMaxCallsPerAgentAlert)
-    })
+	t.Run("with settings", func(t *testing.T) {
+		input := []interface{}{
+			map[string]interface{}{
+				"report_low_max_calls_per_agent_alert": true,
+			},
+		}
+		result := buildDiagnosticsSettings(input)
+		assert.NotNil(t, result)
+		assert.Equal(t, true, *result.ReportLowMaxCallsPerAgentAlert)
+	})
 
-    t.Run("with empty list", func(t *testing.T) {
-        result := buildDiagnosticsSettings([]interface{}{})
-        assert.Nil(t, result)
-    })
+	t.Run("with empty list", func(t *testing.T) {
+		result := buildDiagnosticsSettings([]interface{}{})
+		assert.Nil(t, result)
+	})
 
-    t.Run("with nil", func(t *testing.T) {
-        result := buildDiagnosticsSettings(nil)
-        assert.Nil(t, result)
-    })
+	t.Run("with nil", func(t *testing.T) {
+		result := buildDiagnosticsSettings(nil)
+		assert.Nil(t, result)
+	})
 }

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -321,10 +321,10 @@ func TestAccResourceRoutingEmailRouteSignature(t *testing.T) {
 		resp1ResourceLabel,
 		resp1Name,
 		[]string{"genesyscloud_responsemanagement_library." + libResourceLabel + ".id"},
-		util.NullValue,        // interaction_type
-		util.NullValue,        // substitutions_schema_id
-		`"Footer"`,            // response_type
-		[]string{},            // asset_ids
+		util.NullValue, // interaction_type
+		util.NullValue, // substitutions_schema_id
+		`"Footer"`,     // response_type
+		[]string{},     // asset_ids
 		responsemanagementResponse.GenerateTextsBlock("Email signature one", "text/plain", util.NullValue),
 		`footer { type = "Signature" }`,
 	)


### PR DESCRIPTION
## Summary
- Update `docs/resources/routing_email_route.md` so the generated example includes the `signature` block from `examples/resources/genesyscloud_routing_email_route/resource.tf` (example updated in #2430, docs were not regenerated).
- Apply `go fmt` to four files that fail the Fmt step in Go Checks on current `dev`.
## Context
Go Checks currently fails on `dev` at:
1. **Generate** — `docs/resources/routing_email_route.md` out of date
2. **Fmt** — journey_action_map test, outbound_campaign (+ unit test), routing_email_route test
This is unrelated to feature work; it restores CI hygiene on `dev`.
## Test plan
- [x] `go generate` — no diff
- [x] `go mod tidy` — no diff
- [x] `go fmt ./genesyscloud/...` — no diff
- [x] Go Checks green on fork branch