### PR TITLE
SQUONK-968 add video chat channels resources

### DIFF
--- a/docs/resources/webdeployments_configuration.md
+++ b/docs/resources/webdeployments_configuration.md
@@ -133,7 +133,8 @@ resource "genesyscloud_webdeployments_configuration" "example_configuration" {
     }
   }
   video {
-    enabled = true
+    enabled  = true
+    channels = ["Webmessaging", "Voice"]
     agent {
       allow_camera       = true
       allow_screen_share = true
@@ -666,6 +667,7 @@ Required:
 Optional:
 
 - `agent` (Block List, Max: 1) Video Settings for agent (see [below for nested schema](#nestedblock--video--agent))
+- `channels` (List of String) List of channels through which video chat is available
 - `enabled` (Boolean) Whether or not video is enabled
 - `user` (Block List, Max: 1) Video Settings for user (see [below for nested schema](#nestedblock--video--user))
 

--- a/examples/resources/genesyscloud_webdeployments_configuration/resource.tf
+++ b/examples/resources/genesyscloud_webdeployments_configuration/resource.tf
@@ -90,7 +90,8 @@ resource "genesyscloud_webdeployments_configuration" "example_configuration" {
     }
   }
   video {
-    enabled = true
+    enabled  = true
+    channels = ["Webmessaging", "Voice"]
     agent {
       allow_camera       = true
       allow_screen_share = true

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
@@ -549,6 +549,15 @@ var (
 				Optional:    true,
 				Computed:    true,
 			},
+			"channels": {
+				Description: "List of channels through which video chat is available",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"Webmessaging", "Voice"}, false),
+				},
+			},
 			"agent": {
 				Description: "Video Settings for agent",
 				Type:        schema.TypeList,

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_schema.go
@@ -553,6 +553,7 @@ var (
 				Description: "List of channels through which video chat is available",
 				Type:        schema.TypeList,
 				Optional:    true,
+				Computed:    true,
 				Elem: &schema.Schema{
 					Type:         schema.TypeString,
 					ValidateFunc: validation.StringInSlice([]string{"Webmessaging", "Voice"}, false),

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
@@ -175,6 +175,9 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 		channels       = []string{strconv.Quote("Webmessaging")}
 		channelsUpdate = []string{strconv.Quote("Webmessaging"), strconv.Quote("Voice")}
 
+		videoChannels       = []string{strconv.Quote("Webmessaging")}
+		videoChannelsUpdate = []string{strconv.Quote("Webmessaging"), strconv.Quote("Voice")}
+
 		authenticationSettings1 = authSettings{
 			enabled:             true,
 			integrationId:       uuid.NewString(),
@@ -214,6 +217,17 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 						[]string{strconv.Quote("selector-one")},
 						generatePauseCriteria("/sensitive", "Includes"),
 						generatePauseCriteria("/login", "Equals"),
+					),
+					generateVideoSettings(
+						util.TrueValue,
+						videoChannels,
+						util.TrueValue,
+						util.TrueValue,
+						util.TrueValue,
+						"BLUR",
+						util.TrueValue,
+						util.TrueValue,
+						util.TrueValue,
 					),
 					generateAuthenticationSettings(authenticationSettings1),
 				),
@@ -305,6 +319,20 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.pause_criteria.1.url_fragment", "/login"),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.pause_criteria.1.condition", "Equals"),
 
+					resource.TestCheckResourceAttr(resourcePath, "video.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.enabled", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.channels.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.channels.0", "Webmessaging"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_camera", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_screen_share", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_microphone", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.background", "BLUR"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_camera", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_screen_share", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_microphone", util.TrueValue),
+
 					resource.TestCheckResourceAttr(resourcePath, "journey_events.#", "1"),
 					resource.TestCheckResourceAttr(resourcePath, "journey_events.0.enabled", util.TrueValue),
 					resource.TestCheckResourceAttr(resourcePath, "journey_events.0.excluded_query_parameters.#", "1"),
@@ -371,6 +399,17 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 						generatePauseCriteria("/sensitive", "Includes"),
 						generatePauseCriteria("/login", "Equals"),
 					),
+					generateVideoSettings(
+						util.TrueValue,
+						videoChannelsUpdate,
+						util.TrueValue,
+						util.FalseValue,
+						util.TrueValue,
+						"NONE",
+						util.TrueValue,
+						util.FalseValue,
+						util.TrueValue,
+					),
 					generateAuthenticationSettings(authenticationSettings2),
 				),
 				Check: resource.ComposeTestCheckFunc(
@@ -414,6 +453,22 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.pause_criteria.0.condition", "Includes"),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.pause_criteria.1.url_fragment", "/login"),
 					resource.TestCheckResourceAttr(resourcePath, "cobrowse.0.pause_criteria.1.condition", "Equals"),
+
+					resource.TestCheckResourceAttr(resourcePath, "video.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.enabled", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.channels.#", "2"),
+					util.ValidateStringInArray(resourcePath, "video.0.channels", "Webmessaging"),
+					util.ValidateStringInArray(resourcePath, "video.0.channels", "Voice"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_camera", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_screen_share", util.FalseValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_microphone", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.background", "NONE"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_camera", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_screen_share", util.FalseValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_microphone", util.TrueValue),
+
 					resource.TestCheckResourceAttr(resourcePath, "journey_events.#", "1"),
 					resource.TestCheckResourceAttr(resourcePath, "journey_events.0.enabled", util.TrueValue),
 					resource.TestCheckResourceAttr(resourcePath, "journey_events.0.excluded_query_parameters.#", "1"),
@@ -1158,6 +1213,26 @@ func generatePauseCriteria(urlFragment, condition string) string {
 	url_fragment = "%s"
 	condition = "%s"
 }`, urlFragment, condition)
+}
+
+func generateVideoSettings(enabled string, channels []string, agentAllowCamera, agentAllowScreenShare, agentAllowMicrophone, agentBackground, userAllowCamera, userAllowScreenShare, userAllowMicrophone string) string {
+	return fmt.Sprintf(`
+	video {
+		enabled = %s
+		channels = [ %s ]
+		agent {
+			allow_camera = %s
+			allow_screen_share = %s
+			allow_microphone = %s
+			background = "%s"
+		}
+		user {
+			allow_camera = %s
+			allow_screen_share = %s
+			allow_microphone = %s
+		}
+	}
+`, enabled, strings.Join(channels, ", "), agentAllowCamera, agentAllowScreenShare, agentAllowMicrophone, agentBackground, userAllowCamera, userAllowScreenShare, userAllowMicrophone)
 }
 
 func generateSupportCenterSettings(supportCenter scConfig) string {

--- a/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
+++ b/genesyscloud/webdeployments_configuration/resource_genesyscloud_webdeployments_configuration_test.go
@@ -510,6 +510,54 @@ func TestAccResourceWebDeploymentsConfigurationComplex(t *testing.T) {
 				),
 			},
 			{
+				// Step 3: Update video settings without channels to verify graceful handling of omitted channels
+				Config: knowledgeKnowledgebase.GenerateKnowledgeKnowledgebaseResource(
+					kbResourceLabel1,
+					kbName1,
+					kbDesc1,
+					kbCoreLang1,
+				) + complexConfigurationResource(
+					configName,
+					configDescription,
+					"genesyscloud_knowledge_knowledgebase."+kbResourceLabel1+".id",
+					generateWebDeploymentConfigCobrowseSettings(
+						util.FalseValue,
+						util.FalseValue,
+						util.FalseValue,
+						util.FalseValue,
+						channelsUpdate,
+						[]string{strconv.Quote("selector-one"), strconv.Quote("selector-two")},
+						[]string{strconv.Quote("selector-one"), strconv.Quote("selector-two")},
+						generatePauseCriteria("/sensitive", "Includes"),
+						generatePauseCriteria("/login", "Equals"),
+					),
+					generateVideoSettingsWithoutChannels(
+						util.TrueValue,
+						util.TrueValue,
+						util.FalseValue,
+						util.TrueValue,
+						"NONE",
+						util.TrueValue,
+						util.FalseValue,
+						util.TrueValue,
+					),
+					generateAuthenticationSettings(authenticationSettings2),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourcePath, "video.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.enabled", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_camera", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_screen_share", util.FalseValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.allow_microphone", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.agent.0.background", "NONE"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.#", "1"),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_camera", util.TrueValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_screen_share", util.FalseValue),
+					resource.TestCheckResourceAttr(resourcePath, "video.0.user.0.allow_microphone", util.TrueValue),
+				),
+			},
+			{
 				ResourceName:            resourcePath,
 				ImportState:             true,
 				ImportStateVerify:       true,
@@ -1233,6 +1281,25 @@ func generateVideoSettings(enabled string, channels []string, agentAllowCamera, 
 		}
 	}
 `, enabled, strings.Join(channels, ", "), agentAllowCamera, agentAllowScreenShare, agentAllowMicrophone, agentBackground, userAllowCamera, userAllowScreenShare, userAllowMicrophone)
+}
+
+func generateVideoSettingsWithoutChannels(enabled string, agentAllowCamera, agentAllowScreenShare, agentAllowMicrophone, agentBackground, userAllowCamera, userAllowScreenShare, userAllowMicrophone string) string {
+	return fmt.Sprintf(`
+	video {
+		enabled = %s
+		agent {
+			allow_camera = %s
+			allow_screen_share = %s
+			allow_microphone = %s
+			background = "%s"
+		}
+		user {
+			allow_camera = %s
+			allow_screen_share = %s
+			allow_microphone = %s
+		}
+	}
+`, enabled, agentAllowCamera, agentAllowScreenShare, agentAllowMicrophone, agentBackground, userAllowCamera, userAllowScreenShare, userAllowMicrophone)
 }
 
 func generateSupportCenterSettings(supportCenter scConfig) string {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
@@ -271,7 +271,9 @@ func buildVideoSettings(d *schema.ResourceData) *platformclientv2.Videosettings 
 
 	if v, ok := cfg["channels"]; ok {
 		channels := lists.InterfaceListToStrings(v.([]interface{}))
-		videoSettings.Channels = &channels
+		if len(channels) > 0 {
+			videoSettings.Channels = &channels
+		}
 	}
 
 	if v, ok := cfg["agent"]; ok && v != nil {

--- a/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
+++ b/genesyscloud/webdeployments_configuration/utils/resource_genesyscloud_webdeployments_configuration_utils.go
@@ -269,6 +269,11 @@ func buildVideoSettings(d *schema.ResourceData) *platformclientv2.Videosettings 
 		videoSettings.Enabled = &v
 	}
 
+	if v, ok := cfg["channels"]; ok {
+		channels := lists.InterfaceListToStrings(v.([]interface{}))
+		videoSettings.Channels = &channels
+	}
+
 	if v, ok := cfg["agent"]; ok && v != nil {
 		videoSettings.Agent = buildAgentVideoSettings(v.([]interface{}))
 	}
@@ -345,6 +350,10 @@ func FlattenVideoSettings(videoSettings *platformclientv2.Videosettings) []inter
 	result := map[string]interface{}{}
 	if videoSettings.Enabled != nil {
 		result["enabled"] = videoSettings.Enabled
+	}
+
+	if videoSettings.Channels != nil {
+		result["channels"] = *videoSettings.Channels
 	}
 
 	if videoSettings.Agent != nil {


### PR DESCRIPTION
### Add channels attribute to video settings in web deployments configuration

Adds a new channels attribute to the video block of the genesyscloud_webdeployments_configuration resource. This enables CXasCode support for the "Video Chat from Voice Call" feature (PURE-7232), allowing users to configure which channels support video chat escalation (Webmessaging, Voice).