### PR TITLE
CPR-3056: Remove webchat media type and is_pacing_enabled from journey action map/template

### DIFF
--- a/docs/resources/journey_action_map.md
+++ b/docs/resources/journey_action_map.md
@@ -104,13 +104,12 @@ resource "genesyscloud_journey_action_map" "example_journey_action_map" {
 
 Required:
 
-- `media_type` (String) Media type of action. Valid values: webchat (deprecated), webMessagingOffer, contentOffer, architectFlow, openAction. Note: The 'webchat' media type is deprecated. ACD Chat v2.0 in Genesys Predictive Engagement is being removed. See https://community.genesys.com/discussion/deprecation-acd-chat-v20-support-in-genesys-predictive-engagement.
+- `media_type` (String) Media type of action. Valid values: webMessagingOffer, contentOffer, architectFlow, openAction.
 
 Optional:
 
 - `action_template_id` (String) Action template associated with the action map. For media type contentOffer.
 - `architect_flow_fields` (Block Set, Max: 1) Architect Flow Id and input contract. For media type architectFlow. (see [below for nested schema](#nestedblock--action--architect_flow_fields))
-- `is_pacing_enabled` (Boolean, Deprecated) *DEPRECATED: Web Chat is deprecated and being removed. See https://community.genesys.com/discussion/deprecation-acd-chat-v20-support-in-genesys-predictive-engagement* Whether this action should be throttled. Defaults to `true`.
 - `open_action_fields` (Block Set, Max: 1) Admin-configurable fields of an open action. For media type openAction. (see [below for nested schema](#nestedblock--action--open_action_fields))
 - `web_messaging_offer_fields` (Block Set, Max: 1) Admin-configurable fields of a web messaging offer action. For media type webMessagingOffer. (see [below for nested schema](#nestedblock--action--web_messaging_offer_fields))
 

--- a/docs/resources/journey_action_template.md
+++ b/docs/resources/journey_action_template.md
@@ -107,7 +107,7 @@ resource "genesyscloud_journey_action_template" "example_journey_action_template
 
 ### Required
 
-- `media_type` (String) The media type of the action configured by the action template. Valid values: webchat (deprecated), webMessagingOffer, contentOffer, architectFlow, openAction. Note: The 'webchat' media type is deprecated. ACD Chat v2.0 in Genesys Predictive Engagement is being removed. See https://community.genesys.com/discussion/deprecation-acd-chat-v20-support-in-genesys-predictive-engagement.
+- `media_type` (String) The media type of the action configured by the action template. Valid values: webMessagingOffer, contentOffer, architectFlow, openAction.
 - `name` (String) Name of the action template.
 - `state` (String) The state of the action template.
 

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_schema.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_schema.go
@@ -4,7 +4,7 @@ package journey_action_map
 // @chat: #customer-journey-data
 // @pm: Angelo Cicchitto
 // @jira: CPR
-// @description: Action Map Qualification Service determines if actions should be triggered for customers based on configured action maps. Handles action templates and qualification logic for content offers, architect flows, webchat, web messaging, and open actions.
+// @description: Action Map Qualification Service determines if actions should be triggered for customers based on configured action maps. Handles action templates and qualification logic for content offers, architect flows, web messaging, and open actions.
 
 import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
@@ -233,10 +233,10 @@ var (
 				Optional:    true,
 			},
 			"media_type": {
-				Description:  "Media type of action. Valid values: webchat (deprecated), webMessagingOffer, contentOffer, architectFlow, openAction. Note: The 'webchat' media type is deprecated. ACD Chat v2.0 in Genesys Predictive Engagement is being removed. See https://community.genesys.com/discussion/deprecation-acd-chat-v20-support-in-genesys-predictive-engagement.",
+				Description:  "Media type of action. Valid values: webMessagingOffer, contentOffer, architectFlow, openAction.",
 				Type:         schema.TypeString,
 				Required:     true,
-				ValidateFunc: validation.StringInSlice([]string{"webchat", "webMessagingOffer", "contentOffer", "architectFlow", "openAction"}, false),
+				ValidateFunc: validation.StringInSlice([]string{"webMessagingOffer", "contentOffer", "architectFlow", "openAction"}, false),
 			},
 			"architect_flow_fields": {
 				Description: "Architect Flow Id and input contract. For media type architectFlow.",
@@ -258,13 +258,6 @@ var (
 				Optional:    true,
 				MaxItems:    1,
 				Elem:        openActionFieldsResource,
-			},
-			"is_pacing_enabled": {
-				Description: "Whether this action should be throttled.",
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     true,
-				Deprecated:  "Web Chat is deprecated and being removed. See https://community.genesys.com/discussion/deprecation-acd-chat-v20-support-in-genesys-predictive-engagement",
 			},
 		},
 	}

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_unit_test.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_unit_test.go
@@ -60,7 +60,6 @@ func sampleActionMapForFlatten() *platformclientv2.Actionmap {
 	ignoreFrequencyCap := false
 	activationType := "immediate"
 	mediaType := "openAction"
-	isPacingEnabled := true
 	startDate := time.Date(2022, 7, 4, 12, 0, 0, 0, time.UTC)
 	openActionID := "00000000-0000-0000-0000-000000000001"
 	openActionName := "export-repro-open-action"
@@ -75,8 +74,7 @@ func sampleActionMapForFlatten() *platformclientv2.Actionmap {
 			VarType: &activationType,
 		},
 		Action: &platformclientv2.Actionmapaction{
-			MediaType:       &mediaType,
-			IsPacingEnabled: &isPacingEnabled,
+			MediaType: &mediaType,
 			OpenActionFields: &platformclientv2.Openactionfields{
 				OpenAction: &platformclientv2.Domainentityref{
 					Id:   &openActionID,

--- a/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
+++ b/genesyscloud/journey_action_map/resource_genesyscloud_journey_action_map_utils.go
@@ -211,7 +211,6 @@ func buildSdkActivation(activation map[string]interface{}) *platformclientv2.Act
 func flattenActionMapAction(actionMapAction *platformclientv2.Actionmapaction) map[string]interface{} {
 	actionMapActionMap := make(map[string]interface{})
 	actionMapActionMap["media_type"] = *actionMapAction.MediaType
-	actionMapActionMap["is_pacing_enabled"] = *actionMapAction.IsPacingEnabled
 	if actionMapAction.ActionTemplate != nil {
 		stringmap.SetValueIfNotNil(actionMapActionMap, "action_template_id", actionMapAction.ActionTemplate.Id)
 	}
@@ -223,7 +222,6 @@ func flattenActionMapAction(actionMapAction *platformclientv2.Actionmapaction) m
 
 func buildSdkActionMapAction(actionMapAction map[string]interface{}) *platformclientv2.Actionmapaction {
 	mediaType := actionMapAction["media_type"].(string)
-	isPacingEnabled := actionMapAction["is_pacing_enabled"].(bool)
 	actionMapActionTemplate := getActionMapActionTemplate(actionMapAction)
 	architectFlowFields := stringmap.BuildSdkListFirstElement(actionMapAction, "architect_flow_fields", buildSdkArchitectFlowFields, true)
 	webMessagingOfferFields := stringmap.BuildSdkListFirstElement(actionMapAction, "web_messaging_offer_fields", buildSdkWebMessagingOfferFields, true)
@@ -231,7 +229,6 @@ func buildSdkActionMapAction(actionMapAction map[string]interface{}) *platformcl
 
 	return &platformclientv2.Actionmapaction{
 		MediaType:               &mediaType,
-		IsPacingEnabled:         &isPacingEnabled,
 		ActionTemplate:          actionMapActionTemplate,
 		ArchitectFlowFields:     architectFlowFields,
 		WebMessagingOfferFields: webMessagingOfferFields,
@@ -241,7 +238,6 @@ func buildSdkActionMapAction(actionMapAction map[string]interface{}) *platformcl
 
 func buildSdkPatchAction(patchAction map[string]interface{}) *platformclientv2.Patchaction {
 	mediaType := patchAction["media_type"].(string)
-	isPacingEnabled := patchAction["is_pacing_enabled"].(bool)
 	actionMapActionTemplate := getActionMapActionTemplate(patchAction)
 	architectFlowFields := stringmap.BuildSdkListFirstElement(patchAction, "architect_flow_fields", buildSdkArchitectFlowFields, true)
 	webMessagingOfferFields := stringmap.BuildSdkListFirstElement(patchAction, "web_messaging_offer_fields", buildSdkPatchWebMessagingOfferFields, true)
@@ -249,7 +245,6 @@ func buildSdkPatchAction(patchAction map[string]interface{}) *platformclientv2.P
 
 	sdkPatchAction := platformclientv2.Patchaction{}
 	sdkPatchAction.SetField("MediaType", &mediaType)
-	sdkPatchAction.SetField("IsPacingEnabled", &isPacingEnabled)
 	sdkPatchAction.SetField("ActionTemplate", actionMapActionTemplate)
 	sdkPatchAction.SetField("ArchitectFlowFields", architectFlowFields)
 	sdkPatchAction.SetField("WebMessagingOfferFields", webMessagingOfferFields)

--- a/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_schema.go
+++ b/genesyscloud/journey_action_template/resource_genesyscloud_journey_action_template_schema.go
@@ -4,7 +4,7 @@ package journey_action_template
 // @chat: #customer-journey-data
 // @pm: Angelo Cicchitto
 // @jira: CPR
-// @description: Action Map Qualification Service determines if actions should be triggered for customers based on configured action maps. Handles action templates and qualification logic for content offers, architect flows, webchat, web messaging, and open actions.
+// @description: Action Map Qualification Service determines if actions should be triggered for customers based on configured action maps. Handles action templates and qualification logic for content offers, architect flows, web messaging, and open actions.
 
 import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
@@ -37,10 +37,10 @@ var (
 			Optional:    true,
 		},
 		"media_type": {
-			Description:  "The media type of the action configured by the action template. Valid values: webchat (deprecated), webMessagingOffer, contentOffer, architectFlow, openAction. Note: The 'webchat' media type is deprecated. ACD Chat v2.0 in Genesys Predictive Engagement is being removed. See https://community.genesys.com/discussion/deprecation-acd-chat-v20-support-in-genesys-predictive-engagement.",
+			Description:  "The media type of the action configured by the action template. Valid values: webMessagingOffer, contentOffer, architectFlow, openAction.",
 			Type:         schema.TypeString,
 			Required:     true,
-			ValidateFunc: validation.StringInSlice([]string{"webchat", "webMessagingOffer", "contentOffer", "architectFlow", "openAction"}, false),
+			ValidateFunc: validation.StringInSlice([]string{"webMessagingOffer", "contentOffer", "architectFlow", "openAction"}, false),
 		},
 		"state": {
 			Description:  "The state of the action template.",

--- a/test/data/resource/genesyscloud_journey_action_map/action_media_types_with_trigger_conditions/01_create_web_messaging_offer_with_trigger_event_condition.tf
+++ b/test/data/resource/genesyscloud_journey_action_map/action_media_types_with_trigger_conditions/01_create_web_messaging_offer_with_trigger_event_condition.tf
@@ -10,7 +10,6 @@ resource "genesyscloud_journey_action_map" "terraform_test_-TEST-CASE-" {
   }
   action {
     media_type        = "webMessagingOffer"
-    is_pacing_enabled = false
     web_messaging_offer_fields {
       offer_text = "Hey how're you?"
     }

--- a/test/data/resource/genesyscloud_journey_action_map/action_media_types_with_trigger_conditions/02_update_web_messaging_offer_with_trigger_event_condition.tf
+++ b/test/data/resource/genesyscloud_journey_action_map/action_media_types_with_trigger_conditions/02_update_web_messaging_offer_with_trigger_event_condition.tf
@@ -10,7 +10,6 @@ resource "genesyscloud_journey_action_map" "terraform_test_-TEST-CASE-" {
   }
   action {
     media_type        = "webMessagingOffer"
-    is_pacing_enabled = false
     web_messaging_offer_fields {
       offer_text = "Hey how're you keeping?"
     }

--- a/test/data/resource/genesyscloud_journey_action_map/basic_optional_attributes/08_update_remove_trigger_with_segments.tf
+++ b/test/data/resource/genesyscloud_journey_action_map/basic_optional_attributes/08_update_remove_trigger_with_segments.tf
@@ -10,7 +10,6 @@ resource "genesyscloud_journey_action_map" "terraform_test_-TEST-CASE-" {
   }
   action {
     media_type        = "webMessagingOffer"
-    is_pacing_enabled = false
     web_messaging_offer_fields {
       offer_text = "Hey how're you?"
     }


### PR DESCRIPTION
**What**

> Removes all webchat-related resources and fields from the `journey_action_map` and `journey_action_template` resources.

**Why**
> Webchat (ACD Chat v2.0) has been deprecated in the Public API since `2025-06-23` ([GPE-16788](https://inindca.atlassian.net/browse/GPE-16788)), and deprecation labels were previously added in [CPR-3051](https://inindca.atlassian.net/browse/CPR-3051). This is the follow-up hard removal so that new Terraform configurations can no longer use webchat.

**Breaking Change Note**

> Users with `media_type = "webchat" `or `is_pacing_enabled` in their .tf files will get validation errors on terraform plan. This is intentional because webchat has been deprecated since `June 2025` and users were warned via `CPR-3051`.

[GPE-16788]: https://inindca.atlassian.net/browse/GPE-16788?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CPR-3051]: https://inindca.atlassian.net/browse/CPR-3051?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