### PR TITLE
DEVTOOLING-1798 : schema validation for timeout_seconds ( ranges from 1 to 15 seconds )…

### DIFF
--- a/docs/resources/integration_action.md
+++ b/docs/resources/integration_action.md
@@ -177,7 +177,7 @@ resource "genesyscloud_integration_action" "example_function_action" {
     description       = "Custom function for data processing"
     handler           = "index.handler"
     runtime           = "nodejs22.x"
-    timeout_seconds   = 30
+    timeout_seconds   = 15 //ranges from 1 to 15 seconds
     file_path         = "${local.working_dir.integration_action}/function.zip"
     file_content_hash = filesha256("${local.working_dir.integration_action}/function.zip")
   }
@@ -245,6 +245,6 @@ Optional:
 - `file_content_hash` (String) Hash value of the function zip file content. Used to detect changes. Typically set with filesha256(file_path). Computed by the provider when omitted.
 - `handler` (String) The handler function name.
 - `runtime` (String) The runtime environment for the function.
-- `timeout_seconds` (Number) Timeout in seconds for the function execution.
+- `timeout_seconds` (Number) Timeout in seconds for the function execution. Range allowed 1 to 15. Default value 15 seconds.
 - `zip_id` (String) The ID of the uploaded zip file containing the function code.
 

--- a/examples/resources/genesyscloud_integration_action/resource.tf
+++ b/examples/resources/genesyscloud_integration_action/resource.tf
@@ -108,7 +108,7 @@ resource "genesyscloud_integration_action" "example_function_action" {
     description       = "Custom function for data processing"
     handler           = "index.handler"
     runtime           = "nodejs22.x"
-    timeout_seconds   = 30
+    timeout_seconds   = 15 //ranges from 1 to 15 seconds
     file_path         = "${local.working_dir.integration_action}/function.zip"
     file_content_hash = filesha256("${local.working_dir.integration_action}/function.zip")
   }

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_schema.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_schema.go
@@ -116,10 +116,12 @@ func ResourceIntegrationAction() *schema.Resource {
 				Computed:    true,
 			},
 			"timeout_seconds": {
-				Description: "Timeout in seconds for the function execution.",
+				Description: "Timeout in seconds for the function execution. Range allowed 1 to 15. Default value 15 seconds.",
 				Type:        schema.TypeInt,
 				Optional:    true,
 				Computed:    true,
+				//timeout_seconds ranges between 1 to 15 as per API documentation.
+				ValidateFunc: validation.IntBetween(1, 15),
 			},
 			"zip_id": {
 				Description: "The ID of the uploaded zip file containing the function code.",


### PR DESCRIPTION
Fixes a part of #2503

## Summary

Adds plan-time schema validation for `function_config.timeout_seconds` in `genesyscloud_integration_action`. Previously, invalid values (e.g., 30) were accepted by the provider and only rejected at apply time by the API with a confusing error after retries.

## Changes

- Added `ValidateFunc: validation.IntBetween(1, 15)` to `function_config.timeout_seconds`
- Updated field description to document the allowed range and default value
- Fixed incorrect `timeout_seconds = 30` in docs and examples to use valid value `15`

## Files Modified

- `genesyscloud/integration_action/resource_genesyscloud_integration_action_schema.go`
- `docs/resources/integration_action.md`
- `examples/resources/genesyscloud_integration_action/resource.tf`
