### PR TITLE
fix/DEVTOOLING-1773: Fix sub_type_settings parameter shuffle in routing queue

### DIFF
--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -201,6 +201,18 @@ func setRoutingQueueStateFromQueue(ctx context.Context, d *schema.ResourceData, 
 		resourcedata.SetNillableValue(d, "acw_timeout_ms", currentQueue.AcwSettings.TimeoutMs)
 	}
 
+	// Save the current config order for sub_type_settings before clearing
+	var messageSubTypeConfigOrder []interface{}
+	if v := d.Get("media_settings_message"); v != nil {
+		if msgList, ok := v.([]interface{}); ok && len(msgList) > 0 {
+			if msgMap, ok := msgList[0].(map[string]interface{}); ok {
+				if subTypes, ok := msgMap["sub_type_settings"].([]interface{}); ok {
+					messageSubTypeConfigOrder = subTypes
+				}
+			}
+		}
+	}
+
 	_ = d.Set("media_settings_call", nil)
 	_ = d.Set("media_settings_callback", nil)
 	_ = d.Set("media_settings_chat", nil)
@@ -213,7 +225,9 @@ func setRoutingQueueStateFromQueue(ctx context.Context, d *schema.ResourceData, 
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "media_settings_callback", currentQueue.MediaSettings.Callback, flattenMediaSettingCallback)
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "media_settings_chat", currentQueue.MediaSettings.Chat, flattenMediaSetting)
 		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "media_settings_email", currentQueue.MediaSettings.Email, flattenMediaEmailSetting)
-		resourcedata.SetNillableValueWithInterfaceArrayWithFunc(d, "media_settings_message", currentQueue.MediaSettings.Message, flattenMediaSettingsMessage)
+		if currentQueue.MediaSettings.Message != nil {
+			_ = d.Set("media_settings_message", flattenMediaSettingsMessagePreserveOrder(currentQueue.MediaSettings.Message, messageSubTypeConfigOrder))
+		}
 	}
 	_ = d.Set("outbound_messaging_sms_address_id", nil)
 	_ = d.Set("outbound_messaging_whatsapp_recipient_id", nil)

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -727,6 +727,31 @@ func flattenMediaSetting(settings *platformclientv2.Mediasettings) []interface{}
 	return []interface{}{settingsMap}
 }
 
