### PR TITLE
Potential fix for #2509

### DIFF
--- a/genesyscloud/resource_cache/resource_cache.go
+++ b/genesyscloud/resource_cache/resource_cache.go
@@ -14,6 +14,7 @@ type CacheInterface[T any] interface {
 	SetCache(id string, item T)
 	DeleteCacheItem(id string)
 	GetCacheSize() int
+	InvalidateCache()
 	NewResourceCache() CacheInterface[T]
 
 	// Backward compatibility methods
@@ -72,6 +73,13 @@ func (rc *ResourceCache[T]) DeleteCacheItem(id string) {
 	rc.mutex.Lock()
 	defer rc.mutex.Unlock()
 	delete(rc.cache, id)
+}
+
+// InvalidateCache removes all items from the cache
+func (rc *ResourceCache[T]) InvalidateCache() {
+	rc.mutex.Lock()
+	defer rc.mutex.Unlock()
+	rc.cache = make(map[string]T)
 }
 
 // GetCacheSize returns the number of items in the cache

--- a/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/data_source_genesyscloud_routing_queue.go
@@ -49,7 +49,7 @@ func hydrateRoutingQueueCacheFn(c *rc.DataSourceCache, ctx context.Context) erro
 
 	log.Printf("Hydrating cache for data source %s", ResourceType)
 
-	queues, resp, err := proxy.GetAllRoutingQueues(ctx, "", false)
+	queues, resp, err := proxy.GetAllRoutingQueues(ctx, "", false, false)
 	if err != nil {
 		return fmt.Errorf("failed to get routing queues. Error: %s | API Response: %s", err.Error(), resp)
 	}
@@ -58,7 +58,7 @@ func hydrateRoutingQueueCacheFn(c *rc.DataSourceCache, ctx context.Context) erro
 		allQueues = append(allQueues, *queues...)
 	}
 
-	trueQueues, resp, err := proxy.GetAllRoutingQueues(ctx, "", true)
+	trueQueues, resp, err := proxy.GetAllRoutingQueues(ctx, "", true, false)
 	if err != nil {
 		return fmt.Errorf("failed to get routing queues. Error: %s | API Response: %s", err.Error(), resp)
 	}

--- a/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
+++ b/genesyscloud/routing_queue/genesyscloud_routing_queue_proxy.go
@@ -35,10 +35,6 @@ func routingQueueListCacheKey(name string, hasPeer bool) string {
 	return name + ":" + strconv.FormatBool(hasPeer)
 }
 
