### PR TITLE
fix(knowledge_document): Export label_names and category_name as refe…

### DIFF
--- a/docs/resources/knowledge_document.md
+++ b/docs/resources/knowledge_document.md
@@ -84,6 +84,8 @@ resource "genesyscloud_knowledge_document" "example_unpublished_document" {
 
 ### Optional
 
+- `category_id` (String) The composite ID of the category associated with the document. Set by the provider for export dependency resolution. Do not set manually.
+- `label_ids` (List of String) The composite IDs of labels associated with the document. Set by the provider for export dependency resolution. Do not set manually.
 - `published` (Boolean, Deprecated) *DEPRECATED: By Default a document created will be in Draft. In order to Publish a document, use knowledge_document_variation instead.* If true, the knowledge document will be published. If false, it will be a draft. The document can only be published if it has document variations.
 
 ### Read-Only

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
@@ -144,6 +144,18 @@ func readKnowledgeDocument(ctx context.Context, d *schema.ResourceData, meta int
 
 		_ = d.Set("knowledge_document", flattenedDocument)
 
+		// Set top-level label_ids and category_id for export dependency resolution
+		if knowledgeDocument.Labels != nil && len(*knowledgeDocument.Labels) > 0 {
+			labelIds := make([]string, 0)
+			for _, label := range *knowledgeDocument.Labels {
+				labelIds = append(labelIds, fmt.Sprintf("%s,%s", *label.Id, knowledgeBaseId))
+			}
+			_ = d.Set("label_ids", labelIds)
+		}
+		if knowledgeDocument.Category != nil && knowledgeDocument.Category.Id != nil {
+			_ = d.Set("category_id", fmt.Sprintf("%s,%s", *knowledgeDocument.Category.Id, knowledgeBaseId))
+		}
+
 		log.Printf("Read Knowledge document %s", *knowledgeDocument.Id)
 		return cc.CheckState(d)
 	})

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_schema.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_schema.go
@@ -30,9 +30,14 @@ func KnowledgeDocumentExporter() *resourceExporter.ResourceExporter {
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllKnowledgeDocuments),
 		RefAttrs: map[string]*resourceExporter.RefAttrSettings{
 			"knowledge_base_id": {RefType: "genesyscloud_knowledge_knowledgebase"},
+			"label_ids":         {RefType: "genesyscloud_knowledge_label"},
+			"category_id":       {RefType: "genesyscloud_knowledge_category"},
 		},
 		CustomAttributeResolver: map[string]*resourceExporter.RefAttrCustomResolver{
-			"knowledge_document.label_names": {ResolverFunc: resourceExporter.KnowledgeDocumentLabelNamesResolver},
+			"knowledge_document.label_names":   {ResolverFunc: resourceExporter.KnowledgeDocumentLabelNamesResolver},
+			"knowledge_document.category_name": {ResolverFunc: resourceExporter.KnowledgeDocumentCategoryNameResolver},
+			"label_ids":                        {ResolverFunc: resourceExporter.RemoveLabelIdsResolver},
+			"category_id":                      {ResolverFunc: resourceExporter.RemoveCategoryIdResolver},
 			"knowledge_base_name": {
 				ResolverWithClientConfigFunc: resourceExporter.KnowledgeBaseNameResolver,
 			},
@@ -153,6 +158,19 @@ Export block label: "{parent knowledge base name}_{title}"`,
 				Optional:    true,
 				Computed:    true,
 				Deprecated:  "By Default a document created will be in Draft. In order to Publish a document, use knowledge_document_variation instead.",
+			},
+			"label_ids": {
+				Description: "The composite IDs of labels associated with the document. Set by the provider for export dependency resolution. Do not set manually.",
+				Type:        schema.TypeList,
+				Optional:    true,
+				Computed:    true,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+			},
+			"category_id": {
+				Description: "The composite ID of the category associated with the document. Set by the provider for export dependency resolution. Do not set manually.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
 			},
 		},
 	}

--- a/genesyscloud/resource_exporter/resource_exporter_custom.go
+++ b/genesyscloud/resource_exporter/resource_exporter_custom.go
@@ -1,6 +1,7 @@
 package resource_exporter
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -261,6 +262,18 @@ func ConditionValueResolver(configMap map[string]interface{}, exporters map[stri
 	return nil
 }
 
+// RemoveLabelIdsResolver removes the label_ids field after RefAttr resolution has processed it.
+func RemoveLabelIdsResolver(configMap map[string]interface{}, exporters map[string]*ResourceExporter, resourceLabel string) error {
+	configMap["label_ids"] = nil
+	return nil
+}
+
+// RemoveCategoryIdResolver removes the category_id field after RefAttr resolution has processed it.
+func RemoveCategoryIdResolver(configMap map[string]interface{}, exporters map[string]*ResourceExporter, resourceLabel string) error {
+	configMap["category_id"] = nil
+	return nil
+}
+
 // newFlowResourceExporter stores the flow exporter definition that utilises the
 // archy export service. Depending on a bool in the export resource, this may be swapped for the
 // default (legacy) ResourceExporter definition defined in architect_flow schema file
@@ -283,9 +296,26 @@ func KnowledgeDocumentLabelNamesResolver(configMap map[string]interface{}, expor
 		return nil
 	}
 
+	// Try to get the label exporter from the passed exporters map first,
+	// then fall back to the global registry if not found
 	exporter, ok := exporters["genesyscloud_knowledge_label"]
-	if !ok {
-		return nil
+	if !ok || exporter == nil {
+		allExporters := GetResourceExporters()
+		exporter, ok = allExporters["genesyscloud_knowledge_label"]
+		if !ok || exporter == nil {
+			return nil
+		}
+		// Add the exporter to the exporters map so the framework can export its resources
+		exporters["genesyscloud_knowledge_label"] = exporter
+	}
+
+	// If the label exporter hasn't been loaded yet (dependency resolution scenario),
+	// load it now so we can resolve label names to references
+	if exporter.GetSanitizedResourceMapSize() == 0 {
+		ctx := context.Background()
+		if diagErr := exporter.LoadSanitizedResourceMap(ctx, "genesyscloud_knowledge_label", nil); diagErr != nil {
+			return fmt.Errorf("failed to load knowledge label resources: %v", diagErr)
+		}
 	}
 
 	resolvedNames := make([]string, 0, len(labelNames))
@@ -296,9 +326,6 @@ func KnowledgeDocumentLabelNamesResolver(configMap map[string]interface{}, expor
 		}
 
 		for _, labelResource := range exporter.SanitizedResourceMap {
-
-			// OriginalLabel preserves the original format (with spaces) which matches the labelName format
-			// whereas BlockLabel is sanitized
 			if strings.HasSuffix(labelResource.OriginalLabel, "_"+name) {
 				resolvedNames = append(resolvedNames, fmt.Sprintf("${genesyscloud_knowledge_label.%s.knowledge_label[0].name}", labelResource.BlockLabel))
 				break
@@ -308,6 +335,47 @@ func KnowledgeDocumentLabelNamesResolver(configMap map[string]interface{}, expor
 
 	if len(resolvedNames) > 0 {
 		configMap["label_names"] = resolvedNames
+	}
+
+	return nil
+}
+
+// KnowledgeDocumentCategoryNameResolver resolves the category_name to a reference to the knowledge category resource's name
+// instead of the category name as a string. This is so that the correct creation order is always applied as otherwise knowledge_documents
+// could be created without the category set, which makes the consistency checker fail.
+func KnowledgeDocumentCategoryNameResolver(configMap map[string]interface{}, exporters map[string]*ResourceExporter, resourceLabel string) error {
+	categoryName, ok := configMap["category_name"].(string)
+	if !ok || categoryName == "" {
+		return nil
+	}
+
+	// Try to get the category exporter from the passed exporters map first,
+	// then fall back to the global registry if not found
+	exporter, ok := exporters["genesyscloud_knowledge_category"]
+	if !ok || exporter == nil {
+		allExporters := GetResourceExporters()
+		exporter, ok = allExporters["genesyscloud_knowledge_category"]
+		if !ok || exporter == nil {
+			return nil
+		}
+		// Add the exporter to the exporters map so the framework can export its resources
+		exporters["genesyscloud_knowledge_category"] = exporter
+	}
+
+	// If the category exporter hasn't been loaded yet (dependency resolution scenario),
+	// load it now so we can resolve category names to references
+	if exporter.GetSanitizedResourceMapSize() == 0 {
+		ctx := context.Background()
+		if diagErr := exporter.LoadSanitizedResourceMap(ctx, "genesyscloud_knowledge_category", nil); diagErr != nil {
+			return fmt.Errorf("failed to load knowledge category resources: %v", diagErr)
+		}
+	}
+
+	for _, categoryResource := range exporter.SanitizedResourceMap {
+		if strings.HasSuffix(categoryResource.OriginalLabel, "_"+categoryName) {
+			configMap["category_name"] = fmt.Sprintf("${genesyscloud_knowledge_category.%s.knowledge_category[0].name}", categoryResource.BlockLabel)
+			break
+		}
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
Fixes knowledge document export to produce proper Terraform references for
label_names and category_name, and ensures the dependent label and category
resources are exported when enable_dependency_resolution=true.

## Problem
When exporting a knowledge_document, label_names and category_name were exported
as hardcoded strings. The referenced label and category resources were not included
in the export. This caused terraform apply to hang in fresh orgs because the
labels/categories didn't exist.

## Changes
- `resource_genesyscloud_knowledge_document_schema.go`: Added category_name custom
  resolver, top-level label_ids/category_id fields with RefAttrs for dependency
  resolution, and cleanup resolvers
- `resource_genesyscloud_knowledge_document.go`: Set top-level label_ids and
  category_id in Read for export dependency resolution
- `resource_exporter_custom.go`: Added KnowledgeDocumentCategoryNameResolver,
  modified label resolver to use global registry fallback, added cleanup resolvers

## Testing
- Created knowledge base, label, category, and document in test org
- Exported with include_filter_resources and enable_dependency_resolution=true
- Verified exported .tf contains references (not strings) for label_names and category_name
- Verified label and category resources are included in export output
- Verified label_ids and category_id internal fields do not appear in export
- Unit tests pass
