### PR TITLE
OBR-1683: Add for_duration to campaign rule conditions

### DIFF
--- a/docs/resources/outbound_campaignrule.md
+++ b/docs/resources/outbound_campaignrule.md
@@ -176,6 +176,7 @@ Optional:
 - `dialing_mode` (String) The dialing mode to set a campaign to. Required for the 'setCampaignDialingMode' action (agentless | preview | power | predictive | progressive | external).
 - `email_content_template_id` (String) The content template to set an Email campaign to.
 - `email_messages_per_minute` (String) The number of messages per minute to set an Email messaging campaign to.
+- `for_duration` (Block List, Max: 1) Duration for which the condition must be continuously true before it is evaluated as true. Only valid in condition parameters with campaign_rule_processing = "v2". (see [below for nested schema](#nestedblock--campaign_rule_conditions--parameters--for_duration))
 - `max_calls_per_agent` (String) Max calls per agent. Optional parameter for 'setCampaignMaxCallsPerAgent' action
 - `messages_per_minute` (String) The number of messages per minute to set a messaging campaign to.
 - `operator` (String) The operator for comparison. Required for a CampaignRuleCondition. Valid values: equals, greaterThan, greaterThanEqualTo, lessThan, lessThanEqualTo, before, after, between, in.
@@ -186,6 +187,14 @@ Optional:
 - `sms_content_template_id` (String) The content template to set a SMS campaign to.
 - `sms_messages_per_minute` (String) The number of messages per minute to set a SMS messaging campaign to.
 - `value` (String) The value for comparison. Required for a CampaignRuleCondition.
+
+<a id="nestedblock--campaign_rule_conditions--parameters--for_duration"></a>
+### Nested Schema for `campaign_rule_conditions.parameters.for_duration`
+
+Required:
+
+- `seconds` (Number) Duration in whole seconds. Sub-second precision is not supported: a duration set outside Terraform with a fractional value is read as whole seconds.
+
 
 
 <a id="nestedblock--campaign_rule_conditions--campaign_run_time_settings"></a>
@@ -381,6 +390,7 @@ Optional:
 - `dialing_mode` (String) The dialing mode to set a campaign to. Required for the 'setCampaignDialingMode' action (agentless | preview | power | predictive | progressive | external).
 - `email_content_template_id` (String) The content template to set an Email campaign to.
 - `email_messages_per_minute` (String) The number of messages per minute to set an Email messaging campaign to.
+- `for_duration` (Block List, Max: 1) Duration for which the condition must be continuously true before it is evaluated as true. Only valid in condition parameters with campaign_rule_processing = "v2". (see [below for nested schema](#nestedblock--condition_groups--conditions--parameters--for_duration))
 - `max_calls_per_agent` (String) Max calls per agent. Optional parameter for 'setCampaignMaxCallsPerAgent' action
 - `messages_per_minute` (String) The number of messages per minute to set a messaging campaign to.
 - `operator` (String) The operator for comparison. Required for a CampaignRuleCondition. Valid values: equals, greaterThan, greaterThanEqualTo, lessThan, lessThanEqualTo, before, after, between, in.
@@ -391,6 +401,14 @@ Optional:
 - `sms_content_template_id` (String) The content template to set a SMS campaign to.
 - `sms_messages_per_minute` (String) The number of messages per minute to set a SMS messaging campaign to.
 - `value` (String) The value for comparison. Required for a CampaignRuleCondition.
+
+<a id="nestedblock--condition_groups--conditions--parameters--for_duration"></a>
+### Nested Schema for `condition_groups.conditions.parameters.for_duration`
+
+Required:
+
+- `seconds` (Number) Duration in whole seconds. Sub-second precision is not supported: a duration set outside Terraform with a fractional value is read as whole seconds.
+
 
 
 <a id="nestedblock--condition_groups--conditions--campaign_run_time_settings"></a>

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_schema.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_schema.go
@@ -431,8 +431,6 @@ func validateCampaignRuleConditions(ctx context.Context, d *schema.ResourceDiff,
 		}
 	}
 
-	// for_duration validation is FROZEN pending DEVTOOLING-1759 (field disabled in schema).
-
 	return nil
 }
 
@@ -478,28 +476,24 @@ func validateNoTimeBasedConditionsInLegacy(conditions []interface{}) error {
 			return fmt.Errorf("campaign_wait_time_settings requires campaign_rule_processing = \"v2\" with condition_groups; it cannot be used in legacy campaign_rule_conditions")
 		}
 
-		// FROZEN pending DEVTOOLING-1759: for_duration is disabled in the schema, so this
-		// legacy-reject is moot. Re-enable together with the for_duration field.
-		/*
-			// Reject for_duration in legacy condition parameters
-			paramsRaw := condMap["parameters"]
-			var paramsMap map[string]interface{}
-			switch p := paramsRaw.(type) {
-			case *schema.Set:
-				if p != nil && p.Len() > 0 {
-					paramsMap, _ = p.List()[0].(map[string]interface{})
-				}
-			case []interface{}:
-				if len(p) > 0 && p[0] != nil {
-					paramsMap, _ = p[0].(map[string]interface{})
-				}
+		// Reject for_duration in legacy condition parameters
+		paramsRaw := condMap["parameters"]
+		var paramsMap map[string]interface{}
+		switch p := paramsRaw.(type) {
+		case *schema.Set:
+			if p != nil && p.Len() > 0 {
+				paramsMap, _ = p.List()[0].(map[string]interface{})
 			}
-			if paramsMap != nil {
-				if v, ok := paramsMap["for_duration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-					return fmt.Errorf("for_duration requires campaign_rule_processing = \"v2\" with condition_groups; it cannot be used in legacy campaign_rule_conditions")
-				}
+		case []interface{}:
+			if len(p) > 0 && p[0] != nil {
+				paramsMap, _ = p[0].(map[string]interface{})
 			}
-		*/
+		}
+		if paramsMap != nil {
+			if v, ok := paramsMap["for_duration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+				return fmt.Errorf("for_duration requires campaign_rule_processing = \"v2\" with condition_groups; it cannot be used in legacy campaign_rule_conditions")
+			}
+		}
 	}
 	return nil
 }