-func invalidateRoutingQueueListCache() {
-	routingQueueListCache = rc.NewResourceCache[[]platformclientv2.Queue]()
-}
-
 func storeRoutingQueueInCache(cache rc.CacheInterface[platformclientv2.Queue], queue *platformclientv2.Queue) {
 	if queue != nil && queue.Id != nil {
 		rc.SetCache(cache, *queue.Id, *queue)
@@ -65,7 +61,7 @@ func invalidateQueueMembersCache(queueID string) {
 
 var internalProxy *RoutingQueueProxy
 
-type GetAllRoutingQueuesFunc func(ctx context.Context, p *RoutingQueueProxy, name string, hasPeer bool) (*[]platformclientv2.Queue, *platformclientv2.APIResponse, error)
+type GetAllRoutingQueuesFunc func(ctx context.Context, p *RoutingQueueProxy, name string, hasPeer, checkCache bool) (*[]platformclientv2.Queue, *platformclientv2.APIResponse, error)
 type createRoutingQueueFunc func(ctx context.Context, p *RoutingQueueProxy, createReq *platformclientv2.Createqueuerequest) (*platformclientv2.Queue, *platformclientv2.APIResponse, error)
 type getRoutingQueueByIdFunc func(ctx context.Context, p *RoutingQueueProxy, queueId string, checkCache bool) (*platformclientv2.Queue, *platformclientv2.APIResponse, error)
 type getRoutingQueueByNameFunc func(ctx context.Context, p *RoutingQueueProxy, name string, hasPeer bool) (string, *platformclientv2.APIResponse, bool, error)
@@ -136,8 +132,8 @@ func GetRoutingQueueProxy(clientConfig *platformclientv2.Configuration) *Routing
 	return newRoutingQueuesProxy(clientConfig)
 }
 
-func (p *RoutingQueueProxy) GetAllRoutingQueues(ctx context.Context, name string, hasPeer bool) (*[]platformclientv2.Queue, *platformclientv2.APIResponse, error) {
-	return p.GetAllRoutingQueuesAttr(ctx, p, name, hasPeer)
+func (p *RoutingQueueProxy) GetAllRoutingQueues(ctx context.Context, name string, hasPeer, checkCache bool) (*[]platformclientv2.Queue, *platformclientv2.APIResponse, error) {
+	return p.GetAllRoutingQueuesAttr(ctx, p, name, hasPeer, checkCache)
 }
 
 func (p *RoutingQueueProxy) createRoutingQueue(ctx context.Context, createReq *platformclientv2.Createqueuerequest) (*platformclientv2.Queue, *platformclientv2.APIResponse, error) {
@@ -181,18 +177,25 @@ func (p *RoutingQueueProxy) updateRoutingQueueMember(ctx context.Context, queueI
 }
 
 // GetAllRoutingQueuesFn is the implementation for retrieving all routing queues in Genesys Cloud
-func GetAllRoutingQueuesFn(ctx context.Context, p *RoutingQueueProxy, name string, hasPeer bool) (*[]platformclientv2.Queue, *platformclientv2.APIResponse, error) {
+func GetAllRoutingQueuesFn(ctx context.Context, p *RoutingQueueProxy, name string, hasPeer, checkCache bool) (*[]platformclientv2.Queue, *platformclientv2.APIResponse, error) {
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
 	listKey := routingQueueListCacheKey(name, hasPeer)
-	if cached := rc.GetCacheItem(routingQueueListCache, listKey); cached != nil {
-		log.Printf("[QUEUE-CACHE] list name=%q hasPeer=%t: cache hit (%d queues)", name, hasPeer, len(*cached))
-		return cached, nil, nil
+	if checkCache {
+		if cached := rc.GetCacheItem(routingQueueListCache, listKey); cached != nil && len(*cached) > 0 {
+			log.Printf("[QUEUE-CACHE] list name=%q hasPeer=%t: cache hit (%d queues)", name, hasPeer, len(*cached))
+			return cached, nil, nil
+		}
 	}
 
+	// Drop only this list key so a forced refresh (checkCache=false) does not reuse a stale page.
+	// Do not wipe routingQueueCache: getAll fetches non-peer then peer lists, and export reads
+	// rely on both sets remaining in the per-queue cache.
+	routingQueueListCache.DeleteCacheItem(listKey)
+
 	var allQueues []platformclientv2.Queue
-	pageSize := page_size.ForResource(ResourceType, 500)
+	pageSize := page_size.ForResource(ResourceType, 100)
 
 	queues, resp, getErr := p.routingApi.GetRoutingQueues(1, pageSize, "", name, nil, nil, nil, "", hasPeer, nil)
 	if getErr != nil {
@@ -274,7 +277,7 @@ func getRoutingQueueByNameFn(ctx context.Context, p *RoutingQueueProxy, name str
 	// Set resource context for SDK debug logging
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
-	queues, resp, err := p.GetAllRoutingQueues(ctx, name, hasPeer)
+	queues, resp, err := p.GetAllRoutingQueues(ctx, name, hasPeer, true)
 	if err != nil {
 		return "", resp, false, err
 	}
@@ -310,7 +313,7 @@ func deleteRoutingQueueFn(ctx context.Context, p *RoutingQueueProxy, queueID str
 		return resp, err
 	}
 	rc.DeleteCacheItem(p.RoutingQueueCache, queueID)
-	invalidateRoutingQueueListCache()
+	routingQueueListCache.InvalidateCache()
 	return resp, nil
 }
 

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue.go
@@ -38,7 +38,7 @@ func getAllRoutingQueues(ctx context.Context, clientConfig *platformclientv2.Con
 	time.Sleep(5 * time.Second)
 
 	// Gets all routing queues without a peer
-	queues, resp, err := proxy.GetAllRoutingQueues(ctx, "", false)
+	queues, resp, err := proxy.GetAllRoutingQueues(ctx, "", false, false)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get routing queues: %s", err), resp)
 	}
@@ -48,7 +48,7 @@ func getAllRoutingQueues(ctx context.Context, clientConfig *platformclientv2.Con
 	}
 
 	// Gets all routing queues with a peer
-	queues, resp, err = proxy.GetAllRoutingQueues(ctx, "", true)
+	queues, resp, err = proxy.GetAllRoutingQueues(ctx, "", true, false)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get routing queues with Peer IDs: %s", err), resp)
 	}

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_test.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	architectFlow "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/architect_flow"
-	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/architect_user_prompt"
 	userPrompt "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/architect_user_prompt"
 	authDivision "github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/auth_division"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/group"
@@ -673,14 +672,14 @@ func TestAccResourceRoutingQueueFlows(t *testing.T) {
 		userPromptResourceText1     = "This is a test greeting!"
 		userPromptResourceFileName2 = testrunner.GetTestDataPath("resource", userPrompt.ResourceType, "test-prompt-02.wav")
 		userPromptResourceTTS1      = "This is a test greeting!"
-		userPromptAsset1            = architect_user_prompt.UserPromptResourceStruct{
+		userPromptAsset1            = userPrompt.UserPromptResourceStruct{
 			Language:        userPromptResourceLang1,
 			Tts_string:      strconv.Quote(userPromptResourceTTS1),
 			Text:            util.NullValue,
 			Filename:        util.NullValue,
 			FileContentHash: util.NullValue,
 		}
-		userPromptAsset2 = architect_user_prompt.UserPromptResourceStruct{
+		userPromptAsset2 = userPrompt.UserPromptResourceStruct{
 			Language:        userPromptResourceLang1,
 			Tts_string:      util.NullValue,
 			Text:            strconv.Quote(userPromptResourceText1),
@@ -688,8 +687,8 @@ func TestAccResourceRoutingQueueFlows(t *testing.T) {
 			FileContentHash: userPromptResourceFileName2,
 		}
 
-		userPromptResources1 = []*architect_user_prompt.UserPromptResourceStruct{&userPromptAsset1}
-		userPromptResources2 = []*architect_user_prompt.UserPromptResourceStruct{&userPromptAsset2}
+		userPromptResources1 = []*userPrompt.UserPromptResourceStruct{&userPromptAsset1}
+		userPromptResources2 = []*userPrompt.UserPromptResourceStruct{&userPromptAsset2}
 	)
 
 	var homeDivisionName string
@@ -729,7 +728,7 @@ func TestAccResourceRoutingQueueFlows(t *testing.T) {
 					queueFlowFilePath3,
 					inQueueShortMessageFlowConfig,
 					false,
-				) + architect_user_prompt.GenerateUserPromptResource(&architect_user_prompt.UserPromptStruct{
+				) + userPrompt.GenerateUserPromptResource(&userPrompt.UserPromptStruct{
 					ResourceLabel: userPromptResourceLabel1,
 					Name:          userPromptName1,
 					Description:   strconv.Quote(userPromptDescription1),
@@ -766,7 +765,7 @@ func TestAccResourceRoutingQueueFlows(t *testing.T) {
 					queueFlowFilePath3,
 					inQueueShortMessageFlowConfig,
 					false,
-				) + architect_user_prompt.GenerateUserPromptResource(&architect_user_prompt.UserPromptStruct{
+				) + userPrompt.GenerateUserPromptResource(&userPrompt.UserPromptStruct{
 					ResourceLabel: userPromptResourceLabel1,
 					Name:          userPromptName1,
 					Description:   strconv.Quote(userPromptDescription1),
@@ -801,7 +800,7 @@ func TestAccResourceRoutingQueueFlows(t *testing.T) {
 					queueFlowFilePath3,
 					inQueueShortMessageFlowConfig,
 					false,
-				) + architect_user_prompt.GenerateUserPromptResource(&architect_user_prompt.UserPromptStruct{
+				) + userPrompt.GenerateUserPromptResource(&userPrompt.UserPromptStruct{
 					ResourceLabel: userPromptResourceLabel1,
 					Name:          userPromptName1,
 					Description:   strconv.Quote(userPromptDescription1),

--- a/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
+++ b/genesyscloud/routing_queue/resource_genesyscloud_routing_queue_unit_test.go
@@ -536,6 +536,11 @@ func TestUnitGetRoutingQueueMembersPerQueueCacheHit(t *testing.T) {
 
 func TestUnitGetAllRoutingQueuesListCacheHit(t *testing.T) {
 	tfexporter_state.ActivateExporterState()
+	t.Cleanup(func() {
+		routingQueueCache.InvalidateCache()
+		routingQueueListCache.InvalidateCache()
+		tfexporter_state.ResetExporterStateForTests()
+	})
 
 	listKey := routingQueueListCacheKey("", false)
 	cached := []platformclientv2.Queue{
@@ -543,7 +548,7 @@ func TestUnitGetAllRoutingQueuesListCacheHit(t *testing.T) {
 	}
 	rc.SetCache(routingQueueListCache, listKey, cached)
 
-	queues, _, err := GetAllRoutingQueuesFn(context.Background(), &RoutingQueueProxy{RoutingQueueCache: routingQueueCache}, "", false)
+	queues, _, err := GetAllRoutingQueuesFn(context.Background(), &RoutingQueueProxy{RoutingQueueCache: routingQueueCache}, "", false, true)
 	require.NoError(t, err)
 	require.Len(t, *queues, 1)
 	assert.Equal(t, "queue-list-1", *(*queues)[0].Id)
@@ -551,6 +556,11 @@ func TestUnitGetAllRoutingQueuesListCacheHit(t *testing.T) {
 
 func TestUnitRoutingQueueCacheMergesNonPeerAndPeerQueues(t *testing.T) {
 	tfexporter_state.ActivateExporterState()
+	t.Cleanup(func() {
+		routingQueueCache.InvalidateCache()
+		routingQueueListCache.InvalidateCache()
+		tfexporter_state.ResetExporterStateForTests()
+	})
 
 	nonPeer := []platformclientv2.Queue{
 		{Id: platformclientv2.String("non-peer-queue"), Name: platformclientv2.String("Non Peer")},
@@ -563,6 +573,10 @@ func TestUnitRoutingQueueCacheMergesNonPeerAndPeerQueues(t *testing.T) {
 	for i := range nonPeer {
 		storeRoutingQueueInCache(routingQueueCache, &nonPeer[i])
 	}
+
+	// Matches GetAllRoutingQueuesFn before a hasPeer=true fetch: drop that list key only.
+	routingQueueListCache.DeleteCacheItem(routingQueueListCacheKey("", true))
+	require.NotNil(t, rc.GetCacheItem(routingQueueCache, "non-peer-queue"), "per-queue cache must keep non-peer queues across a peer-list refresh")
 
 	rc.SetCache(routingQueueListCache, routingQueueListCacheKey("", true), peer)
 	for i := range peer {
@@ -579,6 +593,11 @@ func TestUnitRoutingQueueCacheMergesNonPeerAndPeerQueues(t *testing.T) {
 
 func TestUnitStoreRoutingQueueInCache(t *testing.T) {
 	tfexporter_state.ActivateExporterState()
+	t.Cleanup(func() {
+		routingQueueCache.InvalidateCache()
+		routingQueueListCache.InvalidateCache()
+		tfexporter_state.ResetExporterStateForTests()
+	})
 
 	queueID := "queue-write-through-test"
 	queue := platformclientv2.Queue{

--- a/genesyscloud/routing_queue_conditional_group_activation/resource_genesyscloud_routing_queue_conditional_group_activation.go
+++ b/genesyscloud/routing_queue_conditional_group_activation/resource_genesyscloud_routing_queue_conditional_group_activation.go
@@ -29,7 +29,7 @@ func getAllRoutingQueueConditionalGroupActivation(ctx context.Context, clientCon
 		return nil, nil
 	}
 
-	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false)
+	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false, true)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get conditional group activation rules: %s", err), resp)
 	}

--- a/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
+++ b/genesyscloud/routing_queue_conditional_group_routing/resource_genesyscloud_routing_queue_conditional_group_routing.go
@@ -33,7 +33,7 @@ func getAllAuthRoutingQueueConditionalGroup(ctx context.Context, clientConfig *p
 		return nil, nil
 	}
 
-	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false)
+	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false, true)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("failed to get conditional group routing rules: %s", err), resp)
 	}

--- a/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
+++ b/genesyscloud/routing_queue_outbound_email_address/resource_genesyscloud_routing_queue_outbound_email_address.go
@@ -33,7 +33,7 @@ func getAllAuthRoutingQueueOutboundEmailAddress(ctx context.Context, clientConfi
 	resources := make(resourceExporter.ResourceIDMetaMap)
 	proxy := getRoutingQueueOutboundEmailAddressProxy(clientConfig)
 
-	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false)
+	queues, resp, err := proxy.routingQueueProxy.GetAllRoutingQueues(ctx, "", false, true)
 	if err != nil {
 		return nil, util.BuildAPIDiagnosticError(ResourceType, "failed to get outbound email addresses for routing queues", resp)
 	}


### PR DESCRIPTION
## Summary

- Makes the exporter's `getAllRoutingQueues` the source of truth: it always hits the API (`checkCache=false`), clears stale list/per-queue cache entries, then repopulates the cache from that fetch. Other callers (lookup-by-name, CGR/CGA/outbound-email exporters) still reuse the cache.
- Adds a mutex-backed `InvalidateCache()` on `ResourceCache` instead of replacing the global cache pointer (the old `invalidateRoutingQueueListCache()` was racy).
- Restores the default routing-queue list `pageSize` from 500 to 100, matching pre-1.84.1 behavior, in case the larger page size contributed to incomplete list results.

Fixes #2509 (not fully reproduced locally). Reported as a regression in v1.84.1+: queues created with whisper prompts export correctly on apply, but a later `tfexporter` run omits `whisper_prompt_id` even though the queues still have a prompt assigned. v1.84.0 is unaffected.

## Why this should help

During export, `readRoutingQueue` loads each queue via `getRoutingQueueById(..., checkCache=true)`. If `GetAllRoutingQueues` returns (or seeds the per-queue cache with) a stale list snapshot — for example if whisper prompts were changed while export was running, or an earlier list call left incomplete objects in cache — the exporter writes queues without `whisper_prompt_id`.

This change treats the exporter `getAll` as the authoritative refresh:

1. Skip the list cache (`checkCache=false`).
2. Drop that list-cache key and invalidate the per-queue cache.
3. Fetch from the API and write both caches from that response.

Empty list-cache hits are also ignored (`len(*cached) > 0`), so a previously stored empty page cannot short-circuit a real fetch.

## Changes

### Cache is no longer blindly trusted in `GetAllRoutingQueues`

`GetAllRoutingQueues` / `GetAllRoutingQueuesFn` take a new `checkCache` flag.

| Caller | `checkCache` | Intent |
|---|---|---|
| Exporter `getAllRoutingQueues` | `false` | Always fetch; this is the source of truth |
| Data source cache hydrate | `false` | Same — hydrate from the API |
| `getRoutingQueueByName` | `true` | Reuse list cache (name lookup) |
| CGR / CGA / outbound email exporters | `true` | Reuse the cache populated by the queue exporter |

On a miss (or when `checkCache` is false), both caches are cleared **before** the API call, then rewritten from the new pages.

### Thread-safe full cache invalidation

`CacheInterface` now has `InvalidateCache()`, which locks the cache mutex and replaces the inner map. Queue delete uses `routingQueueListCache.InvalidateCache()` instead of assigning `routingQueueListCache = rc.NewResourceCache(...)`, which raced with concurrent readers/writers.

### Default list `pageSize` 500 → 100

`GetAllRoutingQueuesFn` uses `page_size.ForResource(ResourceType, 100)` again. Wrapup-code pagination is still 500. This is defensive; it matches the last known-good exporter behavior.