### PR TITLE
fix:Devtooling-1723 turned of duplicate role which is increasing payi…

### DIFF
--- a/genesyscloud/group_roles/genesyscloud_group_roles_proxy.go
+++ b/genesyscloud/group_roles/genesyscloud_group_roles_proxy.go
@@ -54,7 +54,7 @@ func getGroupRolesByIdFn(ctx context.Context, p *groupRolesProxy, roleId string)
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
 	var grants []platformclientv2.Authzgrant
-	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, true)
+	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, false)
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to get current grants for subject %s: %s", roleId, err)
 	}
@@ -77,7 +77,7 @@ func updateGroupRolesFn(ctx context.Context, p *groupRolesProxy, roleId string, 
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 
 	// Get existing roles/divisions
-	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, true)
+	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, false)
 
 	if err != nil || (resp != nil && resp.StatusCode == http.StatusNotFound) || subject == nil {
 		return resp, fmt.Errorf("failed to get current grants for subject %s: %s while updating group role", roleId, err)
@@ -132,7 +132,7 @@ func updateGroupRolesFn(ctx context.Context, p *groupRolesProxy, roleId string, 
 
 func getAssignedGrants(subjectID string, p *groupRolesProxy) ([]platformclientv2.Authzgrant, *platformclientv2.APIResponse, error) {
 	var grants []platformclientv2.Authzgrant
-	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(subjectID, true)
+	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(subjectID, false)
 
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to get current grants for subject %s: %s", subjectID, err)

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles.go
@@ -3,12 +3,13 @@ package group_roles
 import (
 	"context"
 	"fmt"
+	"log"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/consistency_checker"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/provider"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/constants"
-	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -42,7 +43,10 @@ func readGroupRoles(ctx context.Context, d *schema.ResourceData, meta interface{
 
 		roles, resp, err := flattenSubjectRoles(d, proxy)
 		if err != nil {
-			if util.IsStatus404ByInt(resp.StatusCode) {
+			// Guard against a nil resp (the error path can return a nil APIResponse).
+			// Dereferencing resp.StatusCode without this check is what caused the
+			// DEVTOOLING-1723 plugin crash in the user_roles resource.
+			if resp != nil && util.IsStatus404ByInt(resp.StatusCode) {
 				return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read roles for group %s | error: %v", d.Id(), err), resp))
 			}
 			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Failed to read roles for group %s | error: %v", d.Id(), err), resp))

--- a/genesyscloud/group_roles/resource_genesyscloud_group_roles_utils.go
+++ b/genesyscloud/group_roles/resource_genesyscloud_group_roles_utils.go
@@ -24,6 +24,12 @@ func flattenSubjectRoles(d *schema.ResourceData, p *groupRolesProxy) (*schema.Se
 
 	roleDivsMap := make(map[string]*schema.Set)
 	for _, grant := range grants {
+		// Guard against malformed/partial API responses where Role, Division, or their
+		// Ids may be nil. Skipping such grants prevents a nil pointer panic (which would
+		// crash the whole provider plugin) and lets the read complete gracefully.
+		if grant.Role == nil || grant.Role.Id == nil || grant.Division == nil || grant.Division.Id == nil {
+			continue
+		}
 		if currentDivs, ok := roleDivsMap[*grant.Role.Id]; ok {
 			currentDivs.Add(*grant.Division.Id)
 		} else {
@@ -42,13 +48,20 @@ func flattenSubjectRoles(d *schema.ResourceData, p *groupRolesProxy) (*schema.Se
 }
 
 func roleDivPairsToGrants(grantPairs []string) platformclientv2.Roledivisiongrants {
-	grants := make([]platformclientv2.Roledivisionpair, len(grantPairs))
-	for i, pair := range grantPairs {
-		roleDiv := strings.Split(pair, ":")
-		grants[i] = platformclientv2.Roledivisionpair{
-			RoleId:     &roleDiv[0],
-			DivisionId: &roleDiv[1],
+	grants := make([]platformclientv2.Roledivisionpair, 0, len(grantPairs))
+	for _, pair := range grantPairs {
+		roleDiv := strings.SplitN(pair, ":", 2)
+		// A valid pair is "roleID:divisionID". Skip anything malformed to avoid an
+		// index-out-of-range panic on roleDiv[1].
+		if len(roleDiv) != 2 {
+			continue
 		}
+		roleID := roleDiv[0]
+		divID := roleDiv[1]
+		grants = append(grants, platformclientv2.Roledivisionpair{
+			RoleId:     &roleID,
+			DivisionId: &divID,
+		})
 	}
 	return platformclientv2.Roledivisiongrants{
 		Grants: &grants,
@@ -64,11 +77,18 @@ func addDivisionIdsSetToRole(d *schema.ResourceData, divIdsFromApi *schema.Set, 
 
 	for _, role := range rolesMaps {
 		roleMap, ok := role.(map[string]interface{})
-		// find the role in question
-		if !ok || roleMap["role_id"].(string) != roleId {
+		if !ok {
 			continue
 		}
-		divs := roleMap["division_ids"].(*schema.Set)
+		// find the role in question (guard the type assertion to avoid a panic)
+		roleIDVal, ok := roleMap["role_id"].(string)
+		if !ok || roleIDVal != roleId {
+			continue
+		}
+		divs, ok := roleMap["division_ids"].(*schema.Set)
+		if !ok || divs == nil {
+			continue
+		}
 		for _, div := range divs.List() {
 			// home division id was included in original config -> use division_ids read from API
 			if div.(string) == homeDivId {
@@ -88,6 +108,10 @@ func getExistingAndConfigGrants(grants []platformclientv2.Authzgrant, rolesConfi
 	var existingGrants []string
 
 	for _, grant := range grants {
+		// Guard against nil Role/Division to avoid a panic on malformed API responses.
+		if grant.Role == nil || grant.Role.Id == nil || grant.Division == nil || grant.Division.Id == nil {
+			continue
+		}
 		existingGrants = append(existingGrants, createRoleDivisionPair(*grant.Role.Id, *grant.Division.Id))
 	}
 

--- a/genesyscloud/user_roles/genesyscloud_user_roles_proxy.go
+++ b/genesyscloud/user_roles/genesyscloud_user_roles_proxy.go
@@ -52,7 +52,7 @@ func (p *userRolesProxy) updateUserRoles(ctx context.Context, roleID string, rol
 func getUserRolesByIdFn(ctx context.Context, p *userRolesProxy, roleId string) (*[]platformclientv2.Authzgrant, *platformclientv2.APIResponse, error) {
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 	var grants []platformclientv2.Authzgrant
-	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, true)
+	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, false)
 
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to get current grants for subject %s: %s", roleId, err)
@@ -75,26 +75,20 @@ func getUserRolesByIdFn(ctx context.Context, p *userRolesProxy, roleId string) (
 func updateUserRolesFn(ctx context.Context, p *userRolesProxy, roleId string, rolesConfig *schema.Set, subjectType string) (*platformclientv2.APIResponse, error) {
 	ctx = provider.EnsureResourceContext(ctx, ResourceType)
 	// Get existing roles/divisions
-	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, true)
+	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(roleId, false)
 
-	if err != nil || (resp != nil && resp.StatusCode == http.StatusNotFound) || subject == nil {
-		return resp, fmt.Errorf("failed to get current grants for subject %s: %s while updating user role", roleId, err)
+	if err != nil || (resp != nil && resp.StatusCode == http.StatusNotFound) || subject == nil || subject.Id == nil {
+		return resp, fmt.Errorf("failed to get current grants for subject %s: %v while updating user role", roleId, err)
 	}
 
 	grants, _, err := getAssignedGrants(*subject.Id, p)
-
-	existingGrants, configGrants, _ := getExistingAndConfigGrants(grants, rolesConfig)
-
 	if err != nil {
-		return resp, fmt.Errorf("failed to get current grants for subject %s: %s", roleId, err)
+		return resp, fmt.Errorf("failed to get current grants for subject %s: %v", roleId, err)
 	}
 
-	if subject != nil && subject.Grants != nil {
-		for _, grant := range *subject.Grants {
-			if grant.SubjectId != nil && *grant.SubjectId == roleId {
-				grants = append(grants, grant)
-			}
-		}
+	existingGrants, configGrants, err := getExistingAndConfigGrants(grants, rolesConfig)
+	if err != nil {
+		return resp, fmt.Errorf("failed to build grant lists for subject %s: %v", roleId, err)
 	}
 
 	grantsToRemove, grantsToAdd := getGrantsToAddAndRemove(existingGrants, configGrants)
@@ -131,7 +125,7 @@ func updateUserRolesFn(ctx context.Context, p *userRolesProxy, roleId string, ro
 
 func getAssignedGrants(subjectID string, p *userRolesProxy) ([]platformclientv2.Authzgrant, *platformclientv2.APIResponse, error) {
 	var grants []platformclientv2.Authzgrant
-	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(subjectID, true)
+	subject, resp, err := p.authorizationApi.GetAuthorizationSubject(subjectID, false)
 
 	if err != nil {
 		return nil, resp, fmt.Errorf("failed to get current grants for subject %s: %s", subjectID, err)

--- a/genesyscloud/user_roles/resource_genesyscloud_user_roles_utils.go
+++ b/genesyscloud/user_roles/resource_genesyscloud_user_roles_utils.go
@@ -24,6 +24,12 @@ func flattenSubjectRoles(d *schema.ResourceData, p *userRolesProxy) (*schema.Set
 
 	roleDivsMap := make(map[string]*schema.Set)
 	for _, grant := range grants {
+		// Guard against malformed/partial API responses where Role, Division, or their
+		// Ids may be nil. Skipping such grants prevents a nil pointer panic (which would
+		// crash the whole provider plugin) and lets the read complete gracefully.
+		if grant.Role == nil || grant.Role.Id == nil || grant.Division == nil || grant.Division.Id == nil {
+			continue
+		}
 		if currentDivs, ok := roleDivsMap[*grant.Role.Id]; ok {
 			currentDivs.Add(*grant.Division.Id)
 		} else {
@@ -42,13 +48,20 @@ func flattenSubjectRoles(d *schema.ResourceData, p *userRolesProxy) (*schema.Set
 }
 
 func roleDivPairsToGrants(grantPairs []string) platformclientv2.Roledivisiongrants {
-	grants := make([]platformclientv2.Roledivisionpair, len(grantPairs))
-	for i, pair := range grantPairs {
-		roleDiv := strings.Split(pair, ":")
-		grants[i] = platformclientv2.Roledivisionpair{
-			RoleId:     &roleDiv[0],
-			DivisionId: &roleDiv[1],
+	grants := make([]platformclientv2.Roledivisionpair, 0, len(grantPairs))
+	for _, pair := range grantPairs {
+		roleDiv := strings.SplitN(pair, ":", 2)
+		// A valid pair is "roleID:divisionID". Skip anything malformed to avoid an
+		// index-out-of-range panic on roleDiv[1].
+		if len(roleDiv) != 2 {
+			continue
 		}
+		roleID := roleDiv[0]
+		divID := roleDiv[1]
+		grants = append(grants, platformclientv2.Roledivisionpair{
+			RoleId:     &roleID,
+			DivisionId: &divID,
+		})
 	}
 	return platformclientv2.Roledivisiongrants{
 		Grants: &grants,
@@ -64,11 +77,18 @@ func addDivisionIdsSetToRole(d *schema.ResourceData, divIdsFromApi *schema.Set, 
 
 	for _, role := range rolesMaps {
 		roleMap, ok := role.(map[string]interface{})
-		// find the role in question
-		if !ok || roleMap["role_id"].(string) != roleId {
+		if !ok {
 			continue
 		}
-		divs := roleMap["division_ids"].(*schema.Set)
+		// find the role in question (guard the type assertion to avoid a panic)
+		roleIDVal, ok := roleMap["role_id"].(string)
+		if !ok || roleIDVal != roleId {
+			continue
+		}
+		divs, ok := roleMap["division_ids"].(*schema.Set)
+		if !ok || divs == nil {
+			continue
+		}
 		for _, div := range divs.List() {
 			// home division id was included in original config -> use division_ids read from API
 			if div.(string) == homeDivId {
@@ -88,6 +108,10 @@ func getExistingAndConfigGrants(grants []platformclientv2.Authzgrant, rolesConfi
 	var existingGrants []string
 
 	for _, grant := range grants {
+		// Guard against nil Role/Division to avoid a panic on malformed API responses.
+		if grant.Role == nil || grant.Role.Id == nil || grant.Division == nil || grant.Division.Id == nil {
+			continue
+		}
 		existingGrants = append(existingGrants, createRoleDivisionPair(*grant.Role.Id, *grant.Division.Id))
 	}
 


### PR DESCRIPTION
**PR Summary**
Title: [DEVTOOLING-1723] user_roles/group_roles: use includeDuplicates=false and harden read path against crashes

**Problem**
Exporting genesyscloud_user_roles / genesyscloud_group_roles fails for users or groups with a large number of role assignments. Two failure modes were observed across versions, both stemming from the same root cause:

v1.84.1: nil pointer dereference (resp.StatusCode on a nil resp) → plugin crash.
v1.85.0: crash fixed, but persistent HTTP 500s drove the retry loop into Terraform's timeout → "Plugin did not respond".

**Root Cause**
The provider called GET /api/v2/authorization/subjects/{id}?includeDuplicates=true. For subjects with many roles, this returns a large payload (inherited grants duplicated across group memberships) that the platform API fails to serialize and returns HTTP 500. The provider then discards those duplicate grants anyway (it filters grants by SubjectId), so includeDuplicates=true was requesting data that was never used.

**Solution**
Set includeDuplicates=false on all GetAuthorizationSubject calls (6 sites across user_roles and group_roles). Removes the oversized payload that triggers the 500.
Added the resp != nil guard to the group_roles read path — the same guard that already existed in user_roles. The original crash pattern was still present in group_roles.
Hardened the role read/update paths against malformed/partial API responses so a bad response returns a clean error instead of crashing the plugin.

**Files Changed**
File	Change

genesyscloud_user_roles_proxy.go
includeDuplicates=false (3 calls); subject.Id nil guard; check previously-ignored error; removed dead duplicate grant-append loop

resource_genesyscloud_user_roles_utils.go
Nil guards on grant.Role/grant.Division; safe SplitN role:division parsing; guarded type assertions

genesyscloud_group_roles_proxy.go
includeDuplicates=false (3 calls)

resource_genesyscloud_group_roles.go
Added resp != nil guard before resp.StatusCode (the crash fix, previously only in user_roles)

resource_genesyscloud_group_roles_utils.go
Same nil guards, safe pair parsing, and guarded type assertions as user_roles

**Testing & Results**
Payload reduction (measured against a real org, 1,990 subjects, before/after the flag change):

Metric	                    Before (true)	After (false)	Reduction
Total grants returned	33,684	        27,604	−18%
Max grants for one subject	736	          363	 −51%
The heaviest subjects — the ones prone to the 500 — had their payload roughly halved. Exported Terraform config is unchanged (no duplicate roles/divisions), confirming the removed data was never used.

Export completes end-to-end with no crash.
Unit tests: passed.
Acceptance tests: passed.
Build: clean.

[DEVTOOLING-1723]: https://inindca.atlassian.net/browse/DEVTOOLING-1723?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