### PR TITLE
Fixes DEVTOOLING-1774 by re-sending file content on upload retries

### DIFF
--- a/genesyscloud/util/files/util_files.go
+++ b/genesyscloud/util/files/util_files.go
@@ -29,6 +29,7 @@ type S3Uploader struct {
 	reader        io.Reader
 	formData      map[string]io.Reader
 	bodyBuf       *bytes.Buffer
+	bodyPrepared  bool
 	Writer        *multipart.Writer
 	substitutions map[string]interface{}
 	headers       map[string]string
@@ -83,21 +84,30 @@ func (s *S3Uploader) UploadWithRetries(ctx context.Context, filePath string, tim
 }
 
 func UploadFn(s *S3Uploader) ([]byte, error) {
-	if s.formData != nil {
-		if err := s.createFormData(); err != nil {
-			return nil, err
+	// The body is assembled once and then reused for every attempt. Both the source reader and the
+	// multipart writer are single-use, so reassembling on a retry yields an empty or truncated body.
+	// S3 answers a zero length PUT with a 200, so the retry would look successful while storing
+	// nothing, and the failure would only surface much later as an unprocessable upload.
+	if !s.bodyPrepared {
+		if s.formData != nil {
+			if err := s.createFormData(); err != nil {
+				return nil, err
+			}
+			s.headers["Content-Type"] = s.Writer.FormDataContentType()
+		} else {
+			_, err := io.Copy(s.bodyBuf, s.reader)
+			if err != nil {
+				return nil, fmt.Errorf("failed to copy file content to the handler. Error: %s ", err)
+			}
 		}
-		s.headers["Content-Type"] = s.Writer.FormDataContentType()
-	} else {
-		_, err := io.Copy(s.bodyBuf, s.reader)
-		if err != nil {
-			return nil, fmt.Errorf("failed to copy file content to the handler. Error: %s ", err)
-		}
+
+		s.substituteValues()
+		s.bodyPrepared = true
 	}
 
-	s.substituteValues()
-
-	req, _ := http.NewRequest(s.httpMethod, s.presignedUrl, s.bodyBuf)
+	// Read over a copy of the bytes rather than handing bodyBuf itself to the request, since sending
+	// the request drains whatever reader it is given.
+	req, _ := http.NewRequest(s.httpMethod, s.presignedUrl, bytes.NewReader(s.bodyBuf.Bytes()))
 	for key, value := range s.headers {
 		req.Header.Set(key, value)
 	}

--- a/genesyscloud/util/files/util_files_test.go
+++ b/genesyscloud/util/files/util_files_test.go
@@ -10,7 +10,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	utilAws "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/aws"
 	testrunner "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/testrunner"
@@ -206,6 +208,137 @@ func TestUnitScriptUploadSuccess(t *testing.T) {
 	if resultsStr != scriptFile {
 		t.Errorf(`expected %s got %s`, scriptFile, resultsStr)
 	}
+}
+
+// recordingUploadServer answers the first request with a 503 and every one after it with a 200,
+// collecting the body of each attempt so a retry can be compared against the original send.
+func recordingUploadServer(t *testing.T, response string) (*httptest.Server, func() []string) {
+	t.Helper()
+
+	var (
+		mutex  sync.Mutex
+		bodies []string
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+		}
+
+		mutex.Lock()
+		bodies = append(bodies, string(body))
+		attempt := len(bodies)
+		mutex.Unlock()
+
+		if attempt == 1 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(response))
+	}))
+
+	return server, func() []string {
+		mutex.Lock()
+		defer mutex.Unlock()
+		return append([]string(nil), bodies...)
+	}
+}
+
+// TestUnitS3UploadRetryResendsFileContent covers a retried upload re-sending the file it was given.
+// The source reader and the body buffer are both spent by the first attempt, so a retry used to send
+// an empty body, which S3 accepts with a 200 and stores as a zero byte object.
+func TestUnitS3UploadRetryResendsFileContent(t *testing.T) {
+	const yamlFile = `inboundEmail:
+  name: Inbound Email Flow
+  description: An example inbound Email Flow
+`
+
+	mockServer, recordedBodies := recordingUploadServer(t, "upload complete")
+	defer mockServer.Close()
+
+	// UploadWithRetries stats the path to report the file size when an attempt fails.
+	filePath := filepath.Join(t.TempDir(), "inbound_email_flow.yaml")
+	if err := os.WriteFile(filePath, []byte(yamlFile), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	s3Uploader := NewS3Uploader(strings.NewReader(yamlFile), nil, make(map[string]interface{}), make(map[string]string), "PUT", mockServer.URL+"/s3/presigned")
+
+	if _, err := s3Uploader.UploadWithRetries(context.Background(), filePath, 30*time.Second); err != nil {
+		t.Fatalf("expected the retried upload to succeed, got %v", err)
+	}
+
+	bodies := recordedBodies()
+	assert.Len(t, bodies, 2, "expected the first attempt to fail and be retried")
+	for attempt, body := range bodies {
+		assert.Equal(t, yamlFile, body, "attempt %d sent the wrong body", attempt+1)
+	}
+}
+
+// TestUnitS3UploadRetryAppliesSubstitutionsOnce covers substituted content surviving a retry without
+// being substituted a second time against an already spent buffer.
+func TestUnitS3UploadRetryAppliesSubstitutionsOnce(t *testing.T) {
+	const origYamlFile = `inboundCall:
+  name: {{name}}
+`
+	const expectedYamlFile = `inboundCall:
+  name: SimpleFinancialIvr
+`
+
+	mockServer, recordedBodies := recordingUploadServer(t, "upload complete")
+	defer mockServer.Close()
+
+	filePath := filepath.Join(t.TempDir(), "inbound_call_flow.yaml")
+	if err := os.WriteFile(filePath, []byte(origYamlFile), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	substitutions := map[string]interface{}{"name": "SimpleFinancialIvr"}
+	s3Uploader := NewS3Uploader(strings.NewReader(origYamlFile), nil, substitutions, make(map[string]string), "PUT", mockServer.URL+"/s3/presigned")
+
+	if _, err := s3Uploader.UploadWithRetries(context.Background(), filePath, 30*time.Second); err != nil {
+		t.Fatalf("expected the retried upload to succeed, got %v", err)
+	}
+
+	bodies := recordedBodies()
+	assert.Len(t, bodies, 2, "expected the first attempt to fail and be retried")
+	for attempt, body := range bodies {
+		assert.Equal(t, expectedYamlFile, body, "attempt %d sent the wrong body", attempt+1)
+	}
+}
+
+// TestUnitScriptUploadRetryResendsFormData covers the multipart path, where the writer is closed by
+// the first attempt and so cannot be rebuilt for a retry.
+func TestUnitScriptUploadRetryResendsFormData(t *testing.T) {
+	const scriptName = "testScript"
+
+	mockServer, recordedBodies := recordingUploadServer(t, "upload complete")
+	defer mockServer.Close()
+
+	filePath := filepath.Join(t.TempDir(), "test.json")
+	if err := os.WriteFile(filePath, []byte(`{"id": "123"}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	formData := map[string]io.Reader{
+		"file":       strings.NewReader(`{"id": "123"}`),
+		"scriptName": strings.NewReader(scriptName),
+	}
+	headers := map[string]string{"Authorization": "Bearer 1234abcd"}
+
+	s3Uploader := NewS3Uploader(nil, formData, nil, headers, "POST", mockServer.URL+"/uploads/v2/scripter")
+
+	if _, err := s3Uploader.UploadWithRetries(context.Background(), filePath, 30*time.Second); err != nil {
+		t.Fatalf("expected the retried upload to succeed, got %v", err)
+	}
+
+	bodies := recordedBodies()
+	assert.Len(t, bodies, 2, "expected the first attempt to fail and be retried")
+	assert.Contains(t, bodies[0], scriptName, "the first attempt did not carry the form data")
+	assert.Equal(t, bodies[0], bodies[1], "the retry sent a different body than the first attempt")
 }
 
 func TestUnitDownloadOrOpenFile(t *testing.T) {


### PR DESCRIPTION
## Problem

Uploading a flow through `genesyscloud_flow` can intermittently succeed while
actually uploading nothing, causing the publish to fail later in Archy with
exit code 100 and the message:

    pre-processor - the root of the flow configuration must be an object

The message points at the flow YAML, so users end up debugging a file that is
perfectly valid. The failure does not reproduce on re-run.

## Root cause

`UploadFn` passed `s.bodyBuf` directly to `http.NewRequest`. Sending the
request drains that buffer, and the source `*os.File` it was filled from was
opened once before the uploader was constructed, so it is left at EOF and
never seeked back to the start.

`UploadWithRetriesFn` calls `UploadFn` again on the same instance, so any
attempt after the first copies zero bytes into an already-empty buffer and
issues a `PUT` with `Content-Length: 0`. S3 answers a zero-length PUT with a
`200`, so the retry reports success, the retry loop exits clean, and the
resource logs `Uploaded flow` having uploaded nothing.

This only triggers when a first attempt fails for a transient reason — a
connection reset, a timeout, or any non-200 such as a CloudFront/S3 503 —
which is why it hits one resource in an apply while its siblings succeed.

The multipart branch had the same defect: `createFormData` closes the writer
on the first pass, so a retry produced an envelope with every field value
emptied.

## Fix

Assemble the body once, guarded by a `bodyPrepared` flag, and give each
attempt a fresh non-consuming reader over the same bytes via
`bytes.NewReader(s.bodyBuf.Bytes())`. Using a `*bytes.Reader` also gives the
request a correct `Content-Length` and a working `GetBody` on every attempt.

## Affected resources

Two resources retry uploads and were exposed, both with a 20 second retry
window:

- `genesyscloud_flow`
- `genesyscloud_architect_grammar_language`

Response assets, scripts, contact lists and architect user prompts call
`Upload()` once, so they were not affected in practice, but they share the
multipart path and benefit from the same guard.

## Testing

Three unit tests drive the real `UploadWithRetries` path against a server
that returns 503 for the first request and records the body of every attempt,
covering the raw file path, substituted content, and multipart form data.

Verified they are meaningful by reverting the fix and re-running: the raw
path's retry sends an empty string, and the multipart retry sends an intact
envelope with all field values emptied. All three pass with the fix.

`go build ./...` is clean and the `genesyscloud/util/files` suite passes
under `-race`.

## Jira

DEVTOOLING-1774