### PR TITLE
DEVTOOLING-1764 - Fix missing bullseye member_groups on routing queue export

### DIFF
--- a/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
+++ b/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
@@ -2,6 +2,7 @@ package routing_queue
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"log"
 	"strconv"
@@ -39,10 +40,36 @@ func invalidateRoutingQueueListCache() {
 	routingQueueListCache = rc.NewResourceCache[[]platformclientv2.Queue]()
 }
 
-func storeRoutingQueueInCache(cache rc.CacheInterface[platformclientv2.Queue], queue *platformclientv2.Queue) {
-	if queue != nil && queue.Id != nil {
-		rc.SetCache(cache, *queue.Id, *queue)
+// cloneRoutingQueue returns a deep copy of queue so nested pointers (bullseye rings,
+// member groups, etc.) are not shared with list/SDK response buffers.
+// DEVTOOLING-1764: shallow *queue copies caused non-deterministic loss of bullseye
+// member_groups during export when the list cache was reused on Read.
+func cloneRoutingQueue(queue *platformclientv2.Queue) (platformclientv2.Queue, error) {
+	var clone platformclientv2.Queue
+	if queue == nil {
+		return clone, fmt.Errorf("queue is nil")
 	}
+	bytes, err := json.Marshal(queue)
+	if err != nil {
+		return clone, err
+	}
+	if err := json.Unmarshal(bytes, &clone); err != nil {
+		return clone, err
+	}
+	return clone, nil
+}
+
+func storeRoutingQueueInCache(cache rc.CacheInterface[platformclientv2.Queue], queue *platformclientv2.Queue) {
+	if queue == nil || queue.Id == nil {
+		return
+	}
+	clone, err := cloneRoutingQueue(queue)
+	if err != nil {
+		log.Printf("[WARN] Failed to deep-copy routing queue %s for cache; storing shallow copy: %v", *queue.Id, err)
+		rc.SetCache(cache, *queue.Id, *queue)
+		return
+	}
+	rc.SetCache(cache, *queue.Id, clone)
 }
 
 // queueWrapupCodesCache stores paginated wrapup code assignments per queue during export.

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -325,7 +325,8 @@ func syncRoutingQueueStateFromAPI(ctx context.Context, d *schema.ResourceData, m
 
 	log.Printf("Syncing queue state from API for %s after partial update failure", d.Id())
 
-	currentQueue, resp, getErr := proxy.getRoutingQueueById(ctx, d.Id(), true)
+	// Always GET-by-id: list-cache entries can omit/corrupt nested bullseye member_groups (DEVTOOLING-1764).
+	currentQueue, resp, getErr := proxy.getRoutingQueueById(ctx, d.Id(), false)
 	if getErr != nil {
 		return util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to read queue %s | error: %s", d.Id(), getErr), resp)
 	}
@@ -349,7 +350,10 @@ func readRoutingQueue(ctx context.Context, d *schema.ResourceData, meta interfac
 	ctx = util.SetResourceContext(ctx, d, ResourceType)
 
 	return util.WithRetriesForRead(ctx, d, func() *retry.RetryError {
-		currentQueue, resp, getErr := proxy.getRoutingQueueById(ctx, d.Id(), true)
+		// DEVTOOLING-1764: do not use the export list cache here. Concurrent list pagination
+		// stores shallow Queue copies; nested bullseye member_groups can be lost or incomplete
+		// when Read reuses that cache. Always GET-by-id for authoritative state.
+		currentQueue, resp, getErr := proxy.getRoutingQueueById(ctx, d.Id(), false)
 		if getErr != nil {
 			if util.IsStatus404(resp) {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read queue %s | error: %s", d.Id(), getErr), resp))

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
@@ -603,6 +603,57 @@ func TestUnitStoreRoutingQueueInCache(t *testing.T) {
 	assert.Equal(t, "Write Through Queue", *cached.Name)
 }
 
+// DEVTOOLING-1764: cached queues must deep-copy nested bullseye member_groups so later
+// mutation of the list/SDK response cannot shrink export state.
+func TestUnitStoreRoutingQueueInCacheDeepCopiesBullseyeMemberGroups(t *testing.T) {
+	tfexporter_state.ActivateExporterState()
+
+	queueID := "queue-bullseye-deepcopy-test"
+	ring1Groups := []platformclientv2.Membergroup{
+		{Id: platformclientv2.String("sg-1"), VarType: platformclientv2.String("SKILLGROUP")},
+		{Id: platformclientv2.String("sg-2"), VarType: platformclientv2.String("SKILLGROUP")},
+		{Id: platformclientv2.String("sg-3"), VarType: platformclientv2.String("SKILLGROUP")},
+		{Id: platformclientv2.String("sg-4"), VarType: platformclientv2.String("SKILLGROUP")},
+		{Id: platformclientv2.String("sg-5"), VarType: platformclientv2.String("SKILLGROUP")},
+	}
+	ring6Groups := []platformclientv2.Membergroup{
+		{Id: platformclientv2.String("sg-0"), VarType: platformclientv2.String("SKILLGROUP")},
+	}
+	queue := platformclientv2.Queue{
+		Id:   platformclientv2.String(queueID),
+		Name: platformclientv2.String("Bullseye Deep Copy Queue"),
+		Bullseye: &platformclientv2.Bullseye{
+			Rings: &[]platformclientv2.Ring{
+				{MemberGroups: &ring1Groups},
+				{},
+				{},
+				{},
+				{},
+				{MemberGroups: &ring6Groups},
+			},
+		},
+	}
+
+	storeRoutingQueueInCache(routingQueueCache, &queue)
+
+	// Mutate the original nested slices as if an SDK/list buffer were reused.
+	ring1Groups = ring1Groups[:3]
+	ring6Groups = ring6Groups[:0]
+	(*queue.Bullseye.Rings)[0].MemberGroups = &ring1Groups
+	(*queue.Bullseye.Rings)[5].MemberGroups = &ring6Groups
+
+	cached := rc.GetCacheItem(routingQueueCache, queueID)
+	require.NotNil(t, cached)
+	require.NotNil(t, cached.Bullseye)
+	require.NotNil(t, cached.Bullseye.Rings)
+	require.Len(t, *cached.Bullseye.Rings, 6)
+	require.NotNil(t, (*cached.Bullseye.Rings)[0].MemberGroups)
+	require.NotNil(t, (*cached.Bullseye.Rings)[5].MemberGroups)
+	assert.Len(t, *(*cached.Bullseye.Rings)[0].MemberGroups, 5)
+	assert.Len(t, *(*cached.Bullseye.Rings)[5].MemberGroups, 1)
+	assert.Equal(t, "sg-0", *(*(*cached.Bullseye.Rings)[5].MemberGroups)[0].Id)
+}
+
 // This test proves that the site_id field from the API is preserved through
 // the flatten (read) and build (write) round-trip.
 func TestUnitFlattenAndBuildCallbackSiteId(t *testing.T) {


### PR DESCRIPTION
- Fixes export dropping bullseye member_groups on routing queues.
- Queue Read now always uses GET-by-id instead of the export list cache, and cached queues are deep-copied so nested bullseye data isn’t shared/corrupted.
- Adds a unit test covering the deep-copy behavior.