@@ -735,9 +729,7 @@ func validateOperatorFields(condMap map[string]interface{}, condType string, dat
 
 // paramSchemaOptions controls which fields are included in the campaign rule parameter schema.
 type paramSchemaOptions struct {
-	// FROZEN pending DEVTOOLING-1759: Go SDK serializes Duration as an object (causes 400).
-	// Re-enable for_duration when the SDK is fixed.
-	// includeForDuration       bool
+	includeForDuration       bool
 	includeDateTimeOperators bool
 }
 
@@ -879,28 +871,24 @@ func campaignRuleParameterSchema(opts paramSchemaOptions) map[string]*schema.Sch
 		},
 	}
 
-	// FROZEN pending DEVTOOLING-1759 (Go SDK serializes Duration as an object, causing 400).
-	// Re-enable this block when the SDK is fixed.
-	/*
-		if opts.includeForDuration {
-			params[`for_duration`] = &schema.Schema{
-				Description: `Duration (in seconds) for which the condition must be continuously true before it is evaluated as true. Only valid in condition parameters with campaign_rule_processing = "v2".`,
-				Optional:    true,
-				MaxItems:    1,
-				Type:        schema.TypeList,
-				Elem: &schema.Resource{
-					Schema: map[string]*schema.Schema{
-						`seconds`: {
-							Description:  `Duration in seconds.`,
-							Required:     true,
-							Type:         schema.TypeInt,
-							ValidateFunc: validation.IntAtLeast(1),
-						},
+	if opts.includeForDuration {
+		params[`for_duration`] = &schema.Schema{
+			Description: `Duration for which the condition must be continuously true before it is evaluated as true. Only valid in condition parameters with campaign_rule_processing = "v2".`,
+			Optional:    true,
+			MaxItems:    1,
+			Type:        schema.TypeList,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					`seconds`: {
+						Description:  `Duration in whole seconds. Sub-second precision is not supported: a duration set outside Terraform with a fractional value is read as whole seconds.`,
+						Required:     true,
+						Type:         schema.TypeInt,
+						ValidateFunc: validation.IntAtLeast(1),
 					},
 				},
-			}
+			},
 		}
-	*/
+	}
 
 	return params
 }
