### PR TITLE
feat: WORKITEMS-8335 - add missing genesyscloud_task_management_worktype attributes

### DIFF
--- a/docs/resources/task_management_worktype.md
+++ b/docs/resources/task_management_worktype.md
@@ -58,6 +58,9 @@ resource "genesyscloud_task_management_worktype" "example_worktype" {
   default_script_id   = genesyscloud_script.example_script.id
 
   assignment_enabled = true
+
+  service_level_target                 = 90
+  unassigned_division_contacts_enabled = true
 }
 
 resource "genesyscloud_task_management_worktype" "example_worktype_without_assignment" {
@@ -109,6 +112,8 @@ resource "genesyscloud_task_management_worktype" "example_worktype_without_assig
 - `flow_rules_enabled` (Boolean) When set to true, the worktype's flow rules will be processed. Default value is false. Defaults to `false`.
 - `schema_id` (String) Id of the workitem schema.
 - `schema_version` (Number) Version of the workitem schema to use. If not provided, the worktype will use the latest version.
+- `service_level_target` (Number) The target service level for Workitems created from the Worktype. The default value is 100.
+- `unassigned_division_contacts_enabled` (Boolean) When set to true, will allow Workitems to be associated with External Contacts that are not assigned to any division. Default value is true.
 
 ### Read-Only
 

--- a/examples/resources/genesyscloud_task_management_worktype/resource.tf
+++ b/examples/resources/genesyscloud_task_management_worktype/resource.tf
@@ -18,6 +18,9 @@ resource "genesyscloud_task_management_worktype" "example_worktype" {
   default_script_id   = genesyscloud_script.example_script.id
 
   assignment_enabled = true
+
+  service_level_target                 = 90
+  unassigned_division_contacts_enabled = true
 }
 
 resource "genesyscloud_task_management_worktype" "example_worktype_without_assignment" {

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype.go
@@ -123,6 +123,9 @@ func readTaskManagementWorktype(ctx context.Context, d *schema.ResourceData, met
 			resourcedata.SetNillableValue(d, "flow_rules_enabled", worktype.RuleSettings.FlowRulesEnabled)
 		}
 
+		resourcedata.SetNillableValue(d, "service_level_target", worktype.ServiceLevelTarget)
+		resourcedata.SetNillableValue(d, "unassigned_division_contacts_enabled", worktype.UnassignedDivisionContactsEnabled)
+
 		// disable_default_status_creation is a write-only (create-time) flag in the API/SDK.
 		// Keep state aligned with config to avoid perpetual diffs/invalid plans on refresh.
 		if v := resourcedata.GetNillableBool(d, "disable_default_status_creation"); v != nil {

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_schema.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_schema.go
@@ -151,6 +151,19 @@ func ResourceTaskManagementWorktype() *schema.Resource {
 				Type:        schema.TypeBool,
 				Default:     false,
 			},
+			`service_level_target`: {
+				Description:  `The target service level for Workitems created from the Worktype. The default value is 100.`,
+				Optional:     true,
+				Computed:     true,
+				Type:         schema.TypeInt,
+				ValidateFunc: validation.IntBetween(1, 100),
+			},
+			`unassigned_division_contacts_enabled`: {
+				Description: `When set to true, will allow Workitems to be associated with External Contacts that are not assigned to any division. Default value is true.`,
+				Optional:    true,
+				Computed:    true,
+				Type:        schema.TypeBool,
+			},
 		},
 	}
 }

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_test.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_test.go
@@ -84,10 +84,12 @@ func TestAccResourceTaskManagementWorktype(t *testing.T) {
 				fmt.Sprintf("genesyscloud_routing_skill.%s.id", skillResourceLabel1),
 				fmt.Sprintf("genesyscloud_routing_skill.%s.id", skillResourceLabel2),
 			},
-			assignmentEnabled: false,
-			schemaId:          fmt.Sprintf("genesyscloud_task_management_workitem_schema.%s.id", wsResourceLabel),
-			schemaVersion:     1,
-			defaultScriptId:   fmt.Sprintf("genesyscloud_script.%s.id", scriptResourceLabel),
+			assignmentEnabled:                 false,
+			schemaId:                          fmt.Sprintf("genesyscloud_task_management_workitem_schema.%s.id", wsResourceLabel),
+			schemaVersion:                     1,
+			defaultScriptId:                   fmt.Sprintf("genesyscloud_script.%s.id", scriptResourceLabel),
+			serviceLevelTarget:                80,
+			unassignedDivisionContactsEnabled: false,
 		}
 	)
 
