### PR TITLE
fix/DEVTOOLING-1622: Set empty label_ids and label_names when documen…

### DIFF
--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document.go
@@ -151,9 +151,13 @@ func readKnowledgeDocument(ctx context.Context, d *schema.ResourceData, meta int
 				labelIds = append(labelIds, fmt.Sprintf("%s,%s", *label.Id, knowledgeBaseId))
 			}
 			_ = d.Set("label_ids", labelIds)
+		} else {
+			_ = d.Set("label_ids", []string{})
 		}
 		if knowledgeDocument.Category != nil && knowledgeDocument.Category.Id != nil {
 			_ = d.Set("category_id", fmt.Sprintf("%s,%s", *knowledgeDocument.Category.Id, knowledgeBaseId))
+		} else {
+			_ = d.Set("category_id", "")
 		}
 
 		log.Printf("Read Knowledge document %s", *knowledgeDocument.Id)

--- a/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_utils.go
+++ b/genesyscloud/knowledge_document/resource_genesyscloud_knowledge_document_utils.go
@@ -239,6 +239,8 @@ func flattenKnowledgeDocument(ctx context.Context, documentIn *platformclientv2.
 			}
 		}
 		documentOut["label_names"] = labelNames
+	} else {
+		documentOut["label_names"] = []string{}
 	}
 
 	return []interface{}{documentOut}, nil


### PR DESCRIPTION
Problem
After merging DEVTOOLING-1622, knowledge documents without labels/categories produce a non-empty plan on every terraform plan:


~ resource "genesyscloud_knowledge_document" "example" {
    + label_ids = (known after apply)
    ~ knowledge_document {
        + label_names = []
    }
}
This causes TestAccDataSourceVariationRequest to fail with "plan was not empty."

Root Cause
The readKnowledgeDocument() function only sets label_ids when labels exist. When a document has no labels, the field is never set — Terraform interprets this as "needs recomputation" for Computed fields, showing drift on every plan.

Same issue with label_names in the flatten utility — when no labels exist, the key was never added to the document map.

Fix
Always set the fields, even when empty:

label_ids → []string{} when no labels (was: not set at all)
category_id → "" when no category (was: not set at all)
label_names → []string{} in flatten when no labels (was: key omitted from map)
Impact
Zero impact on API calls (these fields are never read by create/update)
Zero impact on export (empty lists have nothing for RefAttrs to resolve)
Fixes all non-empty plan drift for documents without labels/categories
Testing
TestAccDataSourceVariationRequest — PASS (previously failing)
All knowledge_document acceptance tests — PASS
All knowledge_document_variation acceptance tests — PASS