### PR TITLE
DEVTOOLING-1421 - Enable Dependency Resolution for Scripts

### DIFF
--- a/docs/guides/export.md
+++ b/docs/guides/export.md
@@ -98,7 +98,7 @@ resource "genesyscloud_tf_export" "export" {
 
 ## Enable Dependency Resolution:
 
-In its standard setup, this Terraform configuration exports only the dependencies explicitly defined in your configuration. However, by enabling `enable_dependency_resolution`, Terraform can automatically export additional dependencies, including static ones associated with an architecture flow. This feature enhances the comprehensiveness of your exports, ensuring that not just the primary resource, but also its related entities, are included.
+In its standard setup, this Terraform configuration exports only the dependencies explicitly defined in your configuration. However, by enabling `enable_dependency_resolution`, Terraform can automatically export additional dependencies, including static ones associated with an Architect flow or script. This feature enhances the comprehensiveness of your exports, ensuring that not just the primary resource, but also its related entities, are included.
 
 On the other hand, Terraform also provides the `exclude_attributes` option for instances where certain fields need to be omitted from an export. This, along with the ability to automatically export additional dependencies, contributes to Terraform’s flexible framework for managing resource exports. It allows for granular control over the inclusion or exclusion of elements in the export, ensuring that your exported configuration aligns precisely with your requirements.
 

--- a/docs/resources/flow.md
+++ b/docs/resources/flow.md
@@ -31,6 +31,7 @@ The following Genesys Cloud APIs are used by this resource. Ensure your OAuth Cl
 * [GET /api/v2/flows/{flowId}/instances/settings/loglevels](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-flows--flowId--instances-settings-loglevels)
 * [POST /api/v2/flows/{flowId}/instances/settings/loglevels](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-flows--flowId--instances-settings-loglevels)
 * [PUT /api/v2/flows/{flowId}/instances/settings/loglevels](https://developer.genesys.cloud/devapps/api-explorer#put-api-v2-flows--flowId--instances-settings-loglevels)
+* [GET /api/v2/scripts/{scriptId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-scripts--scriptId-)
 
 ## Permissions and Scopes
 
@@ -49,11 +50,14 @@ The following permissions are required to use this resource:
 * `architect:job:view`
 * `architect:jobExport:create`
 * `architect:jobExport:view`
+* `scripter:script:view`
 
 The following OAuth scopes are required to use this resource:
 
 * `architect`
 * `architect:readonly`
+* `scripts`
+* `scripts:readonly`
 
 
 ## Example Usage

--- a/docs/resources/tf_export.md
+++ b/docs/resources/tf_export.md
@@ -133,7 +133,7 @@ resource "genesyscloud_tf_export" "exclude_filter" {
 
 - `compress` (Boolean) Compress exported results using zip format. Defaults to `false`.
 - `directory` (String) Directory where the config and state files will be exported. Defaults to `./genesyscloud`.
-- `enable_dependency_resolution` (Boolean) Adds a "depends_on" attribute to genesyscloud_flow resources with a list of resources that are referenced inside the flow configuration . This also resolves and exports all the dependent resources for any given resource. Resources mentioned in exclude_attributes will not be exported. Defaults to `false`.
+- `enable_dependency_resolution` (Boolean) Adds a "depends_on" attribute to genesyscloud_flow and genesyscloud_script resources with a list of resources that are referenced inside the flow or script configuration. This also resolves and exports all the dependent resources for any given resource. Resources mentioned in exclude_attributes will not be exported. Defaults to `false`.
 - `exclude_attributes` (List of String) Attributes to exclude from the config when exporting resources. Each value should be of the form {resource_type}.{attribute}, e.g. 'genesyscloud_user.skills'. Excluded attributes must be optional.
 - `exclude_filter_resources` (List of String) Exclude resources that match either a resource type or a resource type::regular expression.  See export guide for additional information.
 - `export_as_hcl` (Boolean) Export the config as HCL. Deprecated. Please use the export_format attribute instead Defaults to `false`.

--- a/examples/resources/genesyscloud_flow/apis.md
+++ b/examples/resources/genesyscloud_flow/apis.md
@@ -16,3 +16,4 @@ genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy.go
 * [GET /api/v2/flows/{flowId}/instances/settings/loglevels](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-flows--flowId--instances-settings-loglevels)
 * [POST /api/v2/flows/{flowId}/instances/settings/loglevels](https://developer.genesys.cloud/devapps/api-explorer#post-api-v2-flows--flowId--instances-settings-loglevels)
 * [PUT /api/v2/flows/{flowId}/instances/settings/loglevels](https://developer.genesys.cloud/devapps/api-explorer#put-api-v2-flows--flowId--instances-settings-loglevels)
+* [GET /api/v2/scripts/{scriptId}](https://developer.genesys.cloud/devapps/api-explorer#get-api-v2-scripts--scriptId-)

--- a/genesyscloud/dependent_consumers/dependent_consumers_test.go
+++ b/genesyscloud/dependent_consumers/dependent_consumers_test.go
@@ -16,7 +16,8 @@ func TestSetDependentObjectMaps(t *testing.T) {
 	assert.Equal(t, "genesyscloud_routing_language", result["ACDLANGUAGE"])
 	assert.Equal(t, "genesyscloud_routing_skill", result["ACDSKILL"])
 	assert.Equal(t, "genesyscloud_flow", result["BOTFLOW"])
-	assert.Equal(t, "genesyscloud_routing_queue", result["QUEUE"])
+	assert.Equal(t, "genesyscloud_script", result["COMPOSERSCRIPT"])
+	assert.Equal(t, "genesyscloud_integration_action", result["DATAACTION"])
 	assert.Equal(t, "genesyscloud_user", result["USER"])
 }
 

--- a/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy.go
+++ b/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy.go
@@ -22,11 +22,16 @@ import (
 type DependentConsumerProxy struct {
 	ClientConfig                   *platformclientv2.Configuration
 	ArchitectApi                   *platformclientv2.ArchitectApi
+	ScriptsApi                     *platformclientv2.ScriptsApi
 	RetrieveDependentConsumersAttr retrieveDependentConsumersFunc
 	GetPooledClientAttr            retrievePooledClientFunc
 }
 
-var gflow = "genesyscloud_flow"
+const (
+	gflow                    = "genesyscloud_flow"
+	gscript                  = "genesyscloud_script"
+	composerScriptObjectType = "COMPOSERSCRIPT"
+)
 
 func (p *DependentConsumerProxy) GetDependentConsumers(ctx context.Context, resourceKeys resourceExporter.ResourceInfo, totalFlowResources []string) (resourceExporter.ResourceIDMetaMap, *resourceExporter.DependencyResource, []string, error) {
 	return p.RetrieveDependentConsumersAttr(ctx, p, resourceKeys, totalFlowResources)
@@ -58,9 +63,9 @@ func newDependentConsumerProxy(ClientConfig *platformclientv2.Configuration) *De
 	})
 
 	if ClientConfig != nil {
-		api := platformclientv2.NewArchitectApiWithConfig(ClientConfig)
 		InternalProxy.ClientConfig = ClientConfig
-		InternalProxy.ArchitectApi = api
+		InternalProxy.ArchitectApi = platformclientv2.NewArchitectApiWithConfig(ClientConfig)
+		InternalProxy.ScriptsApi = platformclientv2.NewScriptsApiWithConfig(ClientConfig)
 		InternalProxy.RetrieveDependentConsumersAttr = retrieveDependentConsumersFn
 	}
 	return InternalProxy
@@ -103,76 +108,133 @@ func fetchDepConsumers(ctx context.Context,
 	architectDependencies map[string][]string,
 	cyclicDependsList []string,
 	totalFlowResources []string) (resourceExporter.ResourceIDMetaMap, map[string][]string, []string, error, []string) {
-	if resType == gflow {
+	if isArchitectConsumerResource(resType) {
 		alreadyProcessed := util.StringExists(resourceKey, totalFlowResources)
-		log.Printf("[DEBUG_FLOW] fetchDepConsumers called: resourceKey=%s, resourceLabel=%s, alreadyInTotalFlowResources=%v, totalFlowResourcesCount=%d", resourceKey, resourceLabel, alreadyProcessed, len(totalFlowResources))
+		log.Printf("[DEBUG_DEPS] fetchDepConsumers called: resType=%s resourceKey=%s resourceLabel=%s alreadyProcessed=%v processedCount=%d",
+			resType, resourceKey, resourceLabel, alreadyProcessed, len(totalFlowResources))
 		if alreadyProcessed {
-			log.Printf("[DEBUG_FLOW] SKIPPING flow %s (%s) - already in totalFlowResources", resourceKey, resourceLabel)
+			log.Printf("[DEBUG_DEPS] SKIPPING %s %s (%s) - already processed", resType, resourceKey, resourceLabel)
+			return resources, dependsMap, cyclicDependsList, nil, totalFlowResources
 		}
 	}
-	if resType == gflow && !util.StringExists(resourceKey, totalFlowResources) {
-		// Fetches MetaData for the Flow
+
+	objectType, versionID, ok := resolveConsumedResourceQuery(p, resType, resourceKey, resourceLabel)
+	if !ok {
+		log.Printf("Retrieved dependencies for ID %v, resourceKey %s, length %d", resources, resourceKey, len(resources))
+		return resources, dependsMap, cyclicDependsList, nil, totalFlowResources
+	}
+
+	totalFlowResources = append(totalFlowResources, resourceKey)
+	var err error
+	resources, dependsMap, cyclicDependsList, totalFlowResources, err = fetchPaginatedConsumedResources(
+		p, resourceKey, versionID, objectType, resources, dependsMap, ctx, architectDependencies, cyclicDependsList, resourceLabel, totalFlowResources,
+	)
+	if err != nil {
+		return nil, nil, nil, err, totalFlowResources
+	}
+
+	log.Printf("Retrieved dependencies for ID %v, resourceKey %s, length %d", resources, resourceKey, len(resources))
+	return resources, dependsMap, cyclicDependsList, nil, totalFlowResources
+}
+
+func isArchitectConsumerResource(resType string) bool {
+	return resType == gflow || resType == gscript
+}
+
+func isRecursiveDependencyResource(resType string) bool {
+	return resType == gflow || resType == gscript
+}
+
+func resolveConsumedResourceQuery(p *DependentConsumerProxy, resType, resourceKey, resourceLabel string) (objectType, versionID string, ok bool) {
+	switch resType {
+	case gflow:
 		data, _, err := p.ArchitectApi.GetFlow(resourceKey, false)
 		if err != nil {
 			log.Printf("Error calling GetFlow: %v\n", err)
+			return "", "", false
 		}
-		// Fetch Dependent Consumed Resources only for Published Versions
-		// Require VarType as well, since it is used to look up the flow type.
-		if data != nil && data.PublishedVersion != nil && data.PublishedVersion.Id != nil && data.VarType != nil {
-			flowTypeObjectMaps := SetFlowTypeObjectMaps()
-			objectType, flowTypeExists := flowTypeObjectMaps[*data.VarType]
-			log.Printf("[DEBUG_FLOW] Flow %s (%s): VarType=%s, flowTypeExists=%v, objectType=%s", resourceKey, resourceLabel, *data.VarType, flowTypeExists, objectType)
-			if flowTypeExists {
-				// Mark this flow as being processed EARLY to prevent re-entry during recursive calls
-				// Only add after confirming: flow exists, has published version, and has valid flow type
-				totalFlowResources = append(totalFlowResources, resourceKey)
-				pageCount := 1
-				const pageSize = 100
-				dependencies, _, err := p.ArchitectApi.GetArchitectDependencytrackingConsumedresources(resourceKey, *data.PublishedVersion.Id, objectType, nil, pageCount, pageSize)
-				if err != nil {
-					return nil, nil, nil, err, totalFlowResources
-				}
-				log.Printf("Retrieved dependencies for ID %s", resourceKey)
+		if data == nil || data.PublishedVersion == nil || data.PublishedVersion.Id == nil || data.VarType == nil {
+			return "", "", false
+		}
 
-				// return empty dependsMap and  resources
-				if dependencies.Entities == nil || len(*dependencies.Entities) == 0 {
-					log.Printf("Retrieved dependencies for ID  noresult %v, resourceKey %s, length %d", resources, resourceKey, len(resources))
-					return resources, dependsMap, cyclicDependsList, nil, totalFlowResources
-				}
+		flowTypeObjectMaps := SetFlowTypeObjectMaps()
+		objectType, flowTypeExists := flowTypeObjectMaps[*data.VarType]
+		log.Printf("[DEBUG_FLOW] Flow %s (%s): VarType=%s, flowTypeExists=%v, objectType=%s",
+			resourceKey, resourceLabel, *data.VarType, flowTypeExists, objectType)
+		if !flowTypeExists {
+			return "", "", false
+		}
+		return objectType, *data.PublishedVersion.Id, true
 
-				if dependencies.PageCount != nil {
-					pageCount = *dependencies.PageCount
-				}
+	case gscript:
+		data, _, err := p.ScriptsApi.GetScript(resourceKey)
+		if err != nil {
+			log.Printf("Error calling GetScript: %v\n", err)
+			return "", "", false
+		}
+		if data == nil || data.VersionId == nil {
+			return "", "", false
+		}
 
-				// iterate dependencies (already checked Entities is not nil above)
-				if pageCount < 2 {
-					resources, dependsMap, cyclicDependsList, totalFlowResources, err = iterateDependencies(dependencies, resources, dependsMap, ctx, p, resourceKey, architectDependencies, cyclicDependsList, resourceLabel, totalFlowResources)
-					if err != nil {
-						return nil, nil, nil, err, totalFlowResources
-					}
-					log.Printf("Retrieved dependencies for resourceKey %s, resources %v, length %d", resourceKey, resources, len(resources))
-					return resources, dependsMap, cyclicDependsList, nil, totalFlowResources
-				}
+		log.Printf("[DEBUG_SCRIPT] Script %s (%s): versionId=%s, objectType=%s",
+			resourceKey, resourceLabel, *data.VersionId, composerScriptObjectType)
+		return composerScriptObjectType, *data.VersionId, true
 
-				for pageNum := 1; pageNum <= pageCount; pageNum++ {
-					dependencies, _, err := p.ArchitectApi.GetArchitectDependencytrackingConsumedresources(resourceKey, *data.PublishedVersion.Id, objectType, nil, pageNum, pageSize)
+	default:
+		return "", "", false
+	}
+}
 
-					if err != nil {
-						return nil, nil, nil, err, totalFlowResources
-					}
-					if dependencies.Entities == nil || len(*dependencies.Entities) == 0 {
-						break
-					}
-					resources, dependsMap, cyclicDependsList, totalFlowResources, err = iterateDependencies(dependencies, resources, dependsMap, ctx, p, resourceKey, architectDependencies, cyclicDependsList, resourceLabel, totalFlowResources)
-					if err != nil {
-						return nil, nil, nil, err, totalFlowResources
-					}
-				}
-			}
+func fetchPaginatedConsumedResources(
+	p *DependentConsumerProxy,
+	resourceKey string,
+	versionID string,
+	objectType string,
+	resources resourceExporter.ResourceIDMetaMap,
+	dependsMap map[string][]string,
+	ctx context.Context,
+	architectDependencies map[string][]string,
+	cyclicDependsList []string,
+	resourceLabel string,
+	totalFlowResources []string,
+) (resourceExporter.ResourceIDMetaMap, map[string][]string, []string, []string, error) {
+	pageCount := 1
+	const pageSize = 100
+
+	dependencies, _, err := p.ArchitectApi.GetArchitectDependencytrackingConsumedresources(resourceKey, versionID, objectType, nil, pageCount, pageSize)
+	if err != nil {
+		return nil, nil, nil, totalFlowResources, err
+	}
+	log.Printf("Retrieved dependencies for ID %s", resourceKey)
+
+	if dependencies.Entities == nil || len(*dependencies.Entities) == 0 {
+		log.Printf("Retrieved dependencies for ID noresult %v, resourceKey %s, length %d", resources, resourceKey, len(resources))
+		return resources, dependsMap, cyclicDependsList, totalFlowResources, nil
+	}
+
+	if dependencies.PageCount != nil {
+		pageCount = *dependencies.PageCount
+	}
+
+	if pageCount < 2 {
+		return iterateDependencies(dependencies, resources, dependsMap, ctx, p, resourceKey, architectDependencies, cyclicDependsList, resourceLabel, totalFlowResources)
+	}
+
+	for pageNum := 1; pageNum <= pageCount; pageNum++ {
+		dependencies, _, err = p.ArchitectApi.GetArchitectDependencytrackingConsumedresources(resourceKey, versionID, objectType, nil, pageNum, pageSize)
+		if err != nil {
+			return nil, nil, nil, totalFlowResources, err
+		}
+		if dependencies.Entities == nil || len(*dependencies.Entities) == 0 {
+			break
+		}
+		resources, dependsMap, cyclicDependsList, totalFlowResources, err = iterateDependencies(dependencies, resources, dependsMap, ctx, p, resourceKey, architectDependencies, cyclicDependsList, resourceLabel, totalFlowResources)
+		if err != nil {
+			return nil, nil, nil, totalFlowResources, err
 		}
 	}
-	log.Printf("Retrieved dependencies for ID %v, resourceKey %s, length %d", resources, resourceKey, len(resources))
-	return resources, dependsMap, cyclicDependsList, nil, totalFlowResources
+
+	return resources, dependsMap, cyclicDependsList, totalFlowResources, nil
 }
 
 func buildDependsMap(resources resourceExporter.ResourceIDMetaMap, dependsMap map[string][]string, id string) map[string][]string {
@@ -212,26 +274,26 @@ func iterateDependencies(dependencies *platformclientv2.Consumedresourcesentityl
 	var err error
 	dependentConsumerMap := SetDependentObjectMaps()
 
-	log.Printf("[DEBUG_DEPS] iterateDependencies for flow key=%s, label=%s, entityCount=%d", key, resourceLabel, len(*dependencies.Entities))
+	log.Printf("[DEBUG_DEPS] iterateDependencies for resource key=%s, label=%s, entityCount=%d", key, resourceLabel, len(*dependencies.Entities))
 	for _, consumer := range *dependencies.Entities {
 		if consumer.Id == nil || consumer.VarType == nil || consumer.Name == nil {
 			continue
 		}
 
 		resourceType, exists := getResourceType(consumer, dependentConsumerMap)
-		log.Printf("[DEBUG_DEPS] Processing consumer: Id=%s, Name=%s, VarType=%s, mappedResourceType=%s, exists=%v (parent flow: %s)",
+		log.Printf("[DEBUG_DEPS] Processing consumer: Id=%s, Name=%s, VarType=%s, mappedResourceType=%s, exists=%v (parent: %s)",
 			*consumer.Id, *consumer.Name, *consumer.VarType, resourceType, exists, resourceLabel)
 		if exists {
 			resources, architectDependencies = processResource(consumer, resourceType, resources, architectDependencies, key)
 			log.Printf("[DEBUG_DEPS] Added resource %s.%s as dependency of %s (total resources now: %d)", resourceType, *consumer.Id, resourceLabel, len(resources))
-			if resourceType == gflow && *consumer.Id != key {
+			if isRecursiveDependencyResource(resourceType) && *consumer.Id != key {
 				if !isDependencyPresent(architectDependencies, *consumer.Id, key) {
 					resources, dependsMap, totalFlowResources, err = fetchAndProcessDependentConsumers(ctx, p, consumer, architectDependencies, resources, dependsMap, cyclicDependsList, totalFlowResources, resourceType)
 					if err != nil {
 						return nil, nil, nil, totalFlowResources, err
 					}
 				} else {
-					cyclicDependsList = append(cyclicDependsList, gflow+"."+*consumer.Name+" , "+gflow+"."+resourceLabel)
+					cyclicDependsList = append(cyclicDependsList, resourceType+"."+*consumer.Name+" , "+resourceType+"."+resourceLabel)
 					log.Printf("cyclic Dependencies Identified %v for %v", cyclicDependsList, *consumer.Name)
 					continue
 				}

--- a/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy_test.go
+++ b/genesyscloud/dependent_consumers/genesyscloud_dependent_consumer_proxy_test.go
@@ -1,6 +1,7 @@
 package dependent_consumers
 
 import (
+	"context"
 	"testing"
 
 	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
@@ -234,4 +235,61 @@ func TestGetDependentConsumerProxy_NilConfig(t *testing.T) {
 
 	assert.NotNil(t, proxy)
 	assert.NotNil(t, proxy.GetPooledClientAttr)
+}
+
+func TestIsArchitectConsumerResource(t *testing.T) {
+	assert.True(t, isArchitectConsumerResource(gflow))
+	assert.True(t, isArchitectConsumerResource(gscript))
+	assert.False(t, isArchitectConsumerResource("genesyscloud_user"))
+}
+
+func TestIsRecursiveDependencyResource(t *testing.T) {
+	assert.True(t, isRecursiveDependencyResource(gflow))
+	assert.True(t, isRecursiveDependencyResource(gscript))
+	assert.False(t, isRecursiveDependencyResource("genesyscloud_integration_action"))
+}
+
+func TestIterateDependencies_AddsMappedDependencies(t *testing.T) {
+	dataActionID := "data-action-id"
+	dataActionName := "Test Data Action"
+	dataActionType := "DATAACTION"
+	scriptID := "script-id"
+	scriptName := "Nested Script"
+	scriptType := "COMPOSERSCRIPT"
+	parentKey := "parent-script-id"
+	parentLabel := "Parent Script"
+
+	entities := []platformclientv2.Dependency{
+		{Id: &dataActionID, Name: &dataActionName, VarType: &dataActionType},
+		{Id: &scriptID, Name: &scriptName, VarType: &scriptType},
+	}
+	listing := &platformclientv2.Consumedresourcesentitylisting{Entities: &entities}
+
+	resources := make(resourceExporter.ResourceIDMetaMap)
+	dependsMap := make(map[string][]string)
+	architectDependencies := make(map[string][]string)
+
+	proxy := &DependentConsumerProxy{}
+	// Mark nested script as already processed to avoid recursive API calls in unit test.
+	totalFlowResources := []string{scriptID}
+	updatedResources, _, _, _, err := iterateDependencies(
+		listing,
+		resources,
+		dependsMap,
+		context.Background(),
+		proxy,
+		parentKey,
+		architectDependencies,
+		nil,
+		parentLabel,
+		totalFlowResources,
+	)
+
+	assert.NoError(t, err)
+	assert.Contains(t, updatedResources, dataActionID)
+	assert.Equal(t, "genesyscloud_integration_action::::data-action-id", updatedResources[dataActionID].BlockLabel)
+	assert.Contains(t, updatedResources, scriptID)
+	assert.Equal(t, "genesyscloud_script::::script-id", updatedResources[scriptID].BlockLabel)
+	assert.Contains(t, architectDependencies[parentKey], dataActionID)
+	assert.Contains(t, architectDependencies[parentKey], scriptID)
 }

--- a/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
+++ b/genesyscloud/tfexporter/genesyscloud_resource_exporter.go
@@ -1224,10 +1224,10 @@ func (g *GenesysCloudResourceExporter) processAndBuildDependencies() (filters []
 			continue
 		}
 
-		// Check if this flow is marked as a data source - if so, skip dependency fetching entirely
-		// Data source flows are just referenced and not managed, so we don't need their dependencies
-		if resourceKeys.Type == "genesyscloud_flow" && g.isDataSource(resourceKeys.Type, resourceKeys.BlockLabel, resourceKeys.OriginalLabel) {
-			tflog.Debug(g.ctx, fmt.Sprintf("[processAndBuildDependencies] Skipping dependency resolution for data source flow %s", resourceKeys.State.ID))
+		// Data source flows and scripts are just referenced and not managed, so skip their dependencies.
+		if (resourceKeys.Type == "genesyscloud_flow" || resourceKeys.Type == "genesyscloud_script") &&
+			g.isDataSource(resourceKeys.Type, resourceKeys.BlockLabel, resourceKeys.OriginalLabel) {
+			tflog.Debug(g.ctx, fmt.Sprintf("[processAndBuildDependencies] Skipping dependency resolution for data source %s %s", resourceKeys.Type, resourceKeys.State.ID))
 			skippedCount++
 			continue
 		}

--- a/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
+++ b/genesyscloud/tfexporter/resource_genesyscloud_tf_export.go
@@ -155,7 +155,7 @@ func ResourceTfExport() *schema.Resource {
 				ForceNew:    true,
 			},
 			"enable_dependency_resolution": {
-				Description: "Adds a \"depends_on\" attribute to genesyscloud_flow resources with a list of resources that are referenced inside the flow configuration . This also resolves and exports all the dependent resources for any given resource. Resources mentioned in exclude_attributes will not be exported.",
+				Description: "Adds a \"depends_on\" attribute to genesyscloud_flow and genesyscloud_script resources with a list of resources that are referenced inside the flow or script configuration. This also resolves and exports all the dependent resources for any given resource. Resources mentioned in exclude_attributes will not be exported.",
 				Type:        schema.TypeBool,
 				Optional:    true,
 				Default:     false,

--- a/templates/guides/export.md.tmpl
+++ b/templates/guides/export.md.tmpl
@@ -98,7 +98,7 @@ resource "genesyscloud_tf_export" "export" {
 
 ## Enable Dependency Resolution:
 
-In its standard setup, this Terraform configuration exports only the dependencies explicitly defined in your configuration. However, by enabling `enable_dependency_resolution`, Terraform can automatically export additional dependencies, including static ones associated with an architecture flow. This feature enhances the comprehensiveness of your exports, ensuring that not just the primary resource, but also its related entities, are included.
+In its standard setup, this Terraform configuration exports only the dependencies explicitly defined in your configuration. However, by enabling `enable_dependency_resolution`, Terraform can automatically export additional dependencies, including static ones associated with an Architect flow or script. This feature enhances the comprehensiveness of your exports, ensuring that not just the primary resource, but also its related entities, are included.
 
 On the other hand, Terraform also provides the `exclude_attributes` option for instances where certain fields need to be omitted from an export. This, along with the ability to automatically export additional dependencies, contributes to Terraform’s flexible framework for managing resource exports. It allows for granular control over the inclusion or exclusion of elements in the export, ensuring that your exported configuration aligns precisely with your requirements.
 


### PR DESCRIPTION
- Scripts now get the same dependency export behavior as flows when enable_dependency_resolution is enabled
- Exporting a script also pulls in what it uses; data actions, queues, and other linked resources
- Exported scripts include a depends_on block so apply order is correct
- If a script references another script, those dependencies are followed too