@@ -908,8 +896,7 @@ func campaignRuleParameterSchema(opts paramSchemaOptions) map[string]*schema.Sch
 // ResourceOutboundCampaignrule registers the genesyscloud_outbound_campaignrule resource with Terraform
 func ResourceOutboundCampaignrule() *schema.Resource {
 	campaignRuleParameters := &schema.Resource{
-		// FROZEN pending DEVTOOLING-1759: includeForDuration omitted (was true).
-		Schema: campaignRuleParameterSchema(paramSchemaOptions{includeDateTimeOperators: true}),
+		Schema: campaignRuleParameterSchema(paramSchemaOptions{includeForDuration: true, includeDateTimeOperators: true}),
 	}
 
 	// Action parameters: no for_duration, no date/time operators

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_test.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_test.go
@@ -1469,9 +1469,6 @@ func TestAccResourceOutboundCampaignRuleWeekDayOfMonth(t *testing.T) {
 	})
 }
 
-// FROZEN pending DEVTOOLING-1759 (Go SDK serializes Duration as an object, causing 400).
-// Re-enable this end-to-end for_duration test when the SDK is fixed.
-/*
 // TestAccResourceOutboundCampaignRuleForDuration covers the for_duration parameter working
 // end-to-end ("campaignAgents < 2 for 900s"). A duration-based condition is self-triggering, so it
 // may stand alone without a separate campaign trigger condition.
@@ -1550,7 +1547,6 @@ func TestAccResourceOutboundCampaignRuleForDuration(t *testing.T) {
 		CheckDestroy: testVerifyCampaignRuleDestroyed,
 	})
 }
-*/
 
 func TestAccResourceOutboundCampaignRuleLegacyRejectsDateTimeParams(t *testing.T) {
 	t.Parallel()
@@ -1594,10 +1590,6 @@ resource "genesyscloud_outbound_campaignrule" "test" {
 	})
 }
 
-// FROZEN pending DEVTOOLING-1759: for_duration is disabled in the schema, so these
-// rejection tests are moot (Terraform now errors with "Unsupported argument" on its own).
-// Re-enable together with the for_duration field.
-/*
 // for_duration is nested inside parameters TypeSet and is not reliably visible
 // to CustomizeDiff, so this is validated before the API call in Create/Update.
 // Therefore this test does NOT use PlanOnly: true.
@@ -1682,7 +1674,6 @@ resource "genesyscloud_outbound_campaignrule" "test" {
 		},
 	})
 }
-*/
 
 func TestAccResourceOutboundCampaignRuleRejectsBetweenWithInSet(t *testing.T) {
 	t.Parallel()
@@ -2405,8 +2396,6 @@ func generateDateTimeParameters(inverted bool, innerBlock string) string {
 `, inverted, innerBlock)
 }
 
-// FROZEN pending DEVTOOLING-1759: re-enable together with the for_duration test.
-/*
 // generateForDurationParameters builds a parameters block with a for_duration sub-block, used by
 // duration-based conditions (e.g. "campaignAgents < 2 for 900s"). Kept separate from
 // generateCampaignRuleParameters because that helper does not model for_duration.
@@ -2421,7 +2410,6 @@ func generateForDurationParameters(operator, value string, seconds int) string {
 		}
 `, operator, value, seconds)
 }
