### PR TITLE
fix(integration_action): Detect function-data-actions by integration …

### DIFF
--- a/docs/data-sources/integration_action.md
+++ b/docs/data-sources/integration_action.md
@@ -20,6 +20,7 @@ The following Genesys Cloud APIs are used by this data source. Ensure your OAuth
 * [GET /api/v2/integrations/actions/{actionId}/draft](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--draft)
 * [GET /api/v2/integrations/actions/{actionId}/draft/function](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--draft-function)
 * [GET /api/v2/integrations/actions/{actionId}/function](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--function)
+* [GET /api/v2/integrations/{integrationId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations--integrationId-)
 
 ## Permissions and Scopes
 

--- a/docs/resources/integration_action.md
+++ b/docs/resources/integration_action.md
@@ -28,6 +28,7 @@ The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Cl
 * [POST /api/v2/integrations/actions/{actionId}/draft/publish](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-integrations-actions--actionId--draft-publish)
 * [GET /api/v2/integrations/actions/{actionId}/function](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--function)
 * [GET /api/v2/integrations/actions/{actionId}/templates/{fileName}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--templates--fileName-)
+* [GET /api/v2/integrations/{integrationId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations--integrationId-)
 
 ## Permissions and Scopes
 

--- a/docs/resources/routing_email_route.md
+++ b/docs/resources/routing_email_route.md
@@ -54,7 +54,7 @@ resource "genesyscloud_routing_email_route" "example_route" {
     enabled            = false
     canned_response_id = genesyscloud_responsemanagement_response.example_signature_response.id
     always_included    = false
-    inclusion_type     = "FirstResponseOnly"
+    inclusion_type     = "Send"
   }
 }
 

--- a/examples/data-sources/genesyscloud_integration_action/apis.md
+++ b/examples/data-sources/genesyscloud_integration_action/apis.md
@@ -8,3 +8,4 @@ genesyscloud/integration_action/resource_genesyscloud_integration_action.go
 * [GET /api/v2/integrations/actions/{actionId}/draft](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--draft)
 * [GET /api/v2/integrations/actions/{actionId}/draft/function](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--draft-function)
 * [GET /api/v2/integrations/actions/{actionId}/function](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--function)
+* [GET /api/v2/integrations/{integrationId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations--integrationId-)

--- a/examples/resources/genesyscloud_integration_action/apis.md
+++ b/examples/resources/genesyscloud_integration_action/apis.md
@@ -16,3 +16,4 @@ genesyscloud/integration_action/resource_genesyscloud_integration_action.go
 * [POST /api/v2/integrations/actions/{actionId}/draft/publish](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-integrations-actions--actionId--draft-publish)
 * [GET /api/v2/integrations/actions/{actionId}/function](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--function)
 * [GET /api/v2/integrations/actions/{actionId}/templates/{fileName}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations-actions--actionId--templates--fileName-)
+* [GET /api/v2/integrations/{integrationId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-integrations--integrationId-)

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
@@ -149,7 +149,7 @@ func createIntegrationAction(ctx context.Context, d *schema.ResourceData, meta i
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
 	iap := getIntegrationActionsProxy(sdkConfig)
 
-	if containsFunctionDataAction(category) {
+	if isFunctionDataActionIntegration(ctx, integrationId, iap) || containsFunctionDataAction(category) {
 		return createFunctionDataActionDraft(ctx, d, meta, iap)
 	}
 
@@ -192,6 +192,20 @@ func containsFunctionDataAction(s string) bool {
 	normalized = strings.ReplaceAll(normalized, "_", " ")
 	normalized = strings.ReplaceAll(normalized, "-", " ")
 	return strings.Contains(normalized, "function data action")
+}
+
+// isFunctionDataActionIntegration checks if the integration with the given ID is of type "function-data-actions"
+// by making a GET API call to retrieve the integration details.
+func isFunctionDataActionIntegration(ctx context.Context, integrationId string, iap *integrationActionsProxy) bool {
+	integration, _, err := iap.integrationsApi.GetIntegration(integrationId, 1, 1, "", nil, "", "")
+	if err != nil {
+		log.Printf("Warning: failed to get integration %s to check type: %v. Falling back to category check.", integrationId, err)
+		return false
+	}
+	if integration != nil && integration.IntegrationType != nil && integration.IntegrationType.Id != nil {
+		return *integration.IntegrationType.Id == "function-data-actions"
+	}
+	return false
 }
 
 func updateFunctionDataActionDraft(ctx context.Context, d *schema.ResourceData, meta interface{}, iap *integrationActionsProxy) diag.Diagnostics {
@@ -707,7 +721,7 @@ func readIntegrationAction(ctx context.Context, d *schema.ResourceData, meta int
 			_ = d.Set("config_response", nil)
 		}
 
-		if containsFunctionDataAction(*action.Category) {
+		if isFunctionDataActionIntegration(ctx, d.Get("integration_id").(string), iap) || containsFunctionDataAction(*action.Category) {
 			var functionData *platformclientv2.Functionconfig
 
 			log.Printf("DEBUG: Reading published function for integration action %s", d.Id())
@@ -770,7 +784,7 @@ func updateIntegrationAction(ctx context.Context, d *schema.ResourceData, meta i
 		return diagErr
 	}
 
-	if containsFunctionDataAction(category) {
+	if isFunctionDataActionIntegration(ctx, d.Get("integration_id").(string), iap) || containsFunctionDataAction(category) {
 		return updateFunctionDataActionDraft(ctx, d, meta, iap)
 	}
 

--- a/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
+++ b/genesyscloud/journey_action_map/data_source_genesyscloud_journey_action_map_test.go
@@ -28,7 +28,7 @@ func runDataJourneyActionMapTestCase(t *testing.T, testCaseName string) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { util.TestAccPreCheck(t) },
 		ProviderFactories: provider.GetProviderFactories(providerResources, providerDataSources),
-		Steps: generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
+		Steps:             generateDataJourneyActionMapTestSteps(testCaseName, testObjectFullName),
 	})
 }
 

--- a/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
+++ b/genesyscloud/routing_email_route/resource_genesyscloud_routing_email_route_test.go
@@ -321,10 +321,10 @@ func TestAccResourceRoutingEmailRouteSignature(t *testing.T) {
 		resp1ResourceLabel,
 		resp1Name,
 		[]string{"genesyscloud_responsemanagement_library." + libResourceLabel + ".id"},
-		util.NullValue,        // interaction_type
-		util.NullValue,        // substitutions_schema_id
-		`"Footer"`,            // response_type
-		[]string{},            // asset_ids
+		util.NullValue, // interaction_type
+		util.NullValue, // substitutions_schema_id
+		`"Footer"`,     // response_type
+		[]string{},     // asset_ids
 		responsemanagementResponse.GenerateTextsBlock("Email signature one", "text/plain", util.NullValue),
 		`footer { type = "Signature" }`,
 	)


### PR DESCRIPTION
## Summary
Fixed integration action creation for function-data-actions integrations by checking
the actual integration type via API instead of string-matching the category name.

## Problem
The provider used `containsFunctionDataAction(category)` to determine if an action
should be created as a draft. This checked if the category string contained 
"function data action" (case-insensitive, with underscore/hyphen normalization).

If a user named their category anything else (e.g., "DEV_Genesys Cloud Function"),
the check failed, and the provider would POST to `/api/v2/integrations/actions` 
(the published endpoint). The API rejects this with 400: "Integration of type 
'function-data-actions' does not support creating published actions."

## Root Cause
The routing decision was based on a user-defined string (category name) instead of
the system-level integration type property.

## Fix
Added `isFunctionDataActionIntegration()` which calls 
`GET /api/v2/integrations/{integrationId}` to check the integration's actual type.
The check now uses: `isFunctionDataActionIntegration() || containsFunctionDataAction()`
(keeping the old check as fallback for backwards compatibility).

Applied to Create, Read, and Update paths.

## Testing
- Replicated the bug with category name "DEV_Genesys Cloud Function" on DCA region
- Before fix: 400 error on POST /api/v2/integrations/actions
- After fix: 201 success on POST /api/v2/integrations/actions/drafts
- Draft created, function upload succeeded
- Existing unit tests pass
