### PR TITLE
AS-5418: Add max_inbound_calls to genesyscloud_routing_utilization resource

### DIFF
--- a/docs/resources/routing_utilization.md
+++ b/docs/resources/routing_utilization.md
@@ -81,6 +81,7 @@ resource "genesyscloud_routing_utilization" "org-utilization" {
 - `chat` (Block List, Max: 1) Chat media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--chat))
 - `email` (Block List, Max: 1) Email media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--email))
 - `label_utilizations` (Block List) Label utilization settings. If not set, default label settings will be applied. (see [below for nested schema](#nestedblock--label_utilizations))
+- `max_inbound_calls` (Number) Max number of inbound voice calls. This limits the total inbound calls (ACD + non-ACD) an agent can receive.
 - `message` (Block List, Max: 1) Message media settings. If not set, this reverts to the default media type settings. (see [below for nested schema](#nestedblock--message))
 - `timeouts` (Block, Optional) (see [below for nested schema](#nestedblock--timeouts))
 

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization.go
@@ -79,6 +79,10 @@ func readRoutingUtilization(ctx context.Context, d *schema.ResourceData, meta in
 			_ = d.Set("label_utilizations", flattenedLabelUtilizations)
 		}
 
+		if orgUtilization.MaxInboundCalls != nil {
+			_ = d.Set("max_inbound_calls", *orgUtilization.MaxInboundCalls)
+		}
+
 		log.Printf("Read Routing Utilization")
 		return cc.CheckState(d)
 	})
@@ -92,10 +96,17 @@ func updateRoutingUtilization(ctx context.Context, d *schema.ResourceData, meta 
 
 	// Retrying on 409s because if a label is created immediately before the utilization update, it can lead to a conflict while the utilization is being updated to handle the new label.
 	diagErr := util.RetryWhen(util.IsStatus409, func() (*platformclientv2.APIResponse, diag.Diagnostics) {
-		_, resp, err := proxy.updateRoutingUtilization(ctx, &platformclientv2.Utilizationrequest{
+		utilizationRequest := &platformclientv2.Utilizationrequest{
 			Utilization:       BuildSdkMediaUtilizations(d),
 			LabelUtilizations: BuildSdkLabelUtilizations(d.Get("label_utilizations").([]interface{})),
-		})
+		}
+
+		if v, ok := d.GetOk("max_inbound_calls"); ok {
+			maxInbound := v.(int)
+			utilizationRequest.MaxInboundCalls = &maxInbound
+		}
+
+		_, resp, err := proxy.updateRoutingUtilization(ctx, utilizationRequest)
 
 		if err != nil {
 			return resp, util.BuildAPIDiagnosticError(ResourceType, fmt.Sprintf("Failed to update Routing Utilization %s error: %s", d.Id(), err), resp)

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_schema.go
@@ -147,6 +147,12 @@ func ResourceRoutingUtilization() *schema.Resource {
 				Computed:    true,
 				Elem:        UtilizationLabelResource,
 			},
+			"max_inbound_calls": {
+				Description: "Max number of inbound voice calls. This limits the total inbound calls (ACD + non-ACD) an agent can receive.",
+				Type:        schema.TypeInt,
+				Optional:    true,
+				Computed:    true,
+			},
 		},
 	}
 }
@@ -154,7 +160,7 @@ func ResourceRoutingUtilization() *schema.Resource {
 func RoutingUtilizationExporter() *resourceExporter.ResourceExporter {
 	return &resourceExporter.ResourceExporter{
 		GetResourcesFunc: provider.GetAllWithPooledClient(getAllRoutingUtilization),
-		AllowZeroValues:  []string{"maximum_capacity"},
+		AllowZeroValues:  []string{"maximum_capacity", "max_inbound_calls"},
 		IsSingleton:      true,
 		ExportId:         ResourceType,
 	}

--- a/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
+++ b/genesyscloud/routing_utilization/resource_genesyscloud_routing_utilization_test.go
@@ -280,6 +280,57 @@ func generateRoutingUtilizationResource(attributes ...string) string {
 	`, strings.Join(attributes, "\n"))
 }
 
+func TestAccResourceRoutingUtilizationMaxInboundCalls(t *testing.T) {
+	t.Parallel()
+	var (
+		maxCapacity      = "1"
+		maxInboundCalls1 = "1"
+		maxInboundCalls2 = "2"
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { util.TestAccPreCheck(t) },
+		ProviderFactories: provider.GetProviderFactories(providerResources, nil),
+		Steps: []resource.TestStep{
+			{
+				// Create with max_inbound_calls
+				Config: generateRoutingUtilizationResource(
+					GenerateRoutingUtilMediaType("call", maxCapacity, util.TrueValue),
+					GenerateRoutingUtilMediaType("callback", maxCapacity, util.FalseValue),
+					GenerateRoutingUtilMediaType("chat", maxCapacity, util.FalseValue),
+					GenerateRoutingUtilMediaType("email", maxCapacity, util.FalseValue),
+					GenerateRoutingUtilMediaType("message", maxCapacity, util.FalseValue),
+					fmt.Sprintf("max_inbound_calls = %s", maxInboundCalls1),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "max_inbound_calls", maxInboundCalls1),
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "call.0.maximum_capacity", maxCapacity),
+				),
+			},
+			{
+				// Update max_inbound_calls
+				Config: generateRoutingUtilizationResource(
+					GenerateRoutingUtilMediaType("call", maxCapacity, util.TrueValue),
+					GenerateRoutingUtilMediaType("callback", maxCapacity, util.FalseValue),
+					GenerateRoutingUtilMediaType("chat", maxCapacity, util.FalseValue),
+					GenerateRoutingUtilMediaType("email", maxCapacity, util.FalseValue),
+					GenerateRoutingUtilMediaType("message", maxCapacity, util.FalseValue),
+					fmt.Sprintf("max_inbound_calls = %s", maxInboundCalls2),
+				),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("genesyscloud_routing_utilization.routing-util", "max_inbound_calls", maxInboundCalls2),
+				),
+			},
+			{
+				// Import/Read
+				ResourceName:      "genesyscloud_routing_utilization.routing-util",
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func CleanupRoutingUtilizationLabel() error {
 	config, err := provider.AuthorizeSdk()
 	if err != nil {


### PR DESCRIPTION
## Why

The `genesyscloud_routing_utilization` Terraform resource does not export or import the `maxInboundCalls` field. When customers export their org utilization config and apply it to another environment, the inbound calls limit is silently reset to default — breaking pipeline promotions.

[AS-5418](https://inindca.atlassian.net/browse/AS-5418)

## What

- Added `max_inbound_calls` attribute (`TypeInt`, `Optional+Computed`) to the resource schema
- Wired into `readRoutingUtilization`: reads `MaxInboundCalls` from API response into Terraform state
- Wired into `updateRoutingUtilization`: sets `MaxInboundCalls` on API request from Terraform state
- Added to exporter `AllowZeroValues` so explicit zero is exported correctly
- Added acceptance test verifying create, update, and import round-trip

## Impact

- Existing configs without `max_inbound_calls` are unaffected (`Optional+Computed`)
- Configs that set it will now correctly persist across export/import cycles
- No SDK changes needed — `MaxInboundCalls *int` already exists on `Utilizationresponse` and `Utilizationrequest` in platform-client-sdk-go/v193

## Testing

Added `TestAccResourceRoutingUtilizationMaxInboundCalls` with:
- Step 1: Create with `max_inbound_calls = 1`, verify persists
- Step 2: Update to `max_inbound_calls = 2`, verify persists
- Step 3: Import/read verification

## Files Changed

| File | Change |
|------|--------|
| `resource_genesyscloud_routing_utilization_schema.go` | Added `max_inbound_calls` attribute + `AllowZeroValues` |
| `resource_genesyscloud_routing_utilization.go` | Read from API response + set on update request |
| `resource_genesyscloud_routing_utilization_test.go` | Acceptance test for create/update/import |

[AS-5418]: https://inindca.atlassian.net/browse/AS-5418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