@@ -140,6 +142,9 @@ func TestAccResourceTaskManagementWorktype(t *testing.T) {
 					resource.TestCheckResourceAttr(ResourceType+"."+wtRes.resourceLabel, "schema_version", fmt.Sprintf("%v", wtRes.schemaVersion)),
 
 					resource.TestCheckResourceAttrPair(ResourceType+"."+wtRes.resourceLabel, "default_script_id", fmt.Sprintf("genesyscloud_script.%s", scriptResourceLabel), "id"),
+
+					resource.TestCheckResourceAttr(ResourceType+"."+wtRes.resourceLabel, "service_level_target", fmt.Sprintf("%v", wtRes.serviceLevelTarget)),
+					resource.TestCheckResourceAttr(ResourceType+"."+wtRes.resourceLabel, "unassigned_division_contacts_enabled", fmt.Sprintf("%v", wtRes.unassignedDivisionContactsEnabled)),
 				),
 			},
 		},
@@ -189,6 +194,8 @@ func generateWorktypeResource(wt worktypeConfig) string {
 		assignment_enabled = %v
 		schema_version = %v
 		default_script_id = %v
+		service_level_target = %v
+		unassigned_division_contacts_enabled = %v
 	}
 		`, ResourceType,
 		wt.resourceLabel,
@@ -208,6 +215,8 @@ func generateWorktypeResource(wt worktypeConfig) string {
 		wt.assignmentEnabled,
 		wt.schemaVersion,
 		wt.defaultScriptId,
+		wt.serviceLevelTarget,
+		wt.unassignedDivisionContactsEnabled,
 	)
 	return tfConfig
 }

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_unit_test.go
@@ -72,6 +72,9 @@ func TestUnitResourceWorktypeCreate(t *testing.T) {
 
 				schemaId:      uuid.NewString(),
 				schemaVersion: 1,
+
+				serviceLevelTarget:                80,
+				unassignedDivisionContactsEnabled: true,
 			}
 
 			taskProxy := &TaskManagementWorktypeProxy{}
@@ -93,6 +96,8 @@ func TestUnitResourceWorktypeCreate(t *testing.T) {
 				assert.Equal(t, wt.schemaId, *create.SchemaId, "wt.schemaId check failed in create createTaskManagementWorktypeAttr")
 				assert.Equal(t, wt.schemaVersion, *create.SchemaVersion, "wt.schemaVersion check failed in create createTaskManagementWorktypeAttr")
 				assert.Equal(t, wt.defaultScriptId, *create.DefaultScriptId, "wt.defaultScriptId check failed in create createTaskManagementWorktypeAttr")
+				assert.Equal(t, wt.serviceLevelTarget, *create.ServiceLevelTarget, "wt.serviceLevelTarget check failed in create createTaskManagementWorktypeAttr")
+				assert.Equal(t, wt.unassignedDivisionContactsEnabled, *create.UnassignedDivisionContactsEnabled, "wt.unassignedDivisionContactsEnabled check failed in create createTaskManagementWorktypeAttr")
 				tc.assertCreateDisableDefaultSet(t, create)
 
 				return &platformclientv2.Worktype{
@@ -123,6 +128,8 @@ func TestUnitResourceWorktypeCreate(t *testing.T) {
 					DefaultScript: &platformclientv2.Workitemscriptreference{
 						Id: &wt.defaultScriptId,
 					},
+					ServiceLevelTarget:                &wt.serviceLevelTarget,
+					UnassignedDivisionContactsEnabled: &wt.unassignedDivisionContactsEnabled,
 				}, nil, nil
 			}
 
@@ -166,6 +173,8 @@ func TestUnitResourceWorktypeCreate(t *testing.T) {
 					DefaultScript: &platformclientv2.Workitemscriptreference{
 						Id: &wt.defaultScriptId,
 					},
+					ServiceLevelTarget:                &wt.serviceLevelTarget,
+					UnassignedDivisionContactsEnabled: &wt.unassignedDivisionContactsEnabled,
 				}
 
 				apiResponse := &platformclientv2.APIResponse{StatusCode: http.StatusOK}
@@ -230,6 +239,9 @@ func TestUnitResourceWorktypeRead(t *testing.T) {
 
 		schemaId:      uuid.NewString(),
 		schemaVersion: 1,
+
+		serviceLevelTarget:                80,
+		unassignedDivisionContactsEnabled: false,
 	}
 
 	taskProxy := &TaskManagementWorktypeProxy{}
@@ -274,6 +286,8 @@ func TestUnitResourceWorktypeRead(t *testing.T) {
 			DefaultScript: &platformclientv2.Workitemscriptreference{
 				Id: &wt.defaultScriptId,
 			},
+			ServiceLevelTarget:                &wt.serviceLevelTarget,
+			UnassignedDivisionContactsEnabled: &wt.unassignedDivisionContactsEnabled,
 		}
 
 		apiResponse := &platformclientv2.APIResponse{StatusCode: http.StatusOK}
@@ -318,6 +332,8 @@ func TestUnitResourceWorktypeRead(t *testing.T) {
 	assert.Equal(t, wt.schemaVersion, d.Get("schema_version").(int))
 	assert.Equal(t, wt.defaultScriptId, d.Get("default_script_id").(string))
 	assert.Equal(t, wt.disableDefaultStatusCreation, d.Get("disable_default_status_creation").(bool))
+	assert.Equal(t, wt.serviceLevelTarget, d.Get("service_level_target").(int))
+	assert.Equal(t, wt.unassignedDivisionContactsEnabled, d.Get("unassigned_division_contacts_enabled").(bool))
 }
 
 func TestUnitResourceWorktypeUpdate(t *testing.T) {
@@ -345,6 +361,9 @@ func TestUnitResourceWorktypeUpdate(t *testing.T) {
 
 		schemaId:      uuid.NewString(),
 		schemaVersion: 1,
+
+		serviceLevelTarget:                80,
+		unassignedDivisionContactsEnabled: false,
 	}
 
 	taskProxy := &TaskManagementWorktypeProxy{}
@@ -385,6 +404,8 @@ func TestUnitResourceWorktypeUpdate(t *testing.T) {
 			DefaultScript: &platformclientv2.Workitemscriptreference{
 				Id: &wt.defaultScriptId,
 			},
+			ServiceLevelTarget:                &wt.serviceLevelTarget,
+			UnassignedDivisionContactsEnabled: &wt.unassignedDivisionContactsEnabled,
 		}, nil, nil
 	}
 
@@ -429,6 +450,8 @@ func TestUnitResourceWorktypeUpdate(t *testing.T) {
 			DefaultScript: &platformclientv2.Workitemscriptreference{
 				Id: &wt.defaultScriptId,
 			},
+			ServiceLevelTarget:                &wt.serviceLevelTarget,
+			UnassignedDivisionContactsEnabled: &wt.unassignedDivisionContactsEnabled,
 		}
 
 		apiResponse := &platformclientv2.APIResponse{StatusCode: http.StatusOK}
@@ -511,23 +534,25 @@ func TestUnitResourceWorktypeDelete(t *testing.T) {
 
 func buildWorktypeResourceMap(tId string, wt *worktypeConfig) map[string]interface{} {
 	resourceDataMap := map[string]interface{}{
-		"id":                           tId,
-		"name":                         wt.name,
-		"description":                  wt.description,
-		"division_id":                  wt.divisionId,
-		"default_workbin_id":           wt.defaultWorkbinId,
-		"default_duration_seconds":     wt.defaultDurationS,
-		"default_expiration_seconds":   wt.defaultExpirationS,
-		"default_due_duration_seconds": wt.defaultDueDurationS,
-		"default_priority":             wt.defaultPriority,
-		"default_ttl_seconds":          wt.defaultTtlS,
-		"default_language_id":          wt.defaultLanguageId,
-		"default_queue_id":             wt.defaultQueueId,
-		"default_skills_ids":           lists.StringListToInterfaceList(wt.defaultSkillIds),
-		"assignment_enabled":           wt.assignmentEnabled,
-		"schema_id":                    wt.schemaId,
-		"schema_version":               wt.schemaVersion,
-		"default_script_id":            wt.defaultScriptId,
+		"id":                                   tId,
+		"name":                                 wt.name,
+		"description":                          wt.description,
+		"division_id":                          wt.divisionId,
+		"default_workbin_id":                   wt.defaultWorkbinId,
+		"default_duration_seconds":             wt.defaultDurationS,
+		"default_expiration_seconds":           wt.defaultExpirationS,
+		"default_due_duration_seconds":         wt.defaultDueDurationS,
+		"default_priority":                     wt.defaultPriority,
+		"default_ttl_seconds":                  wt.defaultTtlS,
+		"default_language_id":                  wt.defaultLanguageId,
+		"default_queue_id":                     wt.defaultQueueId,
+		"default_skills_ids":                   lists.StringListToInterfaceList(wt.defaultSkillIds),
+		"assignment_enabled":                   wt.assignmentEnabled,
+		"schema_id":                            wt.schemaId,
+		"schema_version":                       wt.schemaVersion,
+		"default_script_id":                    wt.defaultScriptId,
+		"service_level_target":                 wt.serviceLevelTarget,
+		"unassigned_division_contacts_enabled": wt.unassignedDivisionContactsEnabled,
 	}
 
 	resourceDataMap["disable_default_status_creation"] = wt.disableDefaultStatusCreation

--- a/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_utils.go
+++ b/genesyscloud/task_management_worktype/resource_genesyscloud_task_management_worktype_utils.go
@@ -22,19 +22,21 @@ type worktypeConfig struct {
 	divisionId       string
 	defaultWorkbinId string
 
-	defaultDurationS             int
-	defaultExpirationS           int
-	defaultDueDurationS          int
-	defaultPriority              int
-	defaultTtlS                  int
-	defaultLanguageId            string
-	defaultQueueId               string
-	defaultSkillIds              []string
-	assignmentEnabled            bool
-	defaultScriptId              string
-	disableDefaultStatusCreation bool
-	schemaId                     string
-	schemaVersion                int
+	defaultDurationS                  int
+	defaultExpirationS                int
+	defaultDueDurationS               int
+	defaultPriority                   int
+	defaultTtlS                       int
+	defaultLanguageId                 string
+	defaultQueueId                    string
+	defaultSkillIds                   []string
+	assignmentEnabled                 bool
+	defaultScriptId                   string
+	disableDefaultStatusCreation      bool
+	schemaId                          string
+	schemaVersion                     int
+	serviceLevelTarget                int
+	unassignedDivisionContactsEnabled bool
 }
 
 // getWorktypeCreateFromResourceData maps data from schema ResourceData object to a platformclientv2.Worktypecreate
@@ -62,6 +64,8 @@ func getWorktypecreateFromResourceData(d *schema.ResourceData) platformclientv2.
 		RuleSettings: &platformclientv2.Workitemrulesettings{
 			FlowRulesEnabled: resourcedata.GetNillableValue[bool](d, "flow_rules_enabled"),
 		},
+		ServiceLevelTarget:                resourcedata.GetNillableValue[int](d, "service_level_target"),
+		UnassignedDivisionContactsEnabled: resourcedata.GetNillableBool(d, "unassigned_division_contacts_enabled"),
 	}
 
 	return worktype
@@ -130,6 +134,14 @@ func getWorktypeupdateFromResourceData(d *schema.ResourceData) platformclientv2.
 		worktype.SetField("RuleSettings", &platformclientv2.Workitemrulesettings{
 			FlowRulesEnabled: resourcedata.GetNillableValue[bool](d, "flow_rules_enabled"),
 		})
+	}
+
+	if d.HasChange("service_level_target") {
+		worktype.SetField("ServiceLevelTarget", resourcedata.GetNillableValue[int](d, "service_level_target"))
+	}
+
+	if d.HasChange("unassigned_division_contacts_enabled") {
+		worktype.SetField("UnassignedDivisionContactsEnabled", resourcedata.GetNillableBool(d, "unassigned_division_contacts_enabled"))
 	}
 
 	return worktype


### PR DESCRIPTION
**PR Summary** 
https://inindca.atlassian.net/browse/WORKITEMS-8335


Ashford Worktype vs genesyscloud_task_management_worktype comparison found 2 gaps:

**API field -> TF attribute**
serviceLevelTarget -> service_level_target
unassignedDivisionContactsEnabled -> unassigned_division_contacts_enabled

**Tests**
Passing locally against a live org.

<img width="894" height="117" alt="Screenshot 2026-09-04 at 12 44 27" src="https://github.com/user-attachments/assets/52279d0f-c471-46b6-861e-6cdd5055cac9" />