-*/
 
 // generateConditionGroup generates a condition_groups block (v2 processing).
 func generateConditionGroup(matchAnyConditions bool, conditionBlocks ...string) string {

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_unit_test.go
@@ -365,3 +365,126 @@ func generateActionEntities(entities *platformclientv2.Campaignruleactionentitie
 
 	return []interface{}{entitiesMap}
 }
+
+// TestUnitSecondsToISO8601Duration covers the write side of for_duration. The API accepts a plain
+// seconds duration and canonicalises it itself, so the provider only ever needs the PT<n>S form.
+func TestUnitSecondsToISO8601Duration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		seconds  int
+		expected string
+	}{
+		{"fifteen minutes as seconds", 900, "PT900S"},
+		{"one second", 1, "PT1S"},
+		{"an hour", 3600, "PT3600S"},
+		{"more than a day", 90000, "PT90000S"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, secondsToISO8601Duration(tt.seconds))
+		})
+	}
+}
+
+// TestUnitParseISO8601DurationSeconds pins the parser to the forms the API was observed to return,
+// rather than to a reading of the ISO-8601 spec. Every "ok" case below was produced by the live API
+// during the OBR-1683 probe: it canonicalises whatever it is given into Java's Duration.toString()
+// form, rolling days into hours, so PT90000S comes back as PT25H and no day component ever appears.
+func TestUnitParseISO8601DurationSeconds(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		seconds int
+		exact   bool
+		ok      bool
+	}{
+		// Forms the API returned during the probe.
+		{"minutes only", "PT15M", 900, true, true},
+		{"seconds only", "PT900S", 900, true, true},
+		{"hours and minutes", "PT2H10M", 7800, true, true},
+		{"hours beyond a day", "PT25H", 90000, true, true},
+		{"all three components", "PT1H1M1S", 3661, true, true},
+		{"zero", "PT0S", 0, true, true},
+
+		// Fractional seconds are accepted and preserved by the API but cannot be represented.
+		{"fractional seconds lose precision", "PT1.5S", 1, false, true},
+		{"fraction below a second", "PT0.5S", 0, false, true},
+		{"zero fraction loses nothing", "PT1.0S", 1, true, true},
+		{"fraction alongside other components", "PT1M0.250S", 60, false, true},
+
+		// Rejected: the API refuses these too, or would never emit them.
+		{"negative", "PT-5S", 0, false, false},
+		{"bare designator", "PT", 0, false, false},
+		{"day component", "P1D", 0, false, false},
+		{"day and time components", "P1DT2H", 0, false, false},
+		{"not a duration", "15m", 0, false, false},
+		{"unknown unit", "PT1X", 0, false, false},
+		{"empty", "", 0, false, false},
+		{"components out of order", "PT1M1H", 0, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			seconds, exact, ok := parseISO8601DurationSeconds(tt.input)
+			assert.Equal(t, tt.ok, ok, "ok")
+			if !tt.ok {
+				return
+			}
+			assert.Equal(t, tt.seconds, seconds, "seconds")
+			assert.Equal(t, tt.exact, exact, "exact")
+		})
+	}
+}
+
+// TestUnitForDurationRoundTrip is the property the seconds-block schema depends on: whatever the
+// API does to the value in between, writing seconds and reading them back returns the same number.
+// This is what makes a seconds block immune to the canonicalisation drift that a raw ISO-8601
+// string field would suffer.
+func TestUnitForDurationRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	for _, seconds := range []int{1, 30, 90, 900, 3600, 3661, 7800, 90000} {
+		t.Run(fmt.Sprintf("%d seconds", seconds), func(t *testing.T) {
+			parsed, exact, ok := parseISO8601DurationSeconds(secondsToISO8601Duration(seconds))
+			assert.True(t, ok, "the value we generate must parse back")
+			assert.True(t, exact, "whole seconds must round-trip without loss")
+			assert.Equal(t, seconds, parsed)
+		})
+	}
+}
+
+// TestUnitFlattenForDuration covers the read path, including the two cases that must not fail the
+// read: a value the parser does not recognise, and one carrying precision the schema cannot hold.
+// Failing either would break terraform import and tf export against a rule created elsewhere.
+func TestUnitFlattenForDuration(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil gives no block", func(t *testing.T) {
+		assert.Nil(t, flattenForDuration(nil))
+	})
+
+	t.Run("empty string gives no block", func(t *testing.T) {
+		assert.Nil(t, flattenForDuration(platformclientv2.String("")))
+	})
+
+	t.Run("canonicalised value parses back to the configured seconds", func(t *testing.T) {
+		assert.Equal(t,
+			[]interface{}{map[string]interface{}{"seconds": 900}},
+			flattenForDuration(platformclientv2.String("PT15M")))
+	})
+
+	t.Run("sub-second precision is truncated rather than dropped", func(t *testing.T) {
+		assert.Equal(t,
+			[]interface{}{map[string]interface{}{"seconds": 1}},
+			flattenForDuration(platformclientv2.String("PT1.5S")))
+	})
+
+	t.Run("unparseable value gives no block rather than zero seconds", func(t *testing.T) {
+		assert.Nil(t, flattenForDuration(platformclientv2.String("garbage")))
+	})
+}

--- a/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_utils.go
+++ b/genesyscloud/outbound_campaignrule/resource_genesyscloud_outbound_campaignrule_utils.go
@@ -2,7 +2,10 @@ package outbound_campaignrule
 
 import (
 	"fmt"
+	"log"
+	"regexp"
 	"strconv"
+	"strings"
 
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util"
 	"github.com/mypurecloud/terraform-provider-genesyscloud/genesyscloud/util/resourcedata"
@@ -63,17 +66,14 @@ func validateNoTimeBasedConditionsInLegacyFromResourceData(conditions []interfac
 			return fmt.Errorf("campaign_rule_conditions[%d]: campaign_wait_time_settings is only valid with campaign_rule_processing = \"v2\" and condition_groups", i)
 		}
 
-		// FROZEN pending DEVTOOLING-1759: for_duration disabled in schema, so this check is moot.
-		/*
-			// Check for_duration in parameters
-			params := condMap["parameters"].(*schema.Set)
-			if params != nil && params.Len() > 0 {
-				paramsMap := params.List()[0].(map[string]interface{})
+		// Check for_duration in parameters
+		if params, ok := condMap["parameters"].(*schema.Set); ok && params != nil && params.Len() > 0 {
+			if paramsMap, ok := params.List()[0].(map[string]interface{}); ok {
 				if v, ok := paramsMap["for_duration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
 					return fmt.Errorf("campaign_rule_conditions[%d]: for_duration is only valid with campaign_rule_processing = \"v2\" and condition_groups", i)
 				}
 			}
-		*/
+		}
 	}
 	return nil
 }
