### PR TITLE
DEVTOOLING-1337 - Fix function data action export and file path handling

### DIFF
--- a/docs/resources/integration_action.md
+++ b/docs/resources/integration_action.md
@@ -134,11 +134,11 @@ resource "genesyscloud_integration_action" "example_action" {
 }
 
 # Example with function configuration
-# Note: function_config is only required for function data actions (when category = "Genesys Cloud Data Action")
-# For regular integration actions, this section can be omitted
+# Required when the integration type is "function-data-actions" (or category contains "function data action").
+# Genesys Cloud cannot download function zips — keep the zip available locally / in your pipeline.
 resource "genesyscloud_integration_action" "example_function_action" {
   name                   = "Example Function Action"
-  category               = "Genesys Cloud Data Action"
+  category               = "Function Data Actions"
   integration_id         = genesyscloud_integration.example_gc_data_integration.id
   secure                 = true
   config_timeout_seconds = 20
@@ -167,12 +167,19 @@ resource "genesyscloud_integration_action" "example_function_action" {
     }
   })
 
+  config_request {
+    request_type         = "POST"
+    request_url_template = ""
+    request_template     = "$${input.rawRequest}"
+  }
+
   function_config {
-    description     = "Custom function for data processing"
-    handler         = "index.handler"
-    runtime         = "nodejs18.x"
-    timeout_seconds = 30
-    file_path       = "${local.working_dir.integration_action}/function.zip"
+    description       = "Custom function for data processing"
+    handler           = "index.handler"
+    runtime           = "nodejs22.x"
+    timeout_seconds   = 30
+    file_path         = "${local.working_dir.integration_action}/function.zip"
+    file_content_hash = filesha256("${local.working_dir.integration_action}/function.zip")
   }
 }
 ```
@@ -182,10 +189,10 @@ resource "genesyscloud_integration_action" "example_function_action" {
 
 ### Required
 
-- `category` (String) Category of action. Can be up to 256 characters long. If the category contains 'function data action' (case-insensitive, underscores and hyphens treated as spaces), the action will be treated as a function data action and requires function_config to be set.
+- `category` (String) Category of action. Can be up to 256 characters long. Function data actions are detected when the associated integration type is 'function-data-actions', or when the category contains 'function data action' (case-insensitive; underscores and hyphens treated as spaces). Function data actions require function_config to be set.
 - `contract_input` (String) JSON Schema that defines the body of the request that the client (edge/architect/postman) is sending to the service, on the /execute path. Changing the contract_input attribute will cause the existing integration_action to be dropped and recreated with a new ID.
 - `contract_output` (String) JSON schema that defines the transformed, successful result that will be sent back to the caller. Changing the contract_output attribute will cause the existing integration_action to be dropped and recreated with a new ID.
-- `integration_id` (String) The ID of the integration this action is associated with. Changing the integration_id attribute will cause the existing integration_action to be dropped and recreated with a new ID.
+- `integration_id` (String) The ID of the integration this action is associated with. When the integration type is 'function-data-actions', this action is created as a draft, the zip is uploaded, then published. Changing the integration_id attribute will cause the existing integration_action to be dropped and recreated with a new ID.
 - `name` (String) Name of the action. Can be up to 256 characters long
 
 ### Optional
@@ -230,11 +237,12 @@ Optional:
 
 Required:
 
-- `file_path` (String) The zip file path containing the function data action's code. During the export just the name of the zip file will be exported
+- `file_path` (String) Local path to the zip file containing the function data action code. Genesys Cloud does not allow downloading function zip files, so exports cannot retrieve the binary. After export, supply the zip at the exported path (or update file_path) before apply. See https://help.genesys.cloud/articles/add-function-configuration/
 
 Optional:
 
 - `description` (String) Description of the function.
+- `file_content_hash` (String) Hash value of the function zip file content. Used to detect changes. Typically set with filesha256(file_path). Computed by the provider when omitted.
 - `handler` (String) The handler function name.
 - `runtime` (String) The runtime environment for the function.
 - `timeout_seconds` (Number) Timeout in seconds for the function execution.

--- a/examples/resources/genesyscloud_integration_action/function_config_example.tf
+++ b/examples/resources/genesyscloud_integration_action/function_config_example.tf
@@ -1,17 +1,29 @@
 # Example demonstrating the function_config schema for integration actions
-# This shows how to configure a custom function with file upload
-# 
-# IMPORTANT: function_config is only required for function data actions 
-# (when category = "function data action")
-# For regular integration actions, this section can be omitted
+#
+# Function data actions are detected when:
+#   - the associated integration has integration_type = "function-data-actions", OR
+#   - category contains "function data action" (case-insensitive)
+#
+# Genesys Cloud does not allow downloading function ZIP files. Keep zips in source
+# control / your pipeline and point file_path at them. After a CX as Code export,
+# copy the zip to the exported path (under function_zips/) or update file_path.
+
+resource "genesyscloud_integration" "example_function_integration" {
+  integration_type = "function-data-actions"
+  intended_state   = "ENABLED"
+  config {
+    name       = "Example Function Integration"
+    properties = jsonencode({})
+    advanced   = jsonencode({})
+  }
+}
 
 resource "genesyscloud_integration_action" "function_example" {
   name           = "Custom Data Processing Function"
-  category       = "function data action"
-  integration_id = genesyscloud_integration.example_gc_data_integration.id
+  category       = "Function Data Actions"
+  integration_id = genesyscloud_integration.example_function_integration.id
   secure         = true
 
-  # Contract defines the input/output schema for the function
   contract_input = jsonencode({
     "type" = "object",
     "required" = [
@@ -27,19 +39,6 @@ resource "genesyscloud_integration_action" "function_example" {
         "type"        = "string",
         "enum"        = ["encrypt", "decrypt", "transform"],
         "description" = "The operation to perform"
-      },
-      "options" = {
-        "type" = "object",
-        "properties" = {
-          "algorithm" = {
-            "type"    = "string",
-            "default" = "AES-256"
-          },
-          "timeout" = {
-            "type"    = "integer",
-            "default" = 30
-          }
-        }
       }
     }
   })
@@ -58,40 +57,31 @@ resource "genesyscloud_integration_action" "function_example" {
       "result" = {
         "type"        = "string",
         "description" = "The processed result"
-      },
-      "metadata" = {
-        "type" = "object",
-        "properties" = {
-          "processingTime" = {
-            "type"        = "number",
-            "description" = "Time taken to process in milliseconds"
-          },
-          "algorithm" = {
-            "type"        = "string",
-            "description" = "Algorithm used for processing"
-          }
-        }
       }
     }
   })
 
-  # Function configuration block - this is where file_path and file_content_hash are defined
+  config_request {
+    request_type         = "POST"
+    request_url_template = ""
+    request_template     = "$${input.rawRequest}"
+  }
+
   function_config {
-    description       = "Custom data processing function with encryption/decryption capabilities"
-    handler           = "src/index.handler"
-    runtime           = "nodejs18.x"
-    timeout_seconds   = 45
-    file_path         = "/path/to/your/function.zip"
-    file_content_hash = "sha256:abcdef1234567890..."
-    publish           = true # Automatically publish after creation
+    description       = "Custom data processing function"
+    handler           = "dist/index.handler"
+    runtime           = "nodejs22.x"
+    timeout_seconds   = 15
+    file_path         = "${path.module}/function.zip"
+    file_content_hash = filesha256("${path.module}/function.zip")
   }
 }
 
-# Example with minimal function configuration
+# Minimal function configuration (hash is optional; provider computes it on apply)
 resource "genesyscloud_integration_action" "minimal_function" {
   name           = "Simple Function"
-  category       = "Genesys Cloud Data Action"
-  integration_id = genesyscloud_integration.example_gc_data_integration.id
+  category       = "Function Data Actions"
+  integration_id = genesyscloud_integration.example_function_integration.id
 
   contract_input = jsonencode({
     "type" = "object",
@@ -111,65 +101,21 @@ resource "genesyscloud_integration_action" "minimal_function" {
     }
   })
 
+  config_request {
+    request_type         = "POST"
+    request_url_template = ""
+    request_template     = "$${input.rawRequest}"
+  }
+
   function_config {
-    handler           = "handler.js"
-    runtime           = "python3.9"
-    file_path         = "./function.zip"
-    file_content_hash = "sha256:1234567890abcdef..."
-    # publish defaults to true if not specified
+    handler   = "index.handler"
+    runtime   = "nodejs22.x"
+    file_path = var.function_zip_path
   }
 }
 
-# Example showing how to use variables for file paths
-resource "genesyscloud_integration_action" "variable_function" {
-  name           = "Variable Function Example"
-  category       = "Genesys Cloud Data Action"
-  integration_id = genesyscloud_integration.example_gc_data_integration.id
-
-  contract_input = jsonencode({
-    "type" = "object",
-    "properties" = {
-      "data" = {
-        "type" = "string"
-      }
-    }
-  })
-
-  contract_output = jsonencode({
-    "type" = "object",
-    "properties" = {
-      "processed" = {
-        "type" = "string"
-      }
-    }
-  })
-
-  function_config {
-    description       = "Function using variable references"
-    handler           = "main.handler"
-    runtime           = "nodejs16.x"
-    timeout_seconds   = 20
-    file_path         = var.function_zip_path
-    file_content_hash = var.function_zip_hash
-    publish           = var.auto_publish
-  }
-}
-
-# Variables for the variable_function example
 variable "function_zip_path" {
   description = "Path to the function zip file"
   type        = string
   default     = "./functions/processor.zip"
 }
-
-variable "function_zip_hash" {
-  description = "Hash of the function zip file content"
-  type        = string
-  default     = "sha256:default_hash_here"
-}
-
-variable "auto_publish" {
-  description = "Whether to automatically publish the action"
-  type        = bool
-  default     = false
-} 

--- a/examples/resources/genesyscloud_integration_action/resource.tf
+++ b/examples/resources/genesyscloud_integration_action/resource.tf
@@ -65,11 +65,11 @@ resource "genesyscloud_integration_action" "example_action" {
 }
 
 # Example with function configuration
-# Note: function_config is only required for function data actions (when category = "Genesys Cloud Data Action")
-# For regular integration actions, this section can be omitted
+# Required when the integration type is "function-data-actions" (or category contains "function data action").
+# Genesys Cloud cannot download function zips — keep the zip available locally / in your pipeline.
 resource "genesyscloud_integration_action" "example_function_action" {
   name                   = "Example Function Action"
-  category               = "Genesys Cloud Data Action"
+  category               = "Function Data Actions"
   integration_id         = genesyscloud_integration.example_gc_data_integration.id
   secure                 = true
   config_timeout_seconds = 20
@@ -98,11 +98,18 @@ resource "genesyscloud_integration_action" "example_function_action" {
     }
   })
 
+  config_request {
+    request_type         = "POST"
+    request_url_template = ""
+    request_template     = "$${input.rawRequest}"
+  }
+
   function_config {
-    description     = "Custom function for data processing"
-    handler         = "index.handler"
-    runtime         = "nodejs18.x"
-    timeout_seconds = 30
-    file_path       = "${local.working_dir.integration_action}/function.zip"
+    description       = "Custom function for data processing"
+    handler           = "index.handler"
+    runtime           = "nodejs22.x"
+    timeout_seconds   = 30
+    file_path         = "${local.working_dir.integration_action}/function.zip"
+    file_content_hash = filesha256("${local.working_dir.integration_action}/function.zip")
   }
 }

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 
+	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/files"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
 
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
@@ -347,6 +348,10 @@ func updateFunctionDataActionDraft(ctx context.Context, d *schema.ResourceData, 
 		return diagErr
 	}
 
+	if err := hashAndSetFunctionConfigFile(ctx, d, filePath); err != nil {
+		return util.BuildDiagnosticError(ResourceType, fmt.Sprintf("failed to hash function zip %s", filePath), err)
+	}
+
 	return readIntegrationActionFunction(ctx, d, meta)
 }
 
@@ -497,7 +502,23 @@ func createFunctionDataActionDraft(ctx context.Context, d *schema.ResourceData, 
 		return diagErr
 	}
 
+	if err := hashAndSetFunctionConfigFile(ctx, d, filePath); err != nil {
+		return util.BuildDiagnosticError(ResourceType, fmt.Sprintf("failed to hash function zip %s", filePath), err)
+	}
+
 	return readIntegrationAction(ctx, d, meta)
+}
+
+func hashAndSetFunctionConfigFile(ctx context.Context, d *schema.ResourceData, filePath string) error {
+	if filePath == "" {
+		return nil
+	}
+	fileHash, err := files.HashFileContent(ctx, filePath, S3Enabled)
+	if err != nil {
+		return err
+	}
+	setFunctionConfigFileHash(d, fileHash)
+	return nil
 }
 
 // extractZipIdFromFunctionData extracts the zipId from the function data response
@@ -625,7 +646,8 @@ func readIntegrationActionFunction(ctx context.Context, d *schema.ResourceData, 
 
 		if functionData != nil {
 			action.Config.Request.RequestTemplate = reqTemp
-			_ = d.Set("function_config", FlattenFunctionConfigRequest(*functionData))
+			existingPath, existingHash := getExistingFunctionConfigFileFields(d)
+			_ = d.Set("function_config", FlattenFunctionConfigRequest(*functionData, existingPath, existingHash))
 		} else {
 			_ = d.Set("function_config", nil)
 		}
@@ -737,7 +759,8 @@ func readIntegrationAction(ctx context.Context, d *schema.ResourceData, meta int
 
 			if functionData != nil {
 				action.Config.Request.RequestTemplate = reqTemp
-				_ = d.Set("function_config", FlattenFunctionConfigRequest(*functionData))
+				existingPath, existingHash := getExistingFunctionConfigFileFields(d)
+				_ = d.Set("function_config", FlattenFunctionConfigRequest(*functionData, existingPath, existingHash))
 			} else {
 				_ = d.Set("function_config", nil)
 			}
@@ -756,11 +779,17 @@ func updateIntegrationAction(ctx context.Context, d *schema.ResourceData, meta i
 	name := d.Get("name").(string)
 	category := d.Get("category").(string)
 	id := d.Id()
+	integrationId := d.Get("integration_id").(string)
 
 	log.Printf("Updating integration action %s", name)
 
 	// Set resource context for SDK debug logging before entering retry loop
 	ctx = util.SetResourceContext(ctx, d, ResourceType)
+
+	// Function data actions must use the draft → upload → publish flow; skip published PATCH.
+	if isFunctionDataActionIntegration(ctx, integrationId, iap) || containsFunctionDataAction(category) {
+		return updateFunctionDataActionDraft(ctx, d, meta, iap)
+	}
 
 	diagErr := util.RetryWhen(util.IsVersionMismatch, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
 		// Get the latest action version to send with PATCH
@@ -782,10 +811,6 @@ func updateIntegrationAction(ctx context.Context, d *schema.ResourceData, meta i
 	})
 	if diagErr != nil {
 		return diagErr
-	}
-
-	if isFunctionDataActionIntegration(ctx, d.Get("integration_id").(string), iap) || containsFunctionDataAction(category) {
-		return updateFunctionDataActionDraft(ctx, d, meta, iap)
 	}
 
 	log.Printf("Updated integration action %s", name)

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter.go
@@ -1,0 +1,114 @@
+package integration_action
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
+)
+
+var functionZipFileNameSanitizer = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+// FunctionZipExportResolver updates exported function_config paths for function data actions.
+//
+// Genesys Cloud does not provide an API (or UI) to download function zip binaries.
+// See: https://help.genesys.cloud/articles/add-function-configuration/
+// This resolver therefore cannot retrieve the zip. It rewrites file_path to a conventional
+// relative location under function_zips/, clears file_content_hash, and writes a README so
+// pipelines know they must supply the zip before apply.
+func FunctionZipExportResolver(actionId, exportDirectory, subDirectory string, configMap map[string]interface{}, meta interface{}, resource resourceExporter.ResourceInfo) error {
+	_ = meta
+
+	functionConfigRaw, ok := configMap["function_config"]
+	if !ok || functionConfigRaw == nil {
+		return nil
+	}
+
+	functionConfigList, ok := functionConfigRaw.([]interface{})
+	if !ok || len(functionConfigList) == 0 || functionConfigList[0] == nil {
+		return nil
+	}
+
+	functionMap, ok := functionConfigList[0].(map[string]interface{})
+	if !ok {
+		return nil
+	}
+
+	fullPath := filepath.Join(exportDirectory, subDirectory)
+	if err := os.MkdirAll(fullPath, os.ModePerm); err != nil {
+		return err
+	}
+
+	if err := writeFunctionZipExportReadme(fullPath); err != nil {
+		return err
+	}
+
+	zipFileName := buildExportedFunctionZipFileName(functionMap, configMap, actionId)
+	exportFilePath := filepath.Join(subDirectory, zipFileName)
+	normalizedPath := strings.ReplaceAll(exportFilePath, "\\", "/")
+
+	log.Printf("WARNING: Function data action zip for %s cannot be downloaded from Genesys Cloud. "+
+		"Exported file_path set to %s — place the zip at that path (or update file_path) before apply.",
+		actionId, normalizedPath)
+
+	functionMap["file_path"] = normalizedPath
+	delete(functionMap, "file_content_hash")
+
+	configMap["function_config"] = []interface{}{functionMap}
+
+	if resource.State != nil && resource.State.Attributes != nil {
+		resource.State.Attributes["function_config.0.file_path"] = normalizedPath
+		delete(resource.State.Attributes, "function_config.0.file_content_hash")
+	}
+
+	return nil
+}
+
+func writeFunctionZipExportReadme(directory string) error {
+	readmePath := filepath.Join(directory, "README.md")
+	if _, err := os.Stat(readmePath); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
+	}
+
+	const contents = `# Function data action zip files
+
+Genesys Cloud does not allow downloading function ZIP files (API or UI).
+See: https://help.genesys.cloud/articles/add-function-configuration/
+
+Exported function actions reference zip paths in this directory, but the binaries
+are **not** included. Before applying exported Terraform:
+
+1. Copy each function zip into this directory using the exported file name, or
+2. Update each resource's function_config.file_path to point at your zip, and
+3. Optionally set function_config.file_content_hash = filesha256("<path>").
+`
+	return os.WriteFile(readmePath, []byte(contents), 0o644)
+}
+
+func buildExportedFunctionZipFileName(functionMap, configMap map[string]interface{}, actionId string) string {
+	if pathVal, ok := functionMap["file_path"].(string); ok && strings.TrimSpace(pathVal) != "" {
+		base := filepath.Base(strings.TrimSpace(pathVal))
+		if base != "" && base != "." && base != string(filepath.Separator) {
+			if !strings.HasSuffix(strings.ToLower(base), ".zip") {
+				base = base + ".zip"
+			}
+			return functionZipFileNameSanitizer.ReplaceAllString(base, "_")
+		}
+	}
+
+	baseName := "function"
+	if name, ok := configMap["name"].(string); ok && strings.TrimSpace(name) != "" {
+		baseName = strings.TrimSpace(name)
+	}
+	baseName = functionZipFileNameSanitizer.ReplaceAllString(baseName, "_")
+	if len(baseName) > 64 {
+		baseName = baseName[:64]
+	}
+	return fmt.Sprintf("%s-%s.zip", baseName, actionId)
+}

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter_test.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter_test.go
@@ -1,0 +1,132 @@
+package integration_action
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
+)
+
+func TestUnitFlattenFunctionConfigRequestPreservesLocalFileFields(t *testing.T) {
+	zipName := "uploaded.zip"
+	handler := "index.handler"
+	functionConfig := platformclientv2.Functionconfig{
+		Function: &platformclientv2.Function{
+			Handler: &handler,
+		},
+		Zip: &platformclientv2.Functionzipconfig{
+			Name: &zipName,
+		},
+	}
+
+	flattened := FlattenFunctionConfigRequest(functionConfig, "/local/path/function.zip", "sha256:abc")
+	if len(flattened) != 1 {
+		t.Fatalf("expected 1 function_config element, got %d", len(flattened))
+	}
+	m := flattened[0].(map[string]interface{})
+	if m["file_path"] != "/local/path/function.zip" {
+		t.Fatalf("expected preserved file_path, got %v", m["file_path"])
+	}
+	if m["file_content_hash"] != "sha256:abc" {
+		t.Fatalf("expected preserved file_content_hash, got %v", m["file_content_hash"])
+	}
+	if m["handler"] != handler {
+		t.Fatalf("expected handler %s, got %v", handler, m["handler"])
+	}
+}
+
+func TestUnitFlattenFunctionConfigRequestFallsBackToZipName(t *testing.T) {
+	zipName := "uploaded.zip"
+	functionConfig := platformclientv2.Functionconfig{
+		Zip: &platformclientv2.Functionzipconfig{
+			Name: &zipName,
+		},
+	}
+
+	flattened := FlattenFunctionConfigRequest(functionConfig, "", "")
+	m := flattened[0].(map[string]interface{})
+	if m["file_path"] != zipName {
+		t.Fatalf("expected zip name fallback, got %v", m["file_path"])
+	}
+	if _, ok := m["file_content_hash"]; ok {
+		t.Fatalf("did not expect file_content_hash when none provided")
+	}
+}
+
+func TestUnitFunctionZipExportResolver(t *testing.T) {
+	exportDir := t.TempDir()
+	actionId := "action-123"
+	configMap := map[string]interface{}{
+		"name": "Get Ticket Status",
+		"function_config": []interface{}{
+			map[string]interface{}{
+				"handler":           "dist/index.handler",
+				"file_path":         "xp2025_get_ticket_status.zip",
+				"file_content_hash": "sha256:should-be-removed",
+			},
+		},
+	}
+	resource := resourceExporter.ResourceInfo{
+		State: &terraform.InstanceState{
+			ID: actionId,
+			Attributes: map[string]string{
+				"function_config.0.file_path":         "xp2025_get_ticket_status.zip",
+				"function_config.0.file_content_hash": "sha256:should-be-removed",
+			},
+		},
+	}
+
+	if err := FunctionZipExportResolver(actionId, exportDir, FunctionZipExportSubDirectory, configMap, nil, resource); err != nil {
+		t.Fatalf("FunctionZipExportResolver returned error: %v", err)
+	}
+
+	fc := configMap["function_config"].([]interface{})[0].(map[string]interface{})
+	expectedPath := filepath.ToSlash(filepath.Join(FunctionZipExportSubDirectory, "xp2025_get_ticket_status.zip"))
+	if fc["file_path"] != expectedPath {
+		t.Fatalf("expected exported file_path %s, got %v", expectedPath, fc["file_path"])
+	}
+	if _, ok := fc["file_content_hash"]; ok {
+		t.Fatalf("file_content_hash should be cleared on export")
+	}
+	if resource.State.Attributes["function_config.0.file_path"] != expectedPath {
+		t.Fatalf("state file_path not updated")
+	}
+	if _, ok := resource.State.Attributes["function_config.0.file_content_hash"]; ok {
+		t.Fatalf("state file_content_hash should be cleared")
+	}
+
+	readmePath := filepath.Join(exportDir, FunctionZipExportSubDirectory, "README.md")
+	if _, err := os.Stat(readmePath); err != nil {
+		t.Fatalf("expected README.md to be written: %v", err)
+	}
+}
+
+func TestUnitFunctionZipExportResolverNoopWithoutFunctionConfig(t *testing.T) {
+	configMap := map[string]interface{}{
+		"name": "Regular Action",
+	}
+	resource := resourceExporter.ResourceInfo{
+		State: &terraform.InstanceState{Attributes: map[string]string{}},
+	}
+	if err := FunctionZipExportResolver("id", t.TempDir(), FunctionZipExportSubDirectory, configMap, nil, resource); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+}
+
+func TestUnitContainsFunctionDataAction(t *testing.T) {
+	cases := map[string]bool{
+		"Function Data Actions":     true,
+		"function-data-action":      true,
+		"function_data_action":      true,
+		"Genesys Cloud Data Action": false,
+		"Get Ticket Status":         false,
+	}
+	for input, want := range cases {
+		if got := containsFunctionDataAction(input); got != want {
+			t.Fatalf("containsFunctionDataAction(%q)=%v, want %v", input, got, want)
+		}
+	}
+}

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_schema.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_schema.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/validators"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -25,7 +26,13 @@ resource_genesyscloud_integration_action_schema.go should hold four types of fun
 3.  The datasource schema definitions for the integration_action datasource.
 4.  The resource exporter configuration for the integration_action exporter.
 */
-const ResourceType = "genesyscloud_integration_action"
+const (
+	ResourceType = "genesyscloud_integration_action"
+	// S3Enabled indicates function zip paths may use local or S3-backed file paths for hashing.
+	S3Enabled = true
+	// FunctionZipExportSubDirectory is where export places placeholder paths for function zips.
+	FunctionZipExportSubDirectory = "function_zips"
+)
 
 // SetRegistrar registers all of the resources, datasources and exporters in the package
 func SetRegistrar(l registrar.Registrar) {
@@ -121,10 +128,20 @@ func ResourceIntegrationAction() *schema.Resource {
 				Computed:    true,
 			},
 			"file_path": {
-				Description:  "The zip file path containing the function data action's code. During the export just the name of the zip file will be exported",
+				Description: "Local path to the zip file containing the function data action code. " +
+					"Genesys Cloud does not allow downloading function zip files, so exports cannot retrieve the binary. " +
+					"After export, supply the zip at the exported path (or update file_path) before apply. " +
+					"See https://help.genesys.cloud/articles/add-function-configuration/",
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validators.ValidatePath,
+			},
+			"file_content_hash": {
+				Description: "Hash value of the function zip file content. Used to detect changes. " +
+					"Typically set with filesha256(file_path). Computed by the provider when omitted.",
+				Type:     schema.TypeString,
+				Optional: true,
+				Computed: true,
 			},
 		},
 	}
@@ -136,6 +153,9 @@ func ResourceIntegrationAction() *schema.Resource {
 		ReadContext:   provider.ReadWithPooledClient(readIntegrationAction),
 		UpdateContext: provider.UpdateWithPooledClient(updateIntegrationAction),
 		DeleteContext: provider.DeleteWithPooledClient(deleteIntegrationAction),
+		CustomizeDiff: customdiff.All(
+			customdiff.ComputedIf("function_config.0.file_content_hash", validators.ValidateFileContentHashChanged("function_config.0.file_path", "function_config.0.file_content_hash", S3Enabled)),
+		),
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
@@ -148,16 +168,21 @@ func ResourceIntegrationAction() *schema.Resource {
 				ValidateFunc: validation.StringLenBetween(1, 256),
 			},
 			"category": {
-				Description:  "Category of action. Can be up to 256 characters long. If the category contains 'function data action' (case-insensitive, underscores and hyphens treated as spaces), the action will be treated as a function data action and requires function_config to be set.",
+				Description: "Category of action. Can be up to 256 characters long. " +
+					"Function data actions are detected when the associated integration type is 'function-data-actions', " +
+					"or when the category contains 'function data action' (case-insensitive; underscores and hyphens treated as spaces). " +
+					"Function data actions require function_config to be set.",
 				Type:         schema.TypeString,
 				Required:     true,
 				ValidateFunc: validation.StringLenBetween(1, 256),
 			},
 			"integration_id": {
-				Description: "The ID of the integration this action is associated with. Changing the integration_id attribute will cause the existing integration_action to be dropped and recreated with a new ID.",
-				Type:        schema.TypeString,
-				Required:    true,
-				ForceNew:    true,
+				Description: "The ID of the integration this action is associated with. " +
+					"When the integration type is 'function-data-actions', this action is created as a draft, the zip is uploaded, then published. " +
+					"Changing the integration_id attribute will cause the existing integration_action to be dropped and recreated with a new ID.",
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
 			},
 			"secure": {
 				Description: "Indication of whether or not the action is designed to accept sensitive data. Changing the secure attribute will cause the existing integration_action to be dropped and recreated with a new ID.",
@@ -228,6 +253,14 @@ func IntegrationActionExporter() *resourceExporter.ResourceExporter {
 		},
 		JsonEncodeAttributes: []string{"contract_input", "contract_output"},
 		AllowZeroValuesInMap: []string{"config_response.translation_map_defaults"},
+		CustomFileWriter: resourceExporter.CustomFileWriterSettings{
+			RetrieveAndWriteFilesFunc: FunctionZipExportResolver,
+			SubDirectory:              FunctionZipExportSubDirectory,
+		},
+		ThirdPartyRefAttrs: []string{
+			"function_config.file_path",
+			"function_config.file_content_hash",
+		},
 		// Static (built-in) data actions are owned by Genesys Cloud and cannot be created,
 		// updated, or deleted via the public API. Export them as data sources so that other
 		// resources (e.g. Architect flows) can reference them by name + integration_id.

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_test.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_test.go
@@ -254,10 +254,7 @@ func TestAccResourceIntegrationActionFunctionData(t *testing.T) {
 		runtime2     = "nodejs22.x"
 		filePath1    = zipPath1
 		filePath2    = zipPath2
-		// publish field is not in the schema, so removing these
-		// publish1         = "true"
-		// publish2         = "false"
-		headerVal2 = "no-store"
+		headerVal2   = "no-store"
 
 		// Request/Response configuration values
 		reqUrlTemplate1 = "/api/v2/users"
@@ -330,9 +327,11 @@ func TestAccResourceIntegrationActionFunctionData(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.handler", handler1),
 					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.runtime", runtime1),
 					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.timeout_seconds", timeout1),
-					// file_path and file_content_hash are input-only fields not returned by the API
-					// so we can't verify them in the state
+					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.file_path", filePath1),
+					resource.TestCheckResourceAttrSet("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.file_content_hash"),
 				),
+				// Function actions: API rewrites request_url_template to the function id and
+				// may omit empty header/translation maps. function_config (incl. file_path) stays stable.
 				ExpectNonEmptyPlan: true,
 			},
 			{
@@ -396,14 +395,17 @@ func TestAccResourceIntegrationActionFunctionData(t *testing.T) {
 					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.handler", handler2),
 					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.runtime", runtime2),
 					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.timeout_seconds", timeout2),
+					resource.TestCheckResourceAttr("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.file_path", filePath2),
+					resource.TestCheckResourceAttrSet("genesyscloud_integration_action."+actionResourceLabel1, "function_config.0.file_content_hash"),
 				),
 				ExpectNonEmptyPlan: true,
 			},
 			{
-				// Import/Read
-				ResourceName:      "genesyscloud_integration_action." + actionResourceLabel1,
-				ImportState:       true,
-				ImportStateVerify: true,
+				// Import/Read — zip path/hash are local-only and not returned by the API
+				ResourceName:            "genesyscloud_integration_action." + actionResourceLabel1,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"function_config.0.file_path", "function_config.0.file_content_hash", "config_request.0.request_url_template"},
 			},
 		},
 		CheckDestroy: testVerifyIntegrationActionDestroyed,
@@ -449,8 +451,9 @@ func generateIntegrationActionFunctionConfig(description, handler, runtime, time
         runtime = %s
         timeout_seconds = %s
         file_path = %s
+        file_content_hash = filesha256(%s)
 	}
-	`, description, handler, runtime, timeoutSeconds, filePath)
+	`, description, handler, runtime, timeoutSeconds, filePath, filePath)
 }
 
 // createTempTestZipFile creates a temporary zip file with some test content for testing purposes

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_utils.go
@@ -230,8 +230,10 @@ func FlattenActionConfigResponse(sdkResponse platformclientv2.Responseconfig) []
 	return []interface{}{responseMap}
 }
 
-// FlattenFunctionConfigRequest converts the platformclientv2.Functionconfig into a map
-func FlattenFunctionConfigRequest(functionConfig platformclientv2.Functionconfig) []interface{} {
+// FlattenFunctionConfigRequest converts the platformclientv2.Functionconfig into a map.
+// existingFilePath and existingHash are preserved because Genesys Cloud does not return
+// the original local path or zip binary — only metadata such as Zip.Name.
+func FlattenFunctionConfigRequest(functionConfig platformclientv2.Functionconfig, existingFilePath, existingHash string) []interface{} {
 	functionMap := make(map[string]interface{})
 
 	// Extract function settings from the Function field
@@ -243,11 +245,65 @@ func FlattenFunctionConfigRequest(functionConfig platformclientv2.Functionconfig
 		resourcedata.SetMapValueIfNotNil(functionMap, "zip_id", functionConfig.Function.ZipId)
 	}
 
-	if functionConfig.Zip != nil {
+	// Prefer the configured local path so terraform plan stays empty after apply.
+	// Fall back to Zip.Name for import / export when no local path is in state.
+	if existingFilePath != "" {
+		functionMap["file_path"] = existingFilePath
+	} else if functionConfig.Zip != nil {
 		resourcedata.SetMapValueIfNotNil(functionMap, "file_path", functionConfig.Zip.Name)
 	}
 
+	if existingHash != "" {
+		functionMap["file_content_hash"] = existingHash
+	}
+
 	return []interface{}{functionMap}
+}
+
+// getExistingFunctionConfigFileFields returns file_path and file_content_hash currently in state/config.
+func getExistingFunctionConfigFileFields(d *schema.ResourceData) (filePath, fileHash string) {
+	functionConfig := d.Get("function_config")
+	if functionConfig == nil {
+		return "", ""
+	}
+	configList, ok := functionConfig.([]interface{})
+	if !ok || len(configList) == 0 || configList[0] == nil {
+		return "", ""
+	}
+	configMap, ok := configList[0].(map[string]interface{})
+	if !ok {
+		return "", ""
+	}
+	if pathVal, exists := configMap["file_path"]; exists && pathVal != nil {
+		filePath, _ = pathVal.(string)
+	}
+	if hashVal, exists := configMap["file_content_hash"]; exists && hashVal != nil {
+		fileHash, _ = hashVal.(string)
+	}
+	return filePath, fileHash
+}
+
+// setFunctionConfigFileHash updates file_content_hash in the function_config block while preserving other fields.
+func setFunctionConfigFileHash(d *schema.ResourceData, hash string) {
+	functionConfig := d.Get("function_config")
+	if functionConfig == nil {
+		return
+	}
+	configList, ok := functionConfig.([]interface{})
+	if !ok || len(configList) == 0 || configList[0] == nil {
+		return
+	}
+	configMap, ok := configList[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	// Copy to avoid mutating the underlying state map in place unexpectedly
+	updated := make(map[string]interface{}, len(configMap)+1)
+	for k, v := range configMap {
+		updated[k] = v
+	}
+	updated["file_content_hash"] = hash
+	_ = d.Set("function_config", []interface{}{updated})
 }
 
 // BuildSdkFunctionConfig takes the resource data and builds the SDK platformclientv2.Functionconfig from it


### PR DESCRIPTION
- Detect function integrations by type (function-data-actions), not just category name
- Keep the local file_path after apply (stop overwriting it with the zip name from the API)
- Add file_content_hash so zip content changes are detected
- On export, point file_path at function_zips/… and write a README; Genesys Cloud can’t download function zips, so the binary still has to be supplied in the pipeline
- Function updates go straight through draft → upload → publish (skip the published PATCH)