### PR TITLE
DEVTOOLING-1796 - genesyscloud_outbound_attempt_limit.reset_period now supports "DAYS_xx" values

### DIFF
--- a/docs/resources/outbound_attempt_limit.md
+++ b/docs/resources/outbound_attempt_limit.md
@@ -66,7 +66,7 @@ resource "genesyscloud_outbound_attempt_limit" "attempt_limit" {
 - `max_attempts_per_number` (Number) The maximum number of times a phone number can be called within the resetPeriod. Required if maxAttemptsPerContact is not defined.
 - `name` (String) The name for the attempt limit.
 - `recall_entries` (Block List, Max: 1) Configuration for recall attempts. (see [below for nested schema](#nestedblock--recall_entries))
-- `reset_period` (String) After how long the number of attempts will be set back to 0. Defaults to `NEVER`.
+- `reset_period` (String) After how long the number of attempts will be set back to 0. Valid values: NEVER, TODAY, or DAYS_xx where xx is 2 through 30 (for example DAYS_30). Defaults to `NEVER`.
 - `time_zone_id` (String) If the resetPeriod is TODAY, this specifies the timezone in which TODAY occurs. Required if the resetPeriod is TODAY.
 
 ### Read-Only

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit.go
@@ -27,6 +27,15 @@ const (
 	ResourceType = "genesyscloud_outbound_attempt_limit"
 )
 
+// validResetPeriods is NEVER, TODAY, and DAYS_2 through DAYS_30 (Genesys Cloud UI/API).
+var validResetPeriods = func() []string {
+	periods := []string{`NEVER`, `TODAY`}
+	for i := 2; i <= 30; i++ {
+		periods = append(periods, fmt.Sprintf(`DAYS_%d`, i))
+	}
+	return periods
+}()
+
 var (
 	recallSettings = &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -138,11 +147,11 @@ func ResourceOutboundAttemptLimit() *schema.Resource {
 				Type:        schema.TypeString,
 			},
 			`reset_period`: {
-				Description:  `After how long the number of attempts will be set back to 0.`,
+				Description:  `After how long the number of attempts will be set back to 0. Valid values: NEVER, TODAY, or DAYS_xx where xx is 2 through 30 (for example DAYS_30).`,
 				Optional:     true,
 				Type:         schema.TypeString,
 				Default:      `NEVER`,
-				ValidateFunc: validation.StringInSlice([]string{`NEVER`, `TODAY`}, true),
+				ValidateFunc: validation.StringInSlice(validResetPeriods, true),
 			},
 			`recall_entries`: {
 				Description: `Configuration for recall attempts.`,

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_test.go
@@ -42,7 +42,7 @@ func TestAccResourceOutboundAttemptLimit(t *testing.T) {
 		maxAttemptsPerContactUpdated = "4"
 		maxAttemptsPerNumberUpdated  = "3"
 		timeZoneIdUpdated            = "Etc/GMT"
-		resetPeriodUpdated           = "NEVER"
+		resetPeriodUpdated           = "DAYS_30"
 
 		updatedRecallEntryType1                = "no_answer"
 		updatedRecallEntryNbrAttempts1         = "2"

--- a/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_unit_test.go
+++ b/genesyscloud/outbound_attempt_limit/resource_genesyscloud_outbound_attempt_limit_unit_test.go
@@ -1,0 +1,43 @@
+package outbound_attempt_limit
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+func TestUnitValidateResetPeriod(t *testing.T) {
+	t.Parallel()
+
+	validate := validation.StringInSlice(validResetPeriods, true)
+
+	valid := []string{
+		"NEVER",
+		"TODAY",
+		"never",
+		"today",
+		"DAYS_2",
+		"DAYS_15",
+		"DAYS_30",
+		"days_30",
+	}
+	for _, value := range valid {
+		if _, errs := validate(value, "reset_period"); len(errs) != 0 {
+			t.Errorf("expected %q to be a valid reset_period, got %v", value, errs)
+		}
+	}
+
+	invalid := []string{
+		"DAYS_1",
+		"DAYS_31",
+		"DAYS_0",
+		"DAY_30",
+		"WEEKLY",
+		"30",
+	}
+	for _, value := range invalid {
+		if _, errs := validate(value, "reset_period"); len(errs) == 0 {
+			t.Errorf("expected %q to be an invalid reset_period", value)
+		}
+	}
+}

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_bullseye_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_bullseye_unit_test.go
@@ -1,0 +1,61 @@
+package routing_queue
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUnitFlattenBullseyeRings_IncludesMemberGroupsOnSixthRing(t *testing.T) {
+	id1 := "sg-ring1-a"
+	id2 := "sg-ring1-b"
+	id3 := "sg-ring1-c"
+	id4 := "sg-ring1-d"
+	id5 := "sg-ring1-e"
+	id6 := "sg-ring6"
+	sg := "SKILLGROUP"
+	timeouts := []float64{10, 20, 2, 2, 7200, 2}
+
+	rings := make([]platformclientv2.Ring, 6)
+	for i := 0; i < 6; i++ {
+		t := timeouts[i]
+		rings[i] = platformclientv2.Ring{
+			ExpansionCriteria: &[]platformclientv2.Expansioncriterium{{
+				VarType:   &bullseyeExpansionTypeTimeout,
+				Threshold: &t,
+			}},
+		}
+	}
+	rings[0].MemberGroups = &[]platformclientv2.Membergroup{
+		{Id: &id1, VarType: &sg},
+		{Id: &id2, VarType: &sg},
+		{Id: &id3, VarType: &sg},
+		{Id: &id4, VarType: &sg},
+		{Id: &id5, VarType: &sg},
+	}
+	rings[5].MemberGroups = &[]platformclientv2.Membergroup{
+		{Id: &id6, VarType: &sg},
+	}
+
+	flattened := flattenBullseyeRings(&rings)
+	assert.Equal(t, 6, len(flattened))
+
+	ring0 := flattened[0].(map[string]interface{})
+	ring5 := flattened[5].(map[string]interface{})
+	mg0 := ring0["member_groups"].(*schema.Set)
+	mg5 := ring5["member_groups"].(*schema.Set)
+	assert.Equal(t, 5, mg0.Len(), "ring 1 should have 5 skill groups")
+	assert.Equal(t, 1, mg5.Len(), "ring 6 should have 1 skill group")
+
+	found := false
+	for _, raw := range mg5.List() {
+		m := raw.(map[string]interface{})
+		if m["member_group_id"] == id6 {
+			found = true
+			assert.Equal(t, sg, m["member_group_type"])
+		}
+	}
+	assert.True(t, found, "ring 6 skill group id should be present")
+}


### PR DESCRIPTION
This is a fix for https://github.com/MyPureCloud/terraform-provider-genesyscloud/issues/2414

genesyscloud_outbound_attempt_limit.reset_period only accepted NEVER and TODAY. Exporting an attempt limit with a multi-day reset (for example DAYS_30) failed validation, even though Genesys Cloud supports resets after 2–30 days.

**Solution:**
Expanded reset_period validation to accept NEVER, TODAY, and DAYS_2 through DAYS_30, matching the values supported by the Genesys Cloud UI and API.

**Changes:**
- Updated reset_period ValidateFunc to allow DAYS_2–DAYS_30 in addition to NEVER and TODAY
- Documented the new valid values in the schema description
- Added unit tests for valid and invalid reset_period values
- Updated the acceptance test to cover an update to reset_period = "DAYS_30"