### PR TITLE
DEVTOOLING-1797: Strip org-specific GUIDs from exported function-data-action config

### DIFF
--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter.go
@@ -58,14 +58,48 @@ func FunctionZipExportResolver(actionId, exportDirectory, subDirectory string, c
 	functionMap["file_path"] = normalizedPath
 	delete(functionMap, "file_content_hash")
 
+	// zip_id is a Genesys Cloud generated, org-specific GUID (Optional+Computed).
+	// Exporting it produces a hardcoded value that is invalid in a target org and
+	// causes perpetual plan drift, since the platform regenerates it on publish.
+	// Drop it so the platform recomputes it on apply.
+	delete(functionMap, "zip_id")
+
 	configMap["function_config"] = []interface{}{functionMap}
+
+	// For function data actions, request_url_template is set server-side to the
+	// generated function id (an org-specific GUID). Like zip_id, exporting it makes
+	// the config non-portable and causes perpetual drift. Remove it so the platform
+	// recomputes it on apply.
+	removeExportedFunctionRequestUrlTemplate(configMap)
 
 	if resource.State != nil && resource.State.Attributes != nil {
 		resource.State.Attributes["function_config.0.file_path"] = normalizedPath
 		delete(resource.State.Attributes, "function_config.0.file_content_hash")
+		delete(resource.State.Attributes, "function_config.0.zip_id")
+		delete(resource.State.Attributes, "config_request.0.request_url_template")
 	}
 
 	return nil
+}
+
+// removeExportedFunctionRequestUrlTemplate deletes request_url_template from the
+// first config_request block in the exported config map, if present.
+func removeExportedFunctionRequestUrlTemplate(configMap map[string]interface{}) {
+	configRequestRaw, ok := configMap["config_request"]
+	if !ok || configRequestRaw == nil {
+		return
+	}
+	configRequestList, ok := configRequestRaw.([]interface{})
+	if !ok || len(configRequestList) == 0 || configRequestList[0] == nil {
+		return
+	}
+	requestMap, ok := configRequestList[0].(map[string]interface{})
+	if !ok {
+		return
+	}
+	delete(requestMap, "request_url_template")
+	configRequestList[0] = requestMap
+	configMap["config_request"] = configRequestList
 }
 
 func writeFunctionZipExportReadme(directory string) error {

--- a/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter_test.go
+++ b/genesyscloud/integration_action/resource_genesyscloud_integration_action_exporter_test.go
@@ -66,6 +66,13 @@ func TestUnitFunctionZipExportResolver(t *testing.T) {
 				"handler":           "dist/index.handler",
 				"file_path":         "xp2025_get_ticket_status.zip",
 				"file_content_hash": "sha256:should-be-removed",
+				"zip_id":            "11111111-1111-1111-1111-111111111111",
+			},
+		},
+		"config_request": []interface{}{
+			map[string]interface{}{
+				"request_type":         "POST",
+				"request_url_template": "22222222-2222-2222-2222-222222222222",
 			},
 		},
 	}
@@ -73,8 +80,10 @@ func TestUnitFunctionZipExportResolver(t *testing.T) {
 		State: &terraform.InstanceState{
 			ID: actionId,
 			Attributes: map[string]string{
-				"function_config.0.file_path":         "xp2025_get_ticket_status.zip",
-				"function_config.0.file_content_hash": "sha256:should-be-removed",
+				"function_config.0.file_path":           "xp2025_get_ticket_status.zip",
+				"function_config.0.file_content_hash":   "sha256:should-be-removed",
+				"function_config.0.zip_id":              "11111111-1111-1111-1111-111111111111",
+				"config_request.0.request_url_template": "22222222-2222-2222-2222-222222222222",
 			},
 		},
 	}
@@ -91,11 +100,27 @@ func TestUnitFunctionZipExportResolver(t *testing.T) {
 	if _, ok := fc["file_content_hash"]; ok {
 		t.Fatalf("file_content_hash should be cleared on export")
 	}
+	if _, ok := fc["zip_id"]; ok {
+		t.Fatalf("zip_id should be cleared on export")
+	}
+	cr := configMap["config_request"].([]interface{})[0].(map[string]interface{})
+	if _, ok := cr["request_url_template"]; ok {
+		t.Fatalf("request_url_template should be cleared on export")
+	}
+	if cr["request_type"] != "POST" {
+		t.Fatalf("request_type should be preserved, got %v", cr["request_type"])
+	}
 	if resource.State.Attributes["function_config.0.file_path"] != expectedPath {
 		t.Fatalf("state file_path not updated")
 	}
 	if _, ok := resource.State.Attributes["function_config.0.file_content_hash"]; ok {
 		t.Fatalf("state file_content_hash should be cleared")
+	}
+	if _, ok := resource.State.Attributes["function_config.0.zip_id"]; ok {
+		t.Fatalf("state zip_id should be cleared")
+	}
+	if _, ok := resource.State.Attributes["config_request.0.request_url_template"]; ok {
+		t.Fatalf("state request_url_template should be cleared")
 	}
 
 	readmePath := filepath.Join(exportDir, FunctionZipExportSubDirectory, "README.md")


### PR DESCRIPTION
**Description:**

Exporting a genesyscloud_integration_action of integration type function-data-actions produced non-portable Terraform config. The exported config contained hardcoded, org-specific GUIDs:

config_request.request_url_template — the server-generated function id
function_config.zip_id — the server-generated zip id
These values are generated by Genesys Cloud on publish and cannot be reused in another org. On top of breaking portability, they caused perpetual plan drift: the config value never matches the platform-generated value in state, so every terraform plan shows a change that never converges.

**Changes:**

Updated FunctionZipExportResolver (runs only for function data actions during export) to remove config_request.0.request_url_template and function_config.0.zip_id from both the exported config map and the resource state.
Both fields are Optional + Computed, so when omitted the platform recomputes them on apply — making the exported config portable and drift-free.
The complete function_config block (handler, runtime, timeout_seconds, description, file_path) and all other request fields (request_type, request_template) are preserved.
Added unit test coverage asserting both GUIDs are stripped from config and state while other fields are retained.
Scope / safety: The change is confined to the export path. Normal resource create/read/update and terraform import are untouched, so regular (non-function) integration actions and their real request_url_template values are unaffected.

**Testing:**

Unit tests pass (TestUnitFunctionZipExportResolver extended).
go vet clean, no diagnostics.
Manually verified end-to-end: exported a function-data-action, confirmed both GUIDs are gone and function_config is complete, applied the exported config into an org, and re-plan showed No changes (no drift). Also confirmed the pre-fix behavior showed permanent drift on both fields.