### PR TITLE
fix(outbound_contact_list_template): modied max_lenght to optional

### DIFF
--- a/docs/resources/outbound_contact_list_template.md
+++ b/docs/resources/outbound_contact_list_template.md
@@ -82,12 +82,12 @@ resource "genesyscloud_outbound_contact_list_template" "contact_list_template" {
 Required:
 
 - `column_name` (String) The column name of a column selected for dynamic queueing.
-- `max_length` (Number) The maximum length of the text column selected for dynamic queueing.
 
 Optional:
 
 - `column_data_type` (String) The data type of the column selected for dynamic queueing (TEXT, NUMERIC or TIMESTAMP)
 - `max` (Number) The maximum length of the numeric column selected for dynamic queueing.
+- `max_length` (Number) The maximum length of the text column selected for dynamic queueing.
 - `min` (Number) The minimum length of the numeric column selected for dynamic queueing.
 
 

--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -54,7 +54,7 @@ resource "genesyscloud_routing_email_route" "example_route" {
     enabled            = false
     canned_response_id = genesyscloud_responsemanagement_response.example_signature_response.id
     always_included    = false
-    inclusion_type     = "FirstResponseOnly"
+    inclusion_type     = "Send"
   }
 }
 

--- a/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
+++ b/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
@@ -28,7 +28,7 @@ func runDataJourneyActionMapTestCase(t *testing.T, testCaseName string) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
-		Steps: generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
+		Steps:             generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
 	})
 }
 

--- a/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_schema.go
+++ b/genesyscloud/outbound_contact_list_template/resource_genesyscloud_outbound_contact_list_template_schema.go
@@ -182,7 +182,7 @@ var (
 			},
 			`max_length`: {
 				Description: `The maximum length of the text column selected for dynamic queueing.`,
-				Required:    true,
+				Optional:    true,
 				Type:        schema.TypeInt,
 			},
 		},

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -321,10 +321,10 @@ func TestAccResourceRoutingEmailRouteSignature(t *testing.T) {
 		resp1ResourceLabel,
 		resp1Name,
 		[]string{"genesyscloud_responsemanagement_library." + libResourceLabel + ".id"},
-		util.NullValue,        // interaction_type
-		util.NullValue,        // substitutions_schema_id
-		`"Footer"`,            // response_type
-		[]string{},            // asset_ids
+		util.NullValue, // interaction_type
+		util.NullValue, // substitutions_schema_id
+		`"Footer"`,     // response_type
+		[]string{},     // asset_ids
 		responsemanagementResponse.GenerateTextsBlock("Email signature one", "text/plain", util.NullValue),
 		`footer { type = "Signature" }`,
 	)


### PR DESCRIPTION
## Summary
Changed the `max_length` attribute on `genesyscloud_outbound_contact_list_template` 
from Required to Optional to match the API behavior.

## Problem
The `max_length` attribute was marked as Required in the schema, but the API does 
not require it. Users were forced to provide a value even when not needed.

## Changes
- `resource_genesyscloud_outbound_contact_list_template_schema.go`: Changed 
  `max_length` from Required to Optional

## Testing
- Verified plan/apply works without specifying `max_length`
- Existing unit tests pass
