### PR TITLE
MRMO-615 Failure refactor

### DIFF
--- a/genesyscloud/architect_flow/resource_genesyscloud_flow.go
+++ b/genesyscloud/architect_flow/resource_genesyscloud_flow.go
@@ -209,7 +209,13 @@ func updateFlow(ctx context.Context, d *schema.ResourceData, meta any) (diags di
 		if flowJob.Status != nil && *flowJob.Status == "Failure" {
 			log.Printf("Failed to Get flow %s, %s, %s", flowName, d.Id(), jobId)
 			if flowJob.Messages == nil {
-				return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("flow publish failed. JobID: %s, flowName: %s,  no tracing messages available", jobId, flowName), response))
+				return retry.NonRetryableError(util.BuildCodedWithRetriesApiDiagnosticError(
+					ResourceType,
+					util.DiagnosticCodeFlowPublishFailed,
+					fmt.Sprintf("flow publish failed. JobID: %s, flowName: %s,  no tracing messages available", jobId, flowName),
+					jobId,
+					response,
+				))
 			}
 			messages := make([]string, 0)
 			for _, m := range *flowJob.Messages {
@@ -220,7 +226,13 @@ func updateFlow(ctx context.Context, d *schema.ResourceData, meta any) (diags di
 					log.Printf("API Message for flow %s, jobId %s: <nil message>", flowName, jobId)
 				}
 			}