@@ -280,17 +280,11 @@ func buildCampaignRuleParameters(set *schema.Set) *platformclientv2.Campaignrule
 	sdkCampaignRuleParameters.EmailContentTemplate = util.GetNillableDomainEntityRefFromMap(paramsMap, "email_content_template_id")
 	sdkCampaignRuleParameters.SmsContentTemplate = util.GetNillableDomainEntityRefFromMap(paramsMap, "sms_content_template_id")
 
-	// FROZEN pending DEVTOOLING-1759 (Go SDK serializes Duration as an object, causing 400).
-	// Re-enable this block when the SDK is fixed.
-	/*
-		if v, ok := paramsMap["for_duration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
-			durationMap := v[0].(map[string]interface{})
-			seconds := durationMap["seconds"].(int)
-			sdkCampaignRuleParameters.ForDuration = &platformclientv2.Duration{
-				Seconds: &seconds,
-			}
-		}
-	*/
+	if v, ok := paramsMap["for_duration"].([]interface{}); ok && len(v) > 0 && v[0] != nil {
+		durationMap := v[0].(map[string]interface{})
+		seconds := durationMap["seconds"].(int)
+		sdkCampaignRuleParameters.ForDuration = platformclientv2.String(secondsToISO8601Duration(seconds))
+	}
 
 	return &sdkCampaignRuleParameters
 }
@@ -538,12 +532,9 @@ func flattenRuleParameters(params *platformclientv2.Campaignruleparameters) []in
 		paramsMap["email_messages_per_minute"] = strconv.Itoa(*params.EmailMessagesPerMinute)
 	}
 
-	// FROZEN pending DEVTOOLING-1759: re-enable together with the for_duration field.
-	/*
-		if params.ForDuration != nil {
-			paramsMap["for_duration"] = flattenForDuration(params.ForDuration)
-		}
-	*/
+	if params.ForDuration != nil {
+		paramsMap["for_duration"] = flattenForDuration(params.ForDuration)
+	}
 
 	return []interface{}{paramsMap}
 }
@@ -756,19 +747,92 @@ func flattenWeekDayOfMonth(sdk *platformclientv2.Campaignruleweekdayofmonth) map
 	return m
 }
 
