### PR TITLE
[MRMO-595] external contacts export improvement

### DIFF
--- a/docs/resources/externalcontacts_contact.md
+++ b/docs/resources/externalcontacts_contact.md
@@ -42,6 +42,11 @@ The following OAuth scopes are required to use this resource:
 * `external-contacts`
 * `external-contacts:readonly`
 
+## Exported block labels
+
+By default, exported external contact block labels include the external organization name, followed by the contact's last and first names. This preserves existing block labels but requires an additional organization API request for each contact associated with an external organization.
+
+Set the `GENESYSCLOUD_EXTERNAL_CONTACTS_SIMPLE_BLOCK_LABEL` environment variable to omit the organization name and avoid those additional API requests. When enabled, block labels use the contact's last and first names. The variable's value is ignored; its presence enables the simpler labels.
 
 ## Example Usage
 

--- a/examples/resources/genesyscloud_externalcontacts_contact/notes.md
+++ b/examples/resources/genesyscloud_externalcontacts_contact/notes.md
@@ -1,0 +1,5 @@
+## Exported block labels
+
+By default, exported external contact block labels include the external organization name, followed by the contact's last and first names. This preserves existing block labels but requires an additional organization API request for each contact associated with an external organization.
+
+Set the `GENESYSCLOUD_EXTERNAL_CONTACTS_SIMPLE_BLOCK_LABEL` environment variable to omit the organization name and avoid those additional API requests. When enabled, block labels use the contact's last and first names. The variable's value is ignored; its presence enables the simpler labels.

--- a/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
+++ b/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
@@ -141,7 +141,7 @@ func getAllExternalContactsFn(ctx context.Context, p *externalContactsContactsPr
 			return nil, resp, fmt.Errorf("failed to get external contacts: %v", err)
 		}
 		response = resp
-		if externalContacts.Entities == nil || len(*externalContacts.Entities) == 0 {
+		if externalContacts == nil || externalContacts.Entities == nil || len(*externalContacts.Entities) == 0 {
 			break
 		}
 

--- a/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
+++ b/genesyscloud/external_contacts/genesyscloud_externalcontacts_contact_proxy.go
@@ -133,9 +133,10 @@ func getAllExternalContactsFn(ctx context.Context, p *externalContactsContactsPr
 
 	var allExternalContacts []platformclientv2.Externalcontact
 	cursor := ""
+	const pageSize = 200
 	var response *platformclientv2.APIResponse
 	for {
-		externalContacts, resp, err := p.externalContactsApi.GetExternalcontactsScanContacts(100, cursor, "")
+		externalContacts, resp, err := p.externalContactsApi.GetExternalcontactsScanContacts(pageSize, cursor, "")
 		if err != nil {
 			return nil, resp, fmt.Errorf("failed to get external contacts: %v", err)
 		}

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
@@ -58,7 +58,7 @@ func getAllAuthExternalContacts(ctx context.Context, clientConfig *platformclien
 		log.Printf("Dealing with external contact id : %s", *externalContact.Id)
 		var blockLabelParts []string
 
-		if externalContact.ExternalOrganization != nil {
+		if false {
 			externalOrg, resp, err := ep.getExternalContactsOrganizationById(ctx, *externalContact.ExternalOrganization.Id)
 			if err != nil {
 				return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get external contact organization %s: %v", *externalContact.ExternalOrganization.Id, err), resp)
@@ -117,7 +117,7 @@ func createExternalContact(ctx context.Context, d *schema.ResourceData, meta int
 // readExternalContacts is used by the externalcontacts_contact resource to read an external contact from genesys cloud.
 func readExternalContact(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ep := getExternalContactsContactsProxy(sdkConfig)
+	ep := newExternalContactsContactsProxy(sdkConfig)
 	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceExternalContact(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading external contact %s", d.Id())

--- a/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
+++ b/genesyscloud/external_contacts/resource_genesyscloud_externalcontacts_contact.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/feature_toggles"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 
@@ -58,7 +59,9 @@ func getAllAuthExternalContacts(ctx context.Context, clientConfig *platformclien
 		log.Printf("Dealing with external contact id : %s", *externalContact.Id)
 		var blockLabelParts []string
 
-		if false {
+		if externalContact.ExternalOrganization != nil &&
+			externalContact.ExternalOrganization.Id != nil &&
+			!feature_toggles.SimpleExternalContactBlockLabelToggleExists() {
 			externalOrg, resp, err := ep.getExternalContactsOrganizationById(ctx, *externalContact.ExternalOrganization.Id)
 			if err != nil {
 				return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to get external contact organization %s: %v", *externalContact.ExternalOrganization.Id, err), resp)
@@ -67,6 +70,7 @@ func getAllAuthExternalContacts(ctx context.Context, clientConfig *platformclien
 				blockLabelParts = append(blockLabelParts, *externalOrg.Name)
 			}
 		}
+
 		if externalContact.LastName != nil {
 			blockLabelParts = append(blockLabelParts, *externalContact.LastName)
 		}
@@ -117,7 +121,7 @@ func createExternalContact(ctx context.Context, d *schema.ResourceData, meta int
 // readExternalContacts is used by the externalcontacts_contact resource to read an external contact from genesys cloud.
 func readExternalContact(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	sdkConfig := meta.(*provider.ProviderMeta).ClientConfig
-	ep := newExternalContactsContactsProxy(sdkConfig)
+	ep := getExternalContactsContactsProxy(sdkConfig)
 	cc := consistency_checker.NewConsistencyCheck(ctx, d, meta, ResourceExternalContact(), constants.ConsistencyChecks(), ResourceType)
 
 	log.Printf("Reading external contact %s", d.Id())

--- a/genesyscloud/util/feature_toggles/external_contacts.go
+++ b/genesyscloud/util/feature_toggles/external_contacts.go
@@ -1,0 +1,18 @@
+package feature_toggles
+
+import "os"
+
+const simpleExternalContactBlockLabelEnvToggle = "GENESYSCLOUD_EXTERNAL_CONTACTS_SIMPLE_BLOCK_LABEL"
+
+// SimpleExternalContactBlockLabelToggleName returns the environment variable
+// that disables organization names in exported external contact block labels.
+func SimpleExternalContactBlockLabelToggleName() string {
+	return simpleExternalContactBlockLabelEnvToggle
+}
+
+// SimpleExternalContactBlockLabelToggleExists returns true when external contact
+// exports should avoid the organization lookup and use a simpler block label.
+func SimpleExternalContactBlockLabelToggleExists() bool {
+	_, exists := os.LookupEnv(simpleExternalContactBlockLabelEnvToggle)
+	return exists
+}

--- a/genesyscloud/util/feature_toggles/external_contacts_test.go
+++ b/genesyscloud/util/feature_toggles/external_contacts_test.go
@@ -1,0 +1,32 @@
+package feature_toggles
+
+import (
+	"os"
+	"testing"
+)
+
+func TestUnitSimpleExternalContactBlockLabelToggleExists(t *testing.T) {
+	toggleName := SimpleExternalContactBlockLabelToggleName()
+	originalValue, originallySet := os.LookupEnv(toggleName)
+	t.Cleanup(func() {
+		if originallySet {
+			os.Setenv(toggleName, originalValue)
+		} else {
+			os.Unsetenv(toggleName)
+		}
+	})
+
+	t.Run("unset", func(t *testing.T) {
+		os.Unsetenv(toggleName)
+		if SimpleExternalContactBlockLabelToggleExists() {
+			t.Fatal("expected simple block labels to be disabled by default")
+		}
+	})
+
+	t.Run("set", func(t *testing.T) {
+		t.Setenv(toggleName, "")
+		if !SimpleExternalContactBlockLabelToggleExists() {
+			t.Fatal("expected simple block labels when the environment variable is set")
+		}
+	})
+}


### PR DESCRIPTION
When collecting all external contacts for export, we are making an extra API call for each contact for the sake of building a block label that includes the external organisation name. That means if we have 1000 external contacts, we will make 10 API calls to [GET /api/v2/externalcontacts/scan/contacts?limit=100](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-externalcontacts-scan-contacts) and 1000 calls to [GET /api/v2/externalcontacts/organizations/{externalOrganizationId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-externalcontacts-organizations--externalOrganizationId-) (provided that all contacts have an external org associated with them) 

To not break existing systems I implemented a FT toggle that, when set, will tell our exporter to skip this extra API call. I also increased the page size to the max 200 in order to reduce API calls to the list endpoint. 

### Improvements 

| Version | # of contacts | Duration |
|---------|---------:|---------:|
| `dev` | 29,505 | ~30 minutes |
| `MRMO-595-ext-contacts-v2` | 29,505 | 59.6s **(30.4x faster)** |