-			return retry.NonRetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("flow publish failed. JobID: %s, flowName: %s, tracing messages: %v ", jobId, flowName, strings.Join(messages, "\n\n")), response))
+			return retry.NonRetryableError(util.BuildCodedWithRetriesApiDiagnosticError(
+				ResourceType,
+				util.DiagnosticCodeFlowPublishFailed,
+				fmt.Sprintf("flow publish failed. JobID: %s, flowName: %s, tracing messages: %v ", jobId, flowName, strings.Join(messages, "\n\n")),
+				jobId,
+				response,
+			))
 		}
 
 		if flowJob.Status != nil && *flowJob.Status == "Success" {
@@ -235,7 +247,13 @@ func updateFlow(ctx context.Context, d *schema.ResourceData, meta any) (diags di
 		}
 
 		time.Sleep(15 * time.Second) // Wait 15 seconds for next retry
-		return retry.RetryableError(util.BuildWithRetriesApiDiagnosticError(ResourceType, fmt.Sprintf("Job (%s) could not finish in 16 minutes and timed out ", jobId), response))
+		return retry.RetryableError(util.BuildCodedWithRetriesApiDiagnosticError(
+			ResourceType,
+			util.DiagnosticCodeFlowPublishTimeout,
+			fmt.Sprintf("Job (%s) could not finish in 16 minutes and timed out ", jobId),
+			jobId,
+			response,
+		))
 	})
 
 	if retryErr != nil {

--- a/genesyscloud/util/util_diagnostic_unit_test.go
+++ b/genesyscloud/util/util_diagnostic_unit_test.go
@@ -142,3 +142,47 @@ func TestUnitTestAPIResponseWithRetriesDiagWithBadApiResponse(t *testing.T) {
 	assert.Equal(t, sumErrMsg, lines[0])
 	assert.Equal(t, targetResponse, lines[1])
 }
+
+func TestUnitTestCodedAPIDiagnosticErrorIncludesCodeAndJobID(t *testing.T) {
+	resourceType := "genesyscloud_flow"
+	sumErrMsg := "flow publish failed. JobID: job-123, flowName: test"
+	jobId := "job-123"
+	apiResponse := &platformclientv2.APIResponse{
+		StatusCode:    http.StatusOK,
+		ErrorMessage:  "",
+		CorrelationID: "corr-1",
+	}
+
+	diags := BuildCodedAPIDiagnosticError(resourceType, DiagnosticCodeFlowPublishFailed, sumErrMsg, jobId, apiResponse)
+	assert.Len(t, diags, 1)
+	assert.Equal(t, sumErrMsg, diags[0].Summary)
+
+	actual := &detailedDiagnosticInfo{}
+	err := json.Unmarshal([]byte(diags[0].Detail), actual)
+	assert.NoError(t, err)
+	assert.Equal(t, DiagnosticCodeFlowPublishFailed, actual.Code)
+	assert.Equal(t, jobId, actual.JobID)
+	assert.Equal(t, resourceType, actual.ResourceType)
+}
+
+func TestUnitTestCodedWithRetriesApiDiagnosticErrorIncludesCodeAndJobID(t *testing.T) {
+	resourceType := "genesyscloud_flow"
+	sumErrMsg := "Job (job-456) could not finish in 16 minutes and timed out "
+	jobId := "job-456"
+	apiResponse := &platformclientv2.APIResponse{
+		StatusCode:   http.StatusOK,
+		ErrorMessage: "",
+	}
+
+	err := BuildCodedWithRetriesApiDiagnosticError(resourceType, DiagnosticCodeFlowPublishTimeout, sumErrMsg, jobId, apiResponse)
+	assert.Error(t, err)
+
+	lines := strings.Split(err.Error(), "\n")
+	assert.Equal(t, sumErrMsg, lines[0])
+
+	actual := &detailedDiagnosticInfo{}
+	assert.NoError(t, json.Unmarshal([]byte(lines[1]), actual))
+	assert.Equal(t, DiagnosticCodeFlowPublishTimeout, actual.Code)
+	assert.Equal(t, jobId, actual.JobID)
+	assert.Equal(t, resourceType, actual.ResourceType)
+}

--- a/genesyscloud/util/util_diagnostics.go
+++ b/genesyscloud/util/util_diagnostics.go
@@ -9,6 +9,12 @@ import (
 	"github.com/mypurecloud/platform-client-sdk-go/v195/platformclientv2"
 )
 
+// Stable diagnostic codes for machine classification (e.g. by MRMO replicator).
+const (
+	DiagnosticCodeFlowPublishFailed  = "flow_publish_failed"
+	DiagnosticCodeFlowPublishTimeout = "flow_publish_timeout"
+)
+
 type detailedDiagnosticInfo struct {
 	ResourceType        string        `json:"resourceType,omitempty"`
 	Method              string        `json:"method,omitempty"`
@@ -18,6 +24,8 @@ type detailedDiagnosticInfo struct {
 	ErrorMessageContext interface{}   `json:"errorMessageContext,omitempty"`
 	ErrorMessageDetails []interface{} `json:"errorMessageDetails,omitempty"`
 	CorrelationID       string        `json:"correlationId,omitempty"`
+	Code                string        `json:"code,omitempty"`
+	JobID               string        `json:"jobId,omitempty"`
 }
 
 func convertResponseToWrapper(resourceType string, apiResponse *platformclientv2.APIResponse) *detailedDiagnosticInfo {
@@ -96,4 +104,57 @@ func BuildWithRetriesApiDiagnosticError(resourceType string, summary string, api
 		errorMsg += fmt.Sprintf("%s\n%s\n", diags.Summary, diags.Detail)
 	}
 	return errors.New(errorMsg)
+}
+
+// BuildCodedAPIDiagnosticError builds an API diagnostic with a stable machine-readable code and optional job ID.
+func BuildCodedAPIDiagnosticError(resourceType, code, summary, jobId string, apiResponse *platformclientv2.APIResponse) diag.Diagnostics {
+	if apiResponse == nil {
+		err := fmt.Errorf("unable to build a message from the response because the APIResponse does not contain the appropriate data.%s", "")
+		diags := BuildDiagnosticError(resourceType, summary, err)
+		return withDiagnosticCodeAndJobID(diags, code, jobId)
+	}
+	diagInfo := convertResponseToWrapper(resourceType, apiResponse)
+	diagInfo.Code = code
+	diagInfo.JobID = jobId
+	diagInfoByte, err := json.Marshal(diagInfo)
+	if err != nil {
+		err = fmt.Errorf("unable to unmarshal diagnostic info while building diagnostic error. Error: %w", err)
+		return withDiagnosticCodeAndJobID(BuildDiagnosticError(resourceType, summary, err), code, jobId)
+	}
+
+	dg := diag.Diagnostic{Severity: diag.Error, Summary: summary, Detail: string(diagInfoByte)}
+	return diag.Diagnostics{dg}
+}
+
+// BuildCodedWithRetriesApiDiagnosticError is like BuildWithRetriesApiDiagnosticError but includes
+// a stable diagnostic code and job ID in the JSON Detail for downstream classification.
+func BuildCodedWithRetriesApiDiagnosticError(resourceType, code, summary, jobId string, apiResponse *platformclientv2.APIResponse) error {
+	var errorMsg string
+	diagnostic := BuildCodedAPIDiagnosticError(resourceType, code, summary, jobId, apiResponse)
+	for _, d := range diagnostic {
+		errorMsg += fmt.Sprintf("%s\n%s\n", d.Summary, d.Detail)
+	}
+	return errors.New(errorMsg)
+}
+
+func withDiagnosticCodeAndJobID(diags diag.Diagnostics, code, jobId string) diag.Diagnostics {
+	if len(diags) == 0 || (code == "" && jobId == "") {
+		return diags
+	}
+	info := &detailedDiagnosticInfo{}
+	if err := json.Unmarshal([]byte(diags[0].Detail), info); err != nil {
+		info = &detailedDiagnosticInfo{}
+	}
+	if code != "" {
+		info.Code = code
+	}
+	if jobId != "" {
+		info.JobID = jobId
+	}
+	diagInfoByte, err := json.Marshal(info)
+	if err != nil {
+		return diags
+	}
+	diags[0].Detail = string(diagInfoByte)
+	return diags
 }


### PR DESCRIPTION
The new `FailedPublish` failure type requires more detailed information in the output of applies.

- Adds `code` to diagnostic errors in `BuildCodedAPIDiagnosticError` and `BuildCodedWithRetriesApiDiagnosticError`
- Adds `flow_publish_failed` and `flow_publish_timeout` diagnostic codes