-// FROZEN pending DEVTOOLING-1759: re-enable together with the for_duration field.
-/*
-func flattenForDuration(sdk *platformclientv2.Duration) []interface{} {
-	if sdk == nil {
+// iso8601DurationPattern matches the duration form the campaign rules API emits, which is Java's
+// Duration.toString(): PT followed by any of an hours, minutes and seconds component, the seconds
+// optionally fractional.
+//
+// There is deliberately no day component. The API rolls days into hours — PT90000S is returned as
+// PT25H — so hours are unbounded and P1DT... never appears.
+var iso8601DurationPattern = regexp.MustCompile(`^PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+(?:\.\d+)?)S)?$`)
+
+// secondsToISO8601Duration renders whole seconds in the ISO-8601 form the API accepts. The API
+// canonicalises what it receives, so PT900S comes back as PT15M, but the rewrite is lossless and
+// parseISO8601DurationSeconds recovers the same number.
+func secondsToISO8601Duration(seconds int) string {
+	return fmt.Sprintf("PT%dS", seconds)
+}
+
+// parseISO8601DurationSeconds converts a duration returned by the API into whole seconds.
+//
+// exact reports whether the value survived the conversion: it is false when a non-zero fractional
+// seconds part had to be dropped, which the schema's integer seconds cannot represent.
+// ok reports whether the value matched the grammar at all; when it does not, the caller should
+// leave the field out of state rather than invent a number.
+func parseISO8601DurationSeconds(v string) (seconds int, exact bool, ok bool) {
+	groups := iso8601DurationPattern.FindStringSubmatch(v)
+	if groups == nil {
+		return 0, false, false
+	}
+
+	hours, minutes, secs := groups[1], groups[2], groups[3]
+	if hours == "" && minutes == "" && secs == "" {
+		// A bare "PT" matches the pattern but carries no duration.
+		return 0, false, false
+	}
+
+	total := 0
+	if hours != "" {
+		parsed, err := strconv.Atoi(hours)
+		if err != nil {
+			return 0, false, false
+		}
+		total += parsed * 3600
+	}
+	if minutes != "" {
+		parsed, err := strconv.Atoi(minutes)
+		if err != nil {
+			return 0, false, false
+		}
+		total += parsed * 60
+	}
+
+	exact = true
+	if secs != "" {
+		whole, fraction, hasFraction := strings.Cut(secs, ".")
+		parsed, err := strconv.Atoi(whole)
+		if err != nil {
+			return 0, false, false
+		}
+		total += parsed
+		if hasFraction && strings.Trim(fraction, "0") != "" {
+			exact = false
+		}
+	}
+
+	return total, exact, true
+}
+
+// flattenForDuration converts the API's ISO-8601 duration into the for_duration block.
+//
+// Neither failure mode returns an error: a read that failed would break terraform import and
+// tf export against a rule someone else created through the GUI or the API. Both are logged
+// instead, so an unexpected value is visible without being fatal.
+func flattenForDuration(iso *string) []interface{} {
+	if iso == nil || *iso == "" {
 		return nil
 	}
-	m := make(map[string]interface{})
-	if sdk.Seconds != nil {
-		m["seconds"] = *sdk.Seconds
+
+	seconds, exact, ok := parseISO8601DurationSeconds(*iso)
+	if !ok {
+		log.Printf("[WARN] outbound_campaignrule: could not parse forDuration %q as an ISO-8601 duration; leaving for_duration unset in state", *iso)
+		return nil
 	}
-	return []interface{}{m}
+	if !exact {
+		log.Printf("[WARN] outbound_campaignrule: forDuration %q carries sub-second precision, which for_duration.seconds cannot represent; state will hold %d seconds and a later apply would overwrite the value held by the API", *iso, seconds)
+	}
+
+	return []interface{}{map[string]interface{}{"seconds": seconds}}
 }
-*/
 
 func nilToEmpty(s *string) string {
 	if s == nil {


### PR DESCRIPTION
Adds `for_duration` to condition parameters in `genesyscloud_outbound_campaignrule`. It sets how long a condition must stay continuously true before it evaluates as true.

Split out of OBR-723: the rest of that scope shipped in v1.86.0, but this field was held back because the Go SDK serialised `Duration` as a JSON object while the API expects an ISO-8601 string, producing a 400 ([DEVTOOLING-1759](https://inindca.atlassian.net/browse/DEVTOOLING-1759), now resolved). SDK v195, which the provider already uses, exposes the field as `ForDuration *string`.

## Changes

- **Schema:** added `for_duration { seconds = N }` to condition parameters only, `IntAtLeast(1)` so the zero the API would otherwise accept is rejected client-side
- **Write:** `secondsToISO8601Duration` renders whole seconds as `PT<n>S`
- **Read:** `parseISO8601DurationSeconds` parses the `PT[nH][nM][nS]` form the API returns. The API canonicalises what it receives — `PT900S` comes back as `PT15M` — so a raw ISO-8601 string field would diff on every plan; a seconds block round-trips instead
- **Sub-second durations:** the API accepts and preserves `PT1.5S`, which an integer schema cannot represent. Read truncates to whole seconds and logs, rather than failing the read and breaking `terraform import` or `tf export` against a rule created elsewhere
- **Validation:** `for_duration` is rejected in legacy `campaign_rule_conditions`, at plan time and again before the API call
- **Unit tests:** formatter, parser and flatten, plus a round-trip property test. Parser cases are the forms the live API actually returned, not a reading of the ISO-8601 spec
- **Acceptance tests:** the previously disabled `TestAccResourceOutboundCampaignRuleForDuration` and the two rejection tests are re-enabled and pass. Its `ImportStateVerify` step is what confirms the write/canonicalise/read round trip end to end
- **Docs:** auto-generated


[DEVTOOLING-1759]: https://inindca.atlassian.net/browse/DEVTOOLING-1759?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