### PR TITLE
bug/DEVTOOLING-1637: Remove cyclic depends_on from exported flows whe…

### DIFF
--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -1289,7 +1289,75 @@ func (g *GenesysCloudResourceExporter) processAndBuildDependencies() (filters []
 	if !g.ignoreCyclicDeps && len(cyclicDependsListCopy) > 0 {
 		return nil, nil, diag.Errorf("Cyclic Dependencies Identified:  %v ", strings.Join(cyclicDependsListCopy, "\n"))
 	}
+
+	// When ignoreCyclicDeps is true, proactively detect and remove bidirectional
+	// dependencies from dependsList to prevent Terraform "Error: Cycle"
+	if g.ignoreCyclicDeps {
+		g.dependsListMutex.Lock()
+		removed := g.removeCyclicDependencies()
+		g.dependsListMutex.Unlock()
+		if removed > 0 {
+			log.Printf("[processAndBuildDependencies] Removed %d cyclic dependency entries from dependsList", removed)
+		}
+	}
+
 	return filterList, totalResources, nil
+}
+
+// removeCyclicDependencies detects bidirectional dependencies in g.dependsList and removes
+// one side to break cycles. If resource A depends on B AND B depends on A, we remove B's
+// dependency on A (keeping A's dependency on B). This must be called while holding dependsListMutex.
+func (g *GenesysCloudResourceExporter) removeCyclicDependencies() int {
+	// dependsList format: map[resourceId][]string{"resourceType.dependencyId", ...}
+	removedCount := 0
+
+	// First pass: identify all cyclic pairs
+	type cyclicPair struct {
+		resourceA string
+		resourceB string
+	}
+	cyclicPairs := make([]cyclicPair, 0)
+
+	for resourceID, deps := range g.dependsList {
+		for _, dep := range deps {
+			parts := strings.SplitN(dep, ".", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			depID := parts[1]
+
+			// Check if the dependency also depends on us
+			if reverseDeps, exists := g.dependsList[depID]; exists {
+				for _, reverseDep := range reverseDeps {
+					reverseParts := strings.SplitN(reverseDep, ".", 2)
+					if len(reverseParts) == 2 && reverseParts[1] == resourceID {
+						cyclicPairs = append(cyclicPairs, cyclicPair{resourceA: resourceID, resourceB: depID})
+						break
+					}
+				}
+			}
+		}
+	}
+
+	// Second pass: remove all cyclic dependencies (both directions)
+	for _, pair := range cyclicPairs {
+		// Remove B from A's deps
+		if deps, exists := g.dependsList[pair.resourceA]; exists {
+			cleaned := make([]string, 0, len(deps))
+			for _, dep := range deps {
+				parts := strings.SplitN(dep, ".", 2)
+				if len(parts) == 2 && parts[1] == pair.resourceB {
+					log.Printf("[removeCyclicDependencies] Removing: %s -> %s", pair.resourceA, dep)
+					removedCount++
+					continue
+				}
+				cleaned = append(cleaned, dep)
+			}
+			g.dependsList[pair.resourceA] = cleaned
+		}
+	}
+
+	return removedCount
 }
 
 func (g *GenesysCloudResourceExporter) rebuildExports(filterList []string) (diagErr diag.Diagnostics) {


### PR DESCRIPTION
Summary
Fixes Error: Cycle when exporting flows that reference each other (e.g., an inbound call flow transferring to a secure call flow and vice versa) with enable_dependency_resolution = true.

Root Cause
The exporter's dependency resolution detects that FlowA references FlowB and FlowB references FlowA, then adds depends_on in both directions. This creates a bidirectional dependency that Terraform cannot resolve. The existing ignore_cyclic_deps = true flag only suppressed the error message but still wrote the cyclic depends_on entries to the exported HCL.

Fix
Added removeCyclicDependencies() function that runs after dependency detection (when ignore_cyclic_deps = true). It scans g.dependsList for bidirectional pairs (A depends on B AND B depends on A) and removes both entries before addDependsOnValues writes them to the exported HCL.

Files Changed
genesyscloud_resource_exporter.go
 — added cyclic dependency removal logic after processAndBuildDependencies
Testing
Created two cross-referencing flows (FlowA transfers to FlowB, FlowB transfers to FlowA)
Exported with enable_dependency_resolution = true and ignore_cyclic_deps = true
Before fix: terraform validate → Error: Cycle: genesyscloud_flow.FlowA, genesyscloud_flow.FlowB
After fix: terraform validate → Success! The configuration is valid.
Non-cyclic depends_on entries (e.g., flow → routing_queue) are preserved correctly
Performance
Only runs when ignore_cyclic_deps = true (no impact on default behavior)
O(n×m) in-memory iteration — negligible compared to export API call time
