### PR TITLE
OBR-1671: Fix time-of-day plan drift on outbound_campaignrule

### DIFF
--- a/docs/resources/outbound_campaignrule.md
+++ b/docs/resources/outbound_campaignrule.md
@@ -278,15 +278,15 @@ Required:
 Optional:
 
 - `interval` (Block List, Max: 1) Time interval for "between" operator. (see [below for nested schema](#nestedblock--campaign_rule_conditions--date_time_parameters--time_of_day--interval))
-- `threshold_value` (String) Time in HH:mm:ss.SSS format.
+- `threshold_value` (String) Time in HH:mm:ss format. Fractional seconds are not stored by the API.
 
 <a id="nestedblock--campaign_rule_conditions--date_time_parameters--time_of_day--interval"></a>
 ### Nested Schema for `campaign_rule_conditions.date_time_parameters.time_of_day.interval`
 
 Required:
 
-- `max` (String) Maximum time in HH:mm:ss.SSS format.
-- `min` (String) Minimum time in HH:mm:ss.SSS format.
+- `max` (String) Maximum time in HH:mm:ss format. Fractional seconds are not stored by the API.
+- `min` (String) Minimum time in HH:mm:ss format. Fractional seconds are not stored by the API.
 
 
 
@@ -483,15 +483,15 @@ Required:
 Optional:
 
 - `interval` (Block List, Max: 1) Time interval for "between" operator. (see [below for nested schema](#nestedblock--condition_groups--conditions--date_time_parameters--time_of_day--interval))
-- `threshold_value` (String) Time in HH:mm:ss.SSS format.
+- `threshold_value` (String) Time in HH:mm:ss format. Fractional seconds are not stored by the API.
 
 <a id="nestedblock--condition_groups--conditions--date_time_parameters--time_of_day--interval"></a>
 ### Nested Schema for `condition_groups.conditions.date_time_parameters.time_of_day.interval`
 
 Required:
 
-- `max` (String) Maximum time in HH:mm:ss.SSS format.
-- `min` (String) Minimum time in HH:mm:ss.SSS format.
+- `max` (String) Maximum time in HH:mm:ss format. Fractional seconds are not stored by the API.
+- `min` (String) Minimum time in HH:mm:ss format. Fractional seconds are not stored by the API.
 
 
 

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_schema.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_schema.go
@@ -138,6 +138,52 @@ var validateTimeZoneID = validation.StringMatch(
 	`must be a valid IANA time zone, e.g. "America/New_York", "UTC", or "GMT"`,
 )
 
+// canonicalTimeOfDay rewrites a time-of-day into the HH:mm:ss form the API stores, but only when
+// doing so discards nothing. The API accepts HH:mm, HH:mm:ss or HH:mm:ss.fff and always stores
+// HH:mm:ss, so both "12:00" -> "12:00:00" (seconds implied zero) and "12:00:00.000" -> "12:00:00"
+// (zero fraction) are lossless. Without this, either spelling sits in the config against the
+// stored value and every plan reports a change that never settles.
+//
+// A non-zero fraction such as "12:00:00.500" is returned unchanged. The API discards sub-second
+// precision, and normalising it here would hide that loss; leaving it makes the plan show the
+// value the operator asked for against the value the API will actually keep.
+//
+// Anything not matching a recognised shape is returned untouched. This runs during plan, so it
+// must never panic and must never invent a value.
+func canonicalTimeOfDay(v string) string {
+	base, fraction, hasFraction := strings.Cut(v, ".")
+	if hasFraction && strings.Trim(fraction, "0") != "" {
+		return v
+	}
+	switch strings.Count(base, ":") {
+	case 1: // HH:mm
+		return base + ":00"
+	case 2: // HH:mm:ss
+		return base
+	default:
+		return v
+	}
+}
+
+// normalizeTimeOfDay adapts canonicalTimeOfDay to schema.SchemaStateFunc, canonicalising a
+// configured value before it is written to state so that the plan shows what the API will hold.
+// The type assertion cannot fail for a TypeString field; the guard is there because a panic
+// during plan would be far worse than an empty string.
+func normalizeTimeOfDay(v interface{}) string {
+	s, ok := v.(string)
+	if !ok {
+		return ""
+	}
+	return canonicalTimeOfDay(s)
+}
+
+// suppressTimeOfDayDiff ignores a difference that is only a matter of spelling, whichever side
+// carries it. Being symmetric keeps the comparison correct whether the API trims the value, as
+// campaign rules do today, or pads it, as the callable timeset API does.
+func suppressTimeOfDayDiff(k, old, new string, d *schema.ResourceData) bool {
+	return canonicalTimeOfDay(old) == canonicalTimeOfDay(new)
+}
+
 var (
 	outboundCampaignRuleWeekDayOfMonth = &schema.Resource{
 		Schema: map[string]*schema.Schema{
@@ -178,9 +224,11 @@ var (
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						`threshold_value`: {
-							Description: `Time in HH:mm:ss.SSS format.`,
-							Optional:    true,
-							Type:        schema.TypeString,
+							Description:      `Time in HH:mm:ss format. Fractional seconds are not stored by the API.`,
+							Optional:         true,
+							Type:             schema.TypeString,
+							StateFunc:        normalizeTimeOfDay,
+							DiffSuppressFunc: suppressTimeOfDayDiff,
 						},
 						`interval`: {
 							Description: `Time interval for "between" operator.`,
@@ -190,14 +238,18 @@ var (
 							Elem: &schema.Resource{
 								Schema: map[string]*schema.Schema{
 									`min`: {
-										Description: `Minimum time in HH:mm:ss.SSS format.`,
-										Required:    true,
-										Type:        schema.TypeString,
+										Description:      `Minimum time in HH:mm:ss format. Fractional seconds are not stored by the API.`,
+										Required:         true,
+										Type:             schema.TypeString,
+										StateFunc:        normalizeTimeOfDay,
+										DiffSuppressFunc: suppressTimeOfDayDiff,
 									},
 									`max`: {
-										Description: `Maximum time in HH:mm:ss.SSS format.`,
-										Required:    true,
-										Type:        schema.TypeString,
+										Description:      `Maximum time in HH:mm:ss format. Fractional seconds are not stored by the API.`,
+										Required:         true,
+										Type:             schema.TypeString,
+										StateFunc:        normalizeTimeOfDay,
+										DiffSuppressFunc: suppressTimeOfDayDiff,
 									},
 								},
 							},

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
@@ -365,3 +365,174 @@ func generateActionEntities(entities *platformclientv2.Campaignruleactionentitie
 
 	return []interface{}{entitiesMap}
 }
+
+// TestUnitCanonicalTimeOfDay covers the normalisation behind the time-of-day drift fix. The
+// campaign rules API accepts HH:mm, HH:mm:ss and HH:mm:ss.fff but always stores HH:mm:ss, so any
+// other spelling left in a config sits against the stored value and every plan reports a change
+// that never settles. Rewrites that discard nothing are normalised; a non-zero fraction is left
+// alone so that the loss the API inflicts stays visible to the operator.
+func TestUnitCanonicalTimeOfDay(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"already canonical", "12:00:00", "12:00:00"},
+		{"zero milliseconds", "12:00:00.000", "12:00:00"},
+		{"single zero fraction digit", "12:00:00.0", "12:00:00"},
+		{"two zero fraction digits", "12:00:00.00", "12:00:00"},
+		{"trailing dot with no digits", "12:00:00.", "12:00:00"},
+		{"hours and minutes only", "12:00", "12:00:00"},
+		{"hours and minutes with zero fraction", "12:00.000", "12:00:00"},
+		{"midnight without seconds", "00:00", "00:00:00"},
+		{"non-zero fraction is preserved", "12:00:00.500", "12:00:00.500"},
+		{"small non-zero fraction is preserved", "12:00:00.010", "12:00:00.010"},
+		{"long non-zero fraction is preserved", "12:00:00.123456", "12:00:00.123456"},
+		{"empty string", "", ""},
+		{"unrecognised text", "not-a-time", "not-a-time"},
+		{"too many colons", "12:00:00:00", "12:00:00:00"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, canonicalTimeOfDay(tt.input))
+		})
+	}
+}
+
+// TestUnitNormalizeTimeOfDay covers the schema.SchemaStateFunc adapter. StateFunc runs during
+// plan, so the non-string guard matters more than the value it returns.
+func TestUnitNormalizeTimeOfDay(t *testing.T) {
+	t.Parallel()
+
+	t.Run("drops a zero fraction", func(t *testing.T) {
+		assert.Equal(t, "12:00:00", normalizeTimeOfDay("12:00:00.000"))
+	})
+
+	t.Run("pads a value with no seconds", func(t *testing.T) {
+		assert.Equal(t, "09:30:00", normalizeTimeOfDay("09:30"))
+	})
+
+	t.Run("preserves a non-zero fraction", func(t *testing.T) {
+		assert.Equal(t, "12:00:00.500", normalizeTimeOfDay("12:00:00.500"))
+	})
+
+	t.Run("returns empty for a non-string without panicking", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			assert.Equal(t, "", normalizeTimeOfDay(42))
+		})
+	})
+
+	t.Run("returns empty for nil without panicking", func(t *testing.T) {
+		assert.NotPanics(t, func() {
+			assert.Equal(t, "", normalizeTimeOfDay(nil))
+		})
+	})
+}
+
+// TestUnitSuppressTimeOfDayDiff covers the diff comparison. It is deliberately symmetric: the
+// campaign rules API trims the fraction, but the sibling callable timeset API appends one, so the
+// comparison has to hold whichever side carries the odd spelling.
+func TestUnitSuppressTimeOfDayDiff(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		old      string
+		new      string
+		suppress bool
+	}{
+		{"config adds zero milliseconds", "12:00:00", "12:00:00.000", true},
+		{"state carries zero milliseconds", "12:00:00.000", "12:00:00", true},
+		{"config omits seconds", "12:00:00", "12:00", true},
+		{"state omits seconds", "12:00", "12:00:00", true},
+		{"identical values", "12:00:00", "12:00:00", true},
+		{"both empty", "", "", true},
+		{"non-zero fraction stays visible", "12:00:00", "12:00:00.500", false},
+		{"a real change stays visible", "12:00:00", "13:00:00", false},
+		{"a real change carrying fractions stays visible", "12:00:00.000", "13:00:00.000", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.suppress, suppressTimeOfDayDiff("", tt.old, tt.new, nil))
+		})
+	}
+}
+
+// nestedSchema walks a path of attribute names down through nested block schemas, descending into
+// each Elem along the way, and returns the leaf schema.
+func nestedSchema(t *testing.T, root map[string]*schema.Schema, path ...string) *schema.Schema {
+	t.Helper()
+
+	current := root
+	for i, name := range path {
+		s, ok := current[name]
+		if !ok {
+			t.Fatalf("attribute %q not found at position %d of %v", name, i, path)
+		}
+		if i == len(path)-1 {
+			return s
+		}
+		res, ok := s.Elem.(*schema.Resource)
+		if !ok {
+			t.Fatalf("attribute %q at position %d of %v has no nested resource to descend into", name, i, path)
+		}
+		current = res.Schema
+	}
+
+	return nil
+}
+
+// TestUnitTimeOfDayFieldsAreWiredForDrift is the guard that keeps the drift fix in place. The
+// helper tests above pass whether or not the schema actually references those helpers, so without
+// this a later edit could quietly drop StateFunc or DiffSuppressFunc from a field and reintroduce
+// the drift. Asserting through the retrieved hooks catches a wrong function as well as a missing
+// one. Passing nil for *schema.ResourceData is safe because suppressTimeOfDayDiff ignores it.
+func TestUnitTimeOfDayFieldsAreWiredForDrift(t *testing.T) {
+	t.Parallel()
+
+	root := ResourceOutboundCampaignrule().Schema
+
+	fields := []struct {
+		name string
+		path []string
+	}{
+		{
+			name: "time_of_day.threshold_value",
+			path: []string{"condition_groups", "conditions", "date_time_parameters", "time_of_day", "threshold_value"},
+		},
+		{
+			name: "time_of_day.interval.min",
+			path: []string{"condition_groups", "conditions", "date_time_parameters", "time_of_day", "interval", "min"},
+		},
+		{
+			name: "time_of_day.interval.max",
+			path: []string{"condition_groups", "conditions", "date_time_parameters", "time_of_day", "interval", "max"},
+		},
+	}
+
+	for _, field := range fields {
+		t.Run(field.name, func(t *testing.T) {
+			leaf := nestedSchema(t, root, field.path...)
+
+			if !assert.NotNil(t, leaf.StateFunc, "StateFunc is not wired; time-of-day values will drift again") {
+				return
+			}
+			if !assert.NotNil(t, leaf.DiffSuppressFunc, "DiffSuppressFunc is not wired; time-of-day values will drift again") {
+				return
+			}
+
+			assert.Equal(t, "12:00:00", leaf.StateFunc("12:00:00.000"), "a zero fraction should be dropped before reaching state")
+			assert.Equal(t, "12:00:00", leaf.StateFunc("12:00"), "missing seconds should be padded before reaching state")
+			assert.Equal(t, "12:00:00.500", leaf.StateFunc("12:00:00.500"), "a real fraction should survive into state so the loss is visible")
+
+			assert.True(t, leaf.DiffSuppressFunc("", "12:00:00", "12:00:00.000", nil), "a zero fraction should be suppressed")
+			assert.True(t, leaf.DiffSuppressFunc("", "12:00:00", "12:00", nil), "a missing seconds part should be suppressed")
+			assert.False(t, leaf.DiffSuppressFunc("", "12:00:00", "12:00:00.500", nil), "a real fraction should stay visible")
+			assert.False(t, leaf.DiffSuppressFunc("", "12:00:00", "13:00:00", nil), "a real change should stay visible")
+		})
+	}
+}


### PR DESCRIPTION
Fixes plan drift on `genesyscloud_outbound_campaignrule` time-of-day conditions.

The API stores `time_of_day` values as `HH:mm:ss` and rewrites anything else, so a config written as `12:00:00.000` (the format the descriptions recommended) or `12:00` never matches state and every plan reports a change that never settles.

## Changes

- **Schema:** corrected `threshold_value`, `interval.min` and `interval.max` descriptions from `HH:mm:ss.SSS` to `HH:mm:ss`
- **Normalisation:** added `canonicalTimeOfDay`, which rewrites a value to `HH:mm:ss` only when that discards nothing (`12:00`, `12:00:00.000`); a non-zero fraction such as `12:00:00.500` is deliberately left visible, since the API drops it
- **Wiring:** `StateFunc` on all three fields so the create-time plan shows the value the API will hold, plus `DiffSuppressFunc` so the comparison holds whichever side carries the odd spelling
- **Unit tests:** coverage for the helpers, plus `TestUnitTimeOfDayFieldsAreWiredForDrift`, which walks the real schema and asserts both hooks stay wired on all three fields
- **Docs:** auto-generated