+func flattenMediaSettingsMessagePreserveOrder(settings *platformclientv2.Messagemediasettings, configOrder []interface{}) []any {
+	if settings == nil {
+		return nil
+	}
+	settingsMap := make(map[string]any)
+
+	resourcedata.SetMapValueIfNotNil(settingsMap, "alerting_timeout_sec", settings.AlertingTimeoutSeconds)
+	resourcedata.SetMapValueIfNotNil(settingsMap, "enable_auto_answer", settings.EnableAutoAnswer)
+	if settings.ServiceLevel != nil {
+		resourcedata.SetMapValueIfNotNil(settingsMap, "service_level_percentage", settings.ServiceLevel.Percentage)
+		resourcedata.SetMapValueIfNotNil(settingsMap, "service_level_duration_ms", settings.ServiceLevel.DurationMs)
+	}
+	if settings.SubTypeSettings != nil {
+		settingsMap["sub_type_settings"] = flattenSubTypeSettingsWithOrder(*settings.SubTypeSettings, configOrder)
+	}
+
+	resourcedata.SetMapValueIfNotNil(settingsMap, "enable_inactivity_timeout", settings.EnableInactivityTimeout)
+
+	if settings.InactivityTimeoutSettings != nil {
+		settingsMap["inactivity_timeout_settings"] = flattenInactivityTimeoutSettings(settings.InactivityTimeoutSettings)
+	}
+
+	return []any{settingsMap}
+}
+
 func flattenMediaSettingsMessage(settings *platformclientv2.Messagemediasettings) []any {
 	if settings == nil {
 		return nil
@@ -768,7 +793,54 @@ func flattenSubTypeSettings(subType map[string]platformclientv2.Messagesubtypese
 		return nil
 	}
 
-	// Sort keys to ensure deterministic ordering and avoid phantom diffs
+	subTypeList := make([]interface{}, 0, len(subType))
+	for key, value := range subType {
+		subTypeMap := make(map[string]interface{})
+		resourcedata.SetMapValueIfNotNil(subTypeMap, "media_type", &key)
+		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_auto_answer", value.EnableAutoAnswer)
+		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_inactivity_timeout", value.EnableInactivityTimeout)
+		subTypeList = append(subTypeList, subTypeMap)
+	}
+	return subTypeList
+}
+
+func flattenSubTypeSettingsWithOrder(subType map[string]platformclientv2.Messagesubtypesettings, configOrder []interface{}) []interface{} {
+	if subType == nil {
+		return nil
+	}
+
+	// Build a map of media_type -> flattened settings from the API response
+	apiMap := make(map[string]map[string]interface{})
+	for key, value := range subType {
+		subTypeMap := make(map[string]interface{})
+		resourcedata.SetMapValueIfNotNil(subTypeMap, "media_type", &key)
+		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_auto_answer", value.EnableAutoAnswer)
+		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_inactivity_timeout", value.EnableInactivityTimeout)
+		apiMap[key] = subTypeMap
+	}
+
+	// If we have config order, preserve it — only return items that are in the config
+	if len(configOrder) > 0 {
+		result := make([]interface{}, 0, len(configOrder))
+
+		// Return items in the config's order, using API values
+		for _, item := range configOrder {
+			if m, ok := item.(map[string]interface{}); ok {
+				if mediaType, ok := m["media_type"].(string); ok {
+					if apiItem, exists := apiMap[mediaType]; exists {
+						result = append(result, apiItem)
+					} else {
+						// Item is in config but not in API response — keep config values
+						result = append(result, m)
+					}
+				}
+			}
+		}
+
+		return result
+	}
+
+	// No config order available, return all API items in sorted order
 	keys := make([]string, 0, len(subType))
 	for key := range subType {
 		keys = append(keys, key)
@@ -777,12 +849,7 @@ func flattenSubTypeSettings(subType map[string]platformclientv2.Messagesubtypese
 
 	subTypeList := make([]interface{}, 0, len(subType))
 	for _, key := range keys {
-		value := subType[key]
-		subTypeMap := make(map[string]interface{})
-		resourcedata.SetMapValueIfNotNil(subTypeMap, "media_type", &key)
-		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_auto_answer", value.EnableAutoAnswer)
-		resourcedata.SetMapValueIfNotNil(subTypeMap, "enable_inactivity_timeout", value.EnableInactivityTimeout)
-		subTypeList = append(subTypeList, subTypeMap)
+		subTypeList = append(subTypeList, apiMap[key])
 	}
 	return subTypeList
 }


### PR DESCRIPTION
**Summary**
Fixes phantom diffs ("parameter shuffle") on media_settings_message.sub_type_settings in genesyscloud_routing_queue. Every terraform plan showed ordering changes even when no actual configuration change occurred.

**Root Cause**
sub_type_settings is a TypeList (order-sensitive) but the API returns data as a Go map[string] (non-deterministic order). The previous fix (v1.78.0) sorted alphabetically, which is deterministic but doesn't match the user's HCL config order — causing perpetual drift.

**Fix**
Implemented "preserve config order" pattern:
Save the current config/state ordering of sub_type_settings before clearing during read
Match API response items to config items by media_type key
Return items in the user's original config order instead of alphabetical order
Fall back to sorted order when no prior state exists (e.g., first import)

**Files Changed**
resource_genesyscloud_routing_queue.go
 — save config order before nil-clear, call new preserve-order flatten
resource_genesyscloud_routing_queue_utils.go
 — added flattenMediaSettingsMessagePreserveOrder and flattenSubTypeSettingsWithOrder

**Testing**
Manual testing: created queue with non-alphabetical sub_type_settings order, confirmed terraform plan shows "No changes" on subsequent runs
Consistency checker passes without retries
Existing functionality (apply, update, import) unaffected

**Related**
DEVTOOLING-1773
Reported on v1.74.0, confirmed present through v1.84.0
Previous incomplete fix: v1.78.0 (alphabetical sort)