### PR TITLE
DEVTOOLING-1757 fix: able to delete bullseye ring even if members are…

### DIFF
--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -422,7 +422,7 @@ func updateRoutingQueue(ctx context.Context, d *schema.ResourceData, meta interf
 		updateQueue.LastAgentRoutingMode = &lastAgentRoutingMode
 	}
 
-	if d.HasChange("bullseye_rings") && updateQueue.Bullseye == nil {
+	if d.HasChange("bullseye_rings") {
 		if diagErr := clearBullseyeRingMemberGroups(ctx, d, &updateQueue, proxy); diagErr.HasError() {
 			return diagErr
 		}

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -1148,6 +1148,11 @@ func flattenQueueWrapupCodes(ctx context.Context, queueID string, proxy *Routing
 	return nil, nil
 }
 
+// clearBullseyeRingMemberGroups clears member groups from bullseye rings before the main update.
+// The Genesys Cloud API rejects removing rings that have members attached. This function issues
+// a preliminary PUT that keeps the current ring count but sets MemberGroups to nil on all rings,
+// satisfying the API prerequisite. The caller's updateQueue.Bullseye (which holds the desired
+// final state — nil for all-rings-removed, or non-nil for partial removal) is left untouched.
 func clearBullseyeRingMemberGroups(ctx context.Context, d *schema.ResourceData, updateQueue *platformclientv2.Queuerequest, proxy *RoutingQueueProxy) diag.Diagnostics {
 	currentQueue, resp, err := proxy.getRoutingQueueById(ctx, d.Id(), true)
 	if err != nil {
@@ -1177,16 +1182,18 @@ func clearBullseyeRingMemberGroups(ctx context.Context, d *schema.ResourceData, 
 		clearedRings[i].MemberGroups = nil
 	}
 
-	updateQueue.Bullseye = &platformclientv2.Bullseye{
-		Rings: &clearedRings,
+	clearQueue := platformclientv2.Queuerequest{
+		Name: updateQueue.Name,
+		Bullseye: &platformclientv2.Bullseye{
+			Rings: &clearedRings,
+		},
 	}
 
-	_, resp, err = proxy.updateRoutingQueue(ctx, d.Id(), updateQueue)
+	_, resp, err = proxy.updateRoutingQueue(ctx, d.Id(), &clearQueue)
 	if err != nil {
 		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to clear member_groups from bullseye rings in queue %s error: %s", d.Id(), err), resp)
 	}
 
-	updateQueue.Bullseye = nil
 	log.Printf("Cleared member_groups from bullseye rings in queue %s", d.Id())
 	return nil
 }

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_utils.go
@@ -1182,11 +1182,9 @@ func clearBullseyeRingMemberGroups(ctx context.Context, d *schema.ResourceData, 
 		clearedRings[i].MemberGroups = nil
 	}
 
-	clearQueue := platformclientv2.Queuerequest{
-		Name: updateQueue.Name,
-		Bullseye: &platformclientv2.Bullseye{
-			Rings: &clearedRings,
-		},
+	clearQueue := *updateQueue
+	clearQueue.Bullseye = &platformclientv2.Bullseye{
+		Rings: &clearedRings,
 	}
 
 	_, resp, err = proxy.updateRoutingQueue(ctx, d.Id(), &clearQueue)


### PR DESCRIPTION
## Summary

Fix routing queue updates to clear member groups before removing bullseye rings, matching the UI behavior. Previously, removing a ring with members returned a 400 error and corrupted tfstate.

## Changes

- Modified `clearBullseyeRingMemberGroups` to issue a preliminary PUT clearing all member groups regardless of whether rings are partially or fully removed
- Simplified the caller in `updateRoutingQueue` to always call the clearing function when `bullseye_rings` changes (removed the `updateQueue.Bullseye == nil` condition)

## Root Cause

The API rejects removing a bullseye ring that has members attached. The provider only cleared member groups when ALL rings were removed (`Bullseye == nil`), not when individual rings were removed. The fix issues a prep PUT to detach members before reducing ring count — the same two-step approach the UI uses.