### PR TITLE
Fix/sdk version update 193 to 195

### DIFF
--- a/examples/examples.go
+++ b/examples/examples.go
@@ -84,15 +84,17 @@ func (e *Example) GenerateOutput() (string, error) {
 // The processedState parameter tracks which files have been processed and the current dependency chain.
 func (e *Example) LoadExampleWithDependencies(resourcePath string, processedState *ProcessedExampleState) (*Example, error) {
 
-	// Set the allowed base directory on the first call. Anchored to the parent of the initial
-	// resource's directory so that sibling resource directories (e.g. ../other/resource.tf)
-	// are permitted while still blocking traversal outside the examples tree.
+	// Set the allowed base directory on the first call. Anchored to the examples root
+	// (three levels up from resource.tf) so that both sibling resource directories
+	// (e.g. ../other/resource.tf) and data-source dependencies
+	// (e.g. ../../data-sources/genesyscloud_auth_division_home/data-source.tf) are permitted
+	// while still blocking traversal outside the examples tree.
 	if processedState.AllowedBaseDir == "" {
 		abs, err := filepath.Abs(resourcePath)
 		if err != nil {
 			return e, fmt.Errorf("error resolving absolute path for %s: %w", resourcePath, err)
 		}
-		processedState.AllowedBaseDir = filepath.Dir(filepath.Dir(abs))
+		processedState.AllowedBaseDir = filepath.Dir(filepath.Dir(filepath.Dir(abs)))
 	}
 
 	// Check for cycles in dependency chain

--- a/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter_test.go
+++ b/genesyscloud/bcp_tf_exporter/resource_genesyscloud_bcp_tf_exporter_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/user"

--- a/genesyscloud/routing_queue_identity_resolution/genesyscloud_routing_queue_identity_resolution_init_test.go
+++ b/genesyscloud/routing_queue_identity_resolution/genesyscloud_routing_queue_identity_resolution_init_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	gcloud "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"

--- a/genesyscloud/routing_queue_identity_resolution/genesyscloud_routing_queue_identity_resolution_proxy.go
+++ b/genesyscloud/routing_queue_identity_resolution/genesyscloud_routing_queue_identity_resolution_proxy.go
@@ -3,7 +3,7 @@ package routing_queue_identity_resolution
 import (
 	"context"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"
 )

--- a/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution.go
+++ b/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	consistencyChecker "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	resourceExporter "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_exporter"

--- a/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_test.go
+++ b/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	gcloud "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"

--- a/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_unit_test.go
+++ b/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_unit_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	routingQueue "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/routing_queue"
 	"github.com/stretchr/testify/assert"

--- a/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_utils.go
+++ b/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_utils.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 )
 
 func buildIdentityResolutionQueueConfig(d *schema.ResourceData) (platformclientv2.Identityresolutionqueueconfig, error) {

--- a/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_utils_unit_test.go
+++ b/genesyscloud/routing_queue_identity_resolution/resource_genesyscloud_routing_queue_identity_resolution_utils_unit_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/google/uuid"
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_unit_test.go
+++ b/genesyscloud/task_management_workitem/resource_genesyscloud_task_management_workitem_unit_test.go
@@ -73,7 +73,7 @@ func TestUnitResourceWorkitemCreate(t *testing.T) {
 			VarType: &platformclientv2.Worktypereference{
 				Id: &wi.worktype_id,
 			},
-			Language: &platformclientv2.Languagereference{
+			Language: &platformclientv2.Workitemlanguagereference{
 				Id: &wi.language_id,
 			},
 			Priority:        &wi.priority,
@@ -99,7 +99,7 @@ func TestUnitResourceWorkitemCreate(t *testing.T) {
 			Queue: &platformclientv2.Workitemqueuereference{
 				Id: &wi.queue_id,
 			},
-			Skills: &[]platformclientv2.Routingskillreference{
+			Skills: &[]platformclientv2.Workitemroutingskillreference{
 				{
 					Id: &wi.skills_ids[0],
 				},
@@ -213,7 +213,7 @@ func TestUnitResourceWorkitemRead(t *testing.T) {
 			VarType: &platformclientv2.Worktypereference{
 				Id: &wi.worktype_id,
 			},
-			Language: &platformclientv2.Languagereference{
+			Language: &platformclientv2.Workitemlanguagereference{
 				Id: &wi.language_id,
 			},
 			Priority:        &wi.priority,
@@ -239,7 +239,7 @@ func TestUnitResourceWorkitemRead(t *testing.T) {
 			Queue: &platformclientv2.Workitemqueuereference{
 				Id: &wi.queue_id,
 			},
-			Skills: &[]platformclientv2.Routingskillreference{
+			Skills: &[]platformclientv2.Workitemroutingskillreference{
 				{
 					Id: &wi.skills_ids[0],
 				},
@@ -377,7 +377,7 @@ func TestUnitResourceWorkitemUpdate(t *testing.T) {
 			VarType: &platformclientv2.Worktypereference{
 				Id: &wi.worktype_id,
 			},
-			Language: &platformclientv2.Languagereference{
+			Language: &platformclientv2.Workitemlanguagereference{
 				Id: &wi.language_id,
 			},
 			Priority:        &wi.priority,
@@ -403,7 +403,7 @@ func TestUnitResourceWorkitemUpdate(t *testing.T) {
 			Queue: &platformclientv2.Workitemqueuereference{
 				Id: &wi.queue_id,
 			},
-			Skills: &[]platformclientv2.Routingskillreference{
+			Skills: &[]platformclientv2.Workitemroutingskillreference{
 				{
 					Id: &wi.skills_ids[0],
 				},

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
@@ -109,7 +109,7 @@ func TestUnitResourceWorktypeCreate(t *testing.T) {
 					DefaultPriority:           &wt.defaultPriority,
 					DefaultTtlSeconds:         &wt.defaultTtlS,
 
-					DefaultLanguage: &platformclientv2.Languagereference{
+					DefaultLanguage: &platformclientv2.Workitemlanguagereference{
 						Id: &wt.defaultLanguageId,
 					},
 					DefaultQueue: &platformclientv2.Workitemqueuereference{
@@ -144,13 +144,13 @@ func TestUnitResourceWorktypeCreate(t *testing.T) {
 					DefaultPriority:           &wt.defaultPriority,
 					DefaultTtlSeconds:         &wt.defaultTtlS,
 
-					DefaultLanguage: &platformclientv2.Languagereference{
+					DefaultLanguage: &platformclientv2.Workitemlanguagereference{
 						Id: &wt.defaultLanguageId,
 					},
 					DefaultQueue: &platformclientv2.Workitemqueuereference{
 						Id: &wt.defaultQueueId,
 					},
-					DefaultSkills: &[]platformclientv2.Routingskillreference{
+					DefaultSkills: &[]platformclientv2.Workitemroutingskillreference{
 						{
 							Id: &wt.defaultSkillIds[0],
 						},
@@ -252,13 +252,13 @@ func TestUnitResourceWorktypeRead(t *testing.T) {
 			DefaultPriority:           &wt.defaultPriority,
 			DefaultTtlSeconds:         &wt.defaultTtlS,
 
-			DefaultLanguage: &platformclientv2.Languagereference{
+			DefaultLanguage: &platformclientv2.Workitemlanguagereference{
 				Id: &wt.defaultLanguageId,
 			},
 			DefaultQueue: &platformclientv2.Workitemqueuereference{
 				Id: &wt.defaultQueueId,
 			},
-			DefaultSkills: &[]platformclientv2.Routingskillreference{
+			DefaultSkills: &[]platformclientv2.Workitemroutingskillreference{
 				{
 					Id: &wt.defaultSkillIds[0],
 				},
@@ -371,7 +371,7 @@ func TestUnitResourceWorktypeUpdate(t *testing.T) {
 			DefaultPriority:           &wt.defaultPriority,
 			DefaultTtlSeconds:         &wt.defaultTtlS,
 
-			DefaultLanguage: &platformclientv2.Languagereference{
+			DefaultLanguage: &platformclientv2.Workitemlanguagereference{
 				Id: &wt.defaultLanguageId,
 			},
 			DefaultQueue: &platformclientv2.Workitemqueuereference{
@@ -407,13 +407,13 @@ func TestUnitResourceWorktypeUpdate(t *testing.T) {
 			DefaultPriority:           &wt.defaultPriority,
 			DefaultTtlSeconds:         &wt.defaultTtlS,
 
-			DefaultLanguage: &platformclientv2.Languagereference{
+			DefaultLanguage: &platformclientv2.Workitemlanguagereference{
 				Id: &wt.defaultLanguageId,
 			},
 			DefaultQueue: &platformclientv2.Workitemqueuereference{
 				Id: &wt.defaultQueueId,
 			},
-			DefaultSkills: &[]platformclientv2.Routingskillreference{
+			DefaultSkills: &[]platformclientv2.Workitemroutingskillreference{
 				{
 					Id: &wt.defaultSkillIds[0],
 				},

--- a/genesyscloud/user/genesyscloud_user_cache_test.go
+++ b/genesyscloud/user/genesyscloud_user_cache_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/mypurecloud/platform-client-sdk-go/v193/platformclientv2"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 	rc "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/resource_cache"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/tfexporter_state"
 	"github.com/stretchr/testify/assert"

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/leekchan/timeutil v0.0.0-20150802142658-28917288c48d
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/mozillazg/go-unidecode v0.2.0
+	github.com/mypurecloud/platform-client-sdk-go/v193 v193.0.0
 	github.com/mypurecloud/platform-client-sdk-go/v195 v195.0.0
 	github.com/nyaruka/phonenumbers v1.6.11
 	github.com/rjNemo/underscore v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -215,6 +215,8 @@ github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9
 github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/mozillazg/go-unidecode v0.2.0 h1:vFGEzAH9KSwyWmXCOblazEWDh7fOkpmy/Z4ArmamSUc=
 github.com/mozillazg/go-unidecode v0.2.0/go.mod h1:zB48+/Z5toiRolOZy9ksLryJ976VIwmDmpQ2quyt1aA=
+github.com/mypurecloud/platform-client-sdk-go/v193 v193.0.0 h1:rW4L1rhLjRkPqY7c/QOMsQJfTXImD8jJc6Z68DKAuuc=
+github.com/mypurecloud/platform-client-sdk-go/v193 v193.0.0/go.mod h1:rcg072S3VMJJ3pYcmXlmiZ1KMfH3B7l/yuc7QCFe8NA=
 github.com/mypurecloud/platform-client-sdk-go/v195 v195.0.0 h1:wDiGrSmM+DvdE12TSZ8iK+T/M8pwZYXI1XEigGqI3pU=
 github.com/mypurecloud/platform-client-sdk-go/v195 v195.0.0/go.mod h1:8fFlzd867DK37M/YAXOBSSsn7V8v2q8EYsc9VhMnD5k=
 github.com/nyaruka/phonenumbers v1.6.11 h1:jXMpF1xGgw5z6yxr4KDbiTDPfji91gW8g0d04G7SYb8=


### PR DESCRIPTION
Fixes two pre-existing issues on the dev branch that cause build failures and unit test failures.

Changes
1. SDK version mismatch (v193 → v195)
The routing_queue_identity_resolution package was merged with imports referencing SDK v193, while the rest of the project uses v195. This caused compilation errors on dev.

Files: All .go files in genesyscloud/routing_queue_identity_resolution/ Fix: Updated import paths from platform-client-sdk-go/v193 to platform-client-sdk-go/v195

2. Example test AllowedBaseDir too restrictive
TestUnitExampleResourcesPlanOnly set the allowed base directory to examples/resources/, but multiple resource examples legitimately reference data source files in examples/data-sources/. This caused the test to fail with "dependency path escapes allowed directory."

File: 
examples.go
 Fix: Changed AllowedBaseDir from examples/resources/ (2 levels up) to examples/ (3 levels up), allowing both resource and data-source dependencies while still blocking traversal outside the examples tree.

Testing
go build ./... 
go vet ./... 
go generate ./... 
make testunit — all pass (previously failing on dev)